### PR TITLE
feat(referral): add queue-based referral reward processing on booking completion

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,6 +13,9 @@ import { NotificationModule } from "./modules/notification/notification.module";
 import { PaymentModule } from "./modules/payment/payment.module";
 import { ReminderModule } from "./modules/reminder/reminder.module";
 import { StatusChangeModule } from "./modules/status-change/status-change.module";
+import { ReferralModule } from './referral/referral.module';
+import { ReferralModule } from './modules/referral/referral.module';
+import { ReferralModule } from './modules/referral/referral.module';
 
 @Module({
   imports: [
@@ -50,6 +53,7 @@ import { StatusChangeModule } from "./modules/status-change/status-change.module
     StatusChangeModule,
     HealthModule,
     JobModule,
+    ReferralModule,
   ],
 })
 export class AppModule {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,11 +11,9 @@ import { HealthModule } from "./modules/health/health.module";
 import { JobModule } from "./modules/job/job.module";
 import { NotificationModule } from "./modules/notification/notification.module";
 import { PaymentModule } from "./modules/payment/payment.module";
+import { ReferralModule } from "./modules/referral/referral.module";
 import { ReminderModule } from "./modules/reminder/reminder.module";
 import { StatusChangeModule } from "./modules/status-change/status-change.module";
-import { ReferralModule } from './referral/referral.module';
-import { ReferralModule } from './modules/referral/referral.module';
-import { ReferralModule } from './modules/referral/referral.module';
 
 @Module({
   imports: [

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -3,6 +3,7 @@ export const TIMEZONE = "Africa/Lagos";
 export const NOTIFICATIONS_QUEUE = "notifications-queue";
 export const STATUS_UPDATES_QUEUE = "status-updates-queue";
 export const REMINDERS_QUEUE = "reminders-queue";
+export const REFERRAL_QUEUE = "referral-queue";
 
 export const EVERY_HOUR = "0 * * * *";
 export const CONFIRMED_TO_ACTIVE = "confirmed-to-active";

--- a/src/modules/notification/email.service.ts
+++ b/src/modules/notification/email.service.ts
@@ -36,6 +36,17 @@ export class EmailService {
         html,
       });
 
+      // Check if the API returned an error
+      if (result.error) {
+        this.logger.error("Email API returned error", {
+          to,
+          subject,
+          error: result.error,
+        });
+        throw new Error(`Resend API error: ${JSON.stringify(result.error)}`);
+      }
+
+      // Log success with message ID
       this.logger.log("Email sent successfully", {
         to,
         subject,

--- a/src/modules/notification/email.service.ts
+++ b/src/modules/notification/email.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { Resend } from "resend";
+import { EmailNotificationData } from "./notification.interface";
 
 @Injectable()
 export class EmailService {
@@ -23,11 +24,7 @@ export class EmailService {
     to,
     subject,
     html,
-  }: {
-    to: string;
-    subject: string;
-    html: string;
-  }): ReturnType<typeof this.resend.emails.send> {
+  }: EmailNotificationData): ReturnType<typeof this.resend.emails.send> {
     try {
       const result = await this.resend.emails.send({
         from: this.from,
@@ -39,7 +36,6 @@ export class EmailService {
       // Check if the API returned an error
       if (result.error) {
         this.logger.error("Email API returned error", {
-          to,
           subject,
           error: result.error,
         });

--- a/src/modules/notification/notification.service.spec.ts
+++ b/src/modules/notification/notification.service.spec.ts
@@ -25,10 +25,6 @@ describe("NotificationService", () => {
   beforeEach(async () => {
     mockQueue = {
       add: vi.fn().mockResolvedValue({ id: "job-123" }),
-      getWaiting: vi.fn().mockResolvedValue([]),
-      getActive: vi.fn().mockResolvedValue([]),
-      getCompleted: vi.fn().mockResolvedValue([]),
-      getFailed: vi.fn().mockResolvedValue([]),
     };
 
     const module: TestingModule = await Test.createTestingModule({

--- a/src/modules/referral/referral.interface.ts
+++ b/src/modules/referral/referral.interface.ts
@@ -1,0 +1,6 @@
+export interface ReferralJobData {
+  bookingId: string;
+  timestamp: string;
+}
+
+export const PROCESS_REFERRAL_COMPLETION = "process-referral-completion";

--- a/src/modules/referral/referral.module.ts
+++ b/src/modules/referral/referral.module.ts
@@ -1,0 +1,33 @@
+import { BullMQAdapter } from "@bull-board/api/bullMQAdapter";
+import { BullBoardModule } from "@bull-board/nestjs";
+import { BullModule } from "@nestjs/bullmq";
+import { Module } from "@nestjs/common";
+import { REFERRAL_QUEUE } from "../../config/constants";
+import { DatabaseModule } from "../database/database.module";
+import { ReferralProcessor } from "./referral.processor";
+import { ReferralService } from "./referral.service";
+
+@Module({
+  imports: [
+    DatabaseModule,
+    BullModule.registerQueue({
+      name: REFERRAL_QUEUE,
+      defaultJobOptions: {
+        attempts: 3,
+        backoff: {
+          type: "exponential",
+          delay: 2000,
+        },
+        removeOnComplete: 100, // Keep last 100 successful jobs
+        removeOnFail: 50, // Keep last 50 failed jobs
+      },
+    }),
+    BullBoardModule.forFeature({
+      name: REFERRAL_QUEUE,
+      adapter: BullMQAdapter,
+    }),
+  ],
+  providers: [ReferralService, ReferralProcessor],
+  exports: [ReferralService, BullModule],
+})
+export class ReferralModule {}

--- a/src/modules/referral/referral.processor.spec.ts
+++ b/src/modules/referral/referral.processor.spec.ts
@@ -1,0 +1,153 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { Job } from "bullmq";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PROCESS_REFERRAL_COMPLETION, ReferralJobData } from "./referral.interface";
+import { ReferralProcessor } from "./referral.processor";
+import { ReferralService } from "./referral.service";
+
+describe("ReferralProcessor", () => {
+  let processor: ReferralProcessor;
+  let referralService: ReferralService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReferralProcessor,
+        {
+          provide: ReferralService,
+          useValue: {
+            processReferralCompletionForBooking: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    processor = module.get<ReferralProcessor>(ReferralProcessor);
+    referralService = module.get<ReferralService>(ReferralService);
+  });
+
+  it("should be defined", () => {
+    expect(processor).toBeDefined();
+  });
+
+  describe("process", () => {
+    it("should process referral completion job successfully", async () => {
+      const job = {
+        id: "job-123",
+        name: PROCESS_REFERRAL_COMPLETION,
+        data: { bookingId: "booking-123", timestamp: new Date().toISOString() },
+      } as Job<ReferralJobData, void, string>;
+
+      vi.mocked(referralService.processReferralCompletionForBooking).mockResolvedValue(undefined);
+
+      const result = await processor.process(job);
+
+      expect(result).toEqual({ success: true });
+      expect(referralService.processReferralCompletionForBooking).toHaveBeenCalledWith(
+        "booking-123",
+      );
+    });
+
+    it("should throw error for unknown job type", async () => {
+      const job = {
+        id: "job-123",
+        name: "unknown-job-type",
+        data: { bookingId: "booking-123", timestamp: new Date().toISOString() },
+      } as Job<ReferralJobData, void, string>;
+
+      await expect(processor.process(job)).rejects.toThrow(
+        "Unknown referral job type: unknown-job-type",
+      );
+      expect(referralService.processReferralCompletionForBooking).not.toHaveBeenCalled();
+    });
+
+    it("should re-throw error when referral service fails", async () => {
+      const job = {
+        id: "job-123",
+        name: PROCESS_REFERRAL_COMPLETION,
+        data: { bookingId: "booking-123", timestamp: new Date().toISOString() },
+      } as Job<ReferralJobData, void, string>;
+
+      const serviceError = new Error("Database connection failed");
+      vi.mocked(referralService.processReferralCompletionForBooking).mockRejectedValue(
+        serviceError,
+      );
+
+      await expect(processor.process(job)).rejects.toThrow("Database connection failed");
+      expect(referralService.processReferralCompletionForBooking).toHaveBeenCalledWith(
+        "booking-123",
+      );
+    });
+  });
+
+  describe("event handlers", () => {
+    it("should log on job completion", () => {
+      const job = {
+        id: "job-123",
+        name: PROCESS_REFERRAL_COMPLETION,
+        data: { bookingId: "booking-123", timestamp: new Date().toISOString() },
+        finishedOn: 1000,
+        processedOn: 500,
+      } as Job<ReferralJobData>;
+
+      processor.onCompleted(job);
+
+      expect(true).toBe(true);
+    });
+
+    it("should log on job failure", () => {
+      const job = {
+        id: "job-123",
+        name: PROCESS_REFERRAL_COMPLETION,
+        data: { bookingId: "booking-123", timestamp: new Date().toISOString() },
+        attemptsMade: 2,
+        opts: { attempts: 3 },
+      } as Job<ReferralJobData>;
+
+      const error = new Error("Test error");
+
+      processor.onFailed(job, error);
+
+      expect(true).toBeTruthy();
+    });
+
+    it("should log on job activation", () => {
+      const job = {
+        id: "job-123",
+        name: PROCESS_REFERRAL_COMPLETION,
+        data: { bookingId: "booking-123", timestamp: new Date().toISOString() },
+        attemptsMade: 0,
+      } as Job<ReferralJobData>;
+
+      processor.onActive(job);
+
+      expect(true).toBeTruthy();
+    });
+
+    it("should log on job stalled", () => {
+      processor.onStalled("job-123");
+
+      expect(true).toBe(true);
+    });
+
+    it("should log on job progress", () => {
+      const job = {
+        id: "job-123",
+        name: PROCESS_REFERRAL_COMPLETION,
+        data: { bookingId: "booking-123", timestamp: new Date().toISOString() },
+      } as Job<ReferralJobData>;
+
+      processor.onProgress(job, 50);
+
+      expect(true).toBe(true);
+    });
+
+    it("should handle job failure with no job context", () => {
+      const error = new Error("Test error");
+
+      processor.onFailed(undefined, error);
+
+      expect(true).toBe(true);
+    });
+  });
+});

--- a/src/modules/referral/referral.processor.spec.ts
+++ b/src/modules/referral/referral.processor.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { Job } from "bullmq";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PROCESS_REFERRAL_COMPLETION, ReferralJobData } from "./referral.interface";
 import { ReferralProcessor } from "./referral.processor";
 import { ReferralService } from "./referral.service";
@@ -81,73 +81,244 @@ describe("ReferralProcessor", () => {
   });
 
   describe("event handlers", () => {
-    it("should log on job completion", () => {
-      const job = {
-        id: "job-123",
-        name: PROCESS_REFERRAL_COMPLETION,
-        data: { bookingId: "booking-123", timestamp: new Date().toISOString() },
-        finishedOn: 1000,
-        processedOn: 500,
-      } as Job<ReferralJobData>;
+    let loggerLogSpy: ReturnType<typeof vi.spyOn>;
+    let loggerErrorSpy: ReturnType<typeof vi.spyOn>;
+    let loggerWarnSpy: ReturnType<typeof vi.spyOn>;
+    let loggerDebugSpy: ReturnType<typeof vi.spyOn>;
 
-      processor.onCompleted(job);
-
-      expect(true).toBe(true);
+    beforeEach(() => {
+      // Mock all logger methods
+      // eslint-disable-next-line @typescript-eslint/dot-notation
+      loggerLogSpy = vi.spyOn(processor["logger"], "log");
+      // eslint-disable-next-line @typescript-eslint/dot-notation
+      loggerErrorSpy = vi.spyOn(processor["logger"], "error");
+      // eslint-disable-next-line @typescript-eslint/dot-notation
+      loggerWarnSpy = vi.spyOn(processor["logger"], "warn");
+      // eslint-disable-next-line @typescript-eslint/dot-notation
+      loggerDebugSpy = vi.spyOn(processor["logger"], "debug");
     });
 
-    it("should log on job failure", () => {
-      const job = {
-        id: "job-123",
-        name: PROCESS_REFERRAL_COMPLETION,
-        data: { bookingId: "booking-123", timestamp: new Date().toISOString() },
-        attemptsMade: 2,
-        opts: { attempts: 3 },
-      } as Job<ReferralJobData>;
-
-      const error = new Error("Test error");
-
-      processor.onFailed(job, error);
-
-      expect(true).toBeTruthy();
+    afterEach(() => {
+      // Reset all mocks between tests
+      vi.clearAllMocks();
     });
 
-    it("should log on job activation", () => {
-      const job = {
-        id: "job-123",
-        name: PROCESS_REFERRAL_COMPLETION,
-        data: { bookingId: "booking-123", timestamp: new Date().toISOString() },
-        attemptsMade: 0,
-      } as Job<ReferralJobData>;
+    describe("onCompleted", () => {
+      it("should log completion with job details and duration", () => {
+        const job = {
+          id: "job-123",
+          name: PROCESS_REFERRAL_COMPLETION,
+          data: { bookingId: "booking-123", timestamp: new Date().toISOString() },
+          finishedOn: 1500,
+          processedOn: 500,
+        } as Job<ReferralJobData>;
 
-      processor.onActive(job);
+        processor.onCompleted(job);
 
-      expect(true).toBeTruthy();
+        expect(loggerLogSpy).toHaveBeenCalledTimes(1);
+        expect(loggerLogSpy).toHaveBeenCalledWith(
+          `Job completed: ${PROCESS_REFERRAL_COMPLETION} [job-123] - Duration: 1000ms`,
+          { bookingId: "booking-123" },
+        );
+      });
+
+      it("should log completion with N/A duration when timestamps are missing", () => {
+        const job = {
+          id: "job-456",
+          name: PROCESS_REFERRAL_COMPLETION,
+          data: { bookingId: "booking-456", timestamp: new Date().toISOString() },
+          finishedOn: undefined,
+          processedOn: undefined,
+        } as Job<ReferralJobData>;
+
+        processor.onCompleted(job);
+
+        expect(loggerLogSpy).toHaveBeenCalledTimes(1);
+        expect(loggerLogSpy).toHaveBeenCalledWith(
+          `Job completed: ${PROCESS_REFERRAL_COMPLETION} [job-456] - Duration: N/Ams`,
+          { bookingId: "booking-456" },
+        );
+      });
     });
 
-    it("should log on job stalled", () => {
-      processor.onStalled("job-123");
+    describe("onFailed", () => {
+      it("should log failure with job details, error, and attempt information", () => {
+        const job = {
+          id: "job-123",
+          name: PROCESS_REFERRAL_COMPLETION,
+          data: { bookingId: "booking-123", timestamp: new Date().toISOString() },
+          attemptsMade: 2,
+          opts: { attempts: 3 },
+        } as Job<ReferralJobData>;
 
-      expect(true).toBe(true);
+        const error = new Error("Database connection failed");
+        error.stack = "Error: Database connection failed\n  at line 1";
+
+        processor.onFailed(job, error);
+
+        expect(loggerErrorSpy).toHaveBeenCalledTimes(1);
+        expect(loggerErrorSpy).toHaveBeenCalledWith(
+          `Job failed: ${PROCESS_REFERRAL_COMPLETION} [job-123]`,
+          {
+            bookingId: "booking-123",
+            error: "Database connection failed",
+            stack: "Error: Database connection failed\n  at line 1",
+            attempts: 2,
+            maxAttempts: 3,
+          },
+        );
+      });
+
+      it("should handle job failure with undefined job context", () => {
+        const error = new Error("Unknown error");
+
+        processor.onFailed(undefined, error);
+
+        expect(loggerErrorSpy).toHaveBeenCalledTimes(1);
+        expect(loggerErrorSpy).toHaveBeenCalledWith("Job failed with no job context", {
+          error: "Unknown error",
+        });
+      });
+
+      it("should handle error without stack trace", () => {
+        const job = {
+          id: "job-789",
+          name: PROCESS_REFERRAL_COMPLETION,
+          data: { bookingId: "booking-789", timestamp: new Date().toISOString() },
+          attemptsMade: 1,
+          opts: { attempts: 3 },
+        } as Job<ReferralJobData>;
+
+        const error = new Error("Simple error");
+        error.stack = undefined;
+
+        processor.onFailed(job, error);
+
+        expect(loggerErrorSpy).toHaveBeenCalledTimes(1);
+        expect(loggerErrorSpy).toHaveBeenCalledWith(
+          `Job failed: ${PROCESS_REFERRAL_COMPLETION} [job-789]`,
+          {
+            bookingId: "booking-789",
+            error: "Simple error",
+            stack: undefined,
+            attempts: 1,
+            maxAttempts: 3,
+          },
+        );
+      });
     });
 
-    it("should log on job progress", () => {
-      const job = {
-        id: "job-123",
-        name: PROCESS_REFERRAL_COMPLETION,
-        data: { bookingId: "booking-123", timestamp: new Date().toISOString() },
-      } as Job<ReferralJobData>;
+    describe("onActive", () => {
+      it("should log job activation with attempt number", () => {
+        const job = {
+          id: "job-123",
+          name: PROCESS_REFERRAL_COMPLETION,
+          data: { bookingId: "booking-123", timestamp: new Date().toISOString() },
+          attemptsMade: 0,
+        } as Job<ReferralJobData>;
 
-      processor.onProgress(job, 50);
+        processor.onActive(job);
 
-      expect(true).toBe(true);
+        expect(loggerLogSpy).toHaveBeenCalledTimes(1);
+        expect(loggerLogSpy).toHaveBeenCalledWith(
+          `Job started: ${PROCESS_REFERRAL_COMPLETION} [job-123] - Attempt 1`,
+          { bookingId: "booking-123" },
+        );
+      });
+
+      it("should log correct attempt number for retried jobs", () => {
+        const job = {
+          id: "job-456",
+          name: PROCESS_REFERRAL_COMPLETION,
+          data: { bookingId: "booking-456", timestamp: new Date().toISOString() },
+          attemptsMade: 2,
+        } as Job<ReferralJobData>;
+
+        processor.onActive(job);
+
+        expect(loggerLogSpy).toHaveBeenCalledTimes(1);
+        expect(loggerLogSpy).toHaveBeenCalledWith(
+          `Job started: ${PROCESS_REFERRAL_COMPLETION} [job-456] - Attempt 3`,
+          { bookingId: "booking-456" },
+        );
+      });
     });
 
-    it("should handle job failure with no job context", () => {
-      const error = new Error("Test error");
+    describe("onStalled", () => {
+      it("should log warning when job stalls", () => {
+        processor.onStalled("job-123");
 
-      processor.onFailed(undefined, error);
+        expect(loggerWarnSpy).toHaveBeenCalledTimes(1);
+        expect(loggerWarnSpy).toHaveBeenCalledWith("Job stalled: job-123");
+      });
 
-      expect(true).toBe(true);
+      it("should handle different job IDs", () => {
+        processor.onStalled("job-xyz-789");
+
+        expect(loggerWarnSpy).toHaveBeenCalledTimes(1);
+        expect(loggerWarnSpy).toHaveBeenCalledWith("Job stalled: job-xyz-789");
+      });
+    });
+
+    describe("onProgress", () => {
+      it("should log debug message with numeric progress", () => {
+        const job = {
+          id: "job-123",
+          name: PROCESS_REFERRAL_COMPLETION,
+          data: { bookingId: "booking-123", timestamp: new Date().toISOString() },
+        } as Job<ReferralJobData>;
+
+        processor.onProgress(job, 50);
+
+        expect(loggerDebugSpy).toHaveBeenCalledTimes(1);
+        expect(loggerDebugSpy).toHaveBeenCalledWith(
+          `Job progress: ${PROCESS_REFERRAL_COMPLETION} [job-123]`,
+          {
+            bookingId: "booking-123",
+            progress: 50,
+          },
+        );
+      });
+
+      it("should log debug message with object progress", () => {
+        const job = {
+          id: "job-456",
+          name: PROCESS_REFERRAL_COMPLETION,
+          data: { bookingId: "booking-456", timestamp: new Date().toISOString() },
+        } as Job<ReferralJobData>;
+
+        const progressData = { step: "validation", percentage: 75 };
+
+        processor.onProgress(job, progressData);
+
+        expect(loggerDebugSpy).toHaveBeenCalledTimes(1);
+        expect(loggerDebugSpy).toHaveBeenCalledWith(
+          `Job progress: ${PROCESS_REFERRAL_COMPLETION} [job-456]`,
+          {
+            bookingId: "booking-456",
+            progress: progressData,
+          },
+        );
+      });
+
+      it("should handle zero progress", () => {
+        const job = {
+          id: "job-789",
+          name: PROCESS_REFERRAL_COMPLETION,
+          data: { bookingId: "booking-789", timestamp: new Date().toISOString() },
+        } as Job<ReferralJobData>;
+
+        processor.onProgress(job, 0);
+
+        expect(loggerDebugSpy).toHaveBeenCalledTimes(1);
+        expect(loggerDebugSpy).toHaveBeenCalledWith(
+          `Job progress: ${PROCESS_REFERRAL_COMPLETION} [job-789]`,
+          {
+            bookingId: "booking-789",
+            progress: 0,
+          },
+        );
+      });
     });
   });
 });

--- a/src/modules/referral/referral.processor.ts
+++ b/src/modules/referral/referral.processor.ts
@@ -1,0 +1,83 @@
+import { OnWorkerEvent, Processor, WorkerHost } from "@nestjs/bullmq";
+import { Logger } from "@nestjs/common";
+import { Job } from "bullmq";
+import { REFERRAL_QUEUE } from "../../config/constants";
+import { PROCESS_REFERRAL_COMPLETION, ReferralJobData } from "./referral.interface";
+import { ReferralService } from "./referral.service";
+
+@Processor(REFERRAL_QUEUE)
+export class ReferralProcessor extends WorkerHost {
+  private readonly logger = new Logger(ReferralProcessor.name);
+
+  constructor(private readonly referralService: ReferralService) {
+    super();
+  }
+
+  async process(job: Job<ReferralJobData, void, string>): Promise<{ success: boolean }> {
+    this.logger.log(`Processing referral job: ${job.name}`, {
+      jobId: job.id,
+      bookingId: job.data.bookingId,
+    });
+
+    try {
+      if (job.name === PROCESS_REFERRAL_COMPLETION) {
+        await this.referralService.processReferralCompletionForBooking(job.data.bookingId);
+        this.logger.log(`Referral completion processed successfully for booking ${job.data.bookingId}`);
+        return { success: true };
+      }
+
+      throw new Error(`Unknown referral job type: ${job.name}`);
+    } catch (error) {
+      this.logger.error(`Failed to process ${job.name} job:`, {
+        jobId: job.id,
+        bookingId: job.data.bookingId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error; // Re-throw to trigger retry mechanism
+    }
+  }
+
+  @OnWorkerEvent("completed")
+  onCompleted(job: Job<ReferralJobData>): void {
+    const duration = job.finishedOn && job.processedOn ? job.finishedOn - job.processedOn : "N/A";
+    this.logger.log(`Job completed: ${job.name} [${job.id}] - Duration: ${duration}ms`, {
+      bookingId: job.data.bookingId,
+    });
+  }
+
+  @OnWorkerEvent("failed")
+  onFailed(job: Job<ReferralJobData> | undefined, error: Error): void {
+    if (!job) {
+      this.logger.error("Job failed with no job context", { error: error.message });
+      return;
+    }
+
+    this.logger.error(`Job failed: ${job.name} [${job.id}]`, {
+      bookingId: job.data.bookingId,
+      error: error.message,
+      stack: error.stack,
+      attempts: job.attemptsMade,
+      maxAttempts: job.opts.attempts,
+    });
+  }
+
+  @OnWorkerEvent("active")
+  onActive(job: Job<ReferralJobData>): void {
+    this.logger.log(`Job started: ${job.name} [${job.id}] - Attempt ${job.attemptsMade + 1}`, {
+      bookingId: job.data.bookingId,
+    });
+  }
+
+  @OnWorkerEvent("stalled")
+  onStalled(jobId: string): void {
+    this.logger.warn(`Job stalled: ${jobId}`);
+  }
+
+  @OnWorkerEvent("progress")
+  onProgress(job: Job<ReferralJobData>, progress: number | object): void {
+    this.logger.debug(`Job progress: ${job.name} [${job.id}]`, {
+      bookingId: job.data.bookingId,
+      progress,
+    });
+  }
+}

--- a/src/modules/referral/referral.service.spec.ts
+++ b/src/modules/referral/referral.service.spec.ts
@@ -158,7 +158,12 @@ describe("ReferralService", () => {
     });
 
     it("should skip processing when booking has no userId", async () => {
-      const booking = createBooking({ id: "booking-1231" });
+      const booking = createBooking({
+        id: "booking-1231",
+        referralStatus: BookingReferralStatus.APPLIED,
+        referralReferrerUserId: "referrer-123",
+        userId: undefined,
+      });
 
       vi.mocked(databaseService.booking.findUnique).mockResolvedValue(booking);
 
@@ -169,7 +174,11 @@ describe("ReferralService", () => {
     });
 
     it("should skip processing when booking has no referralReferrerUserId", async () => {
-      const booking = createBooking({ id: "booking-1231" });
+      const booking = createBooking({
+        id: "booking-1231",
+        referralStatus: BookingReferralStatus.APPLIED,
+        referralReferrerUserId: undefined,
+      });
 
       vi.mocked(databaseService.booking.findUnique).mockResolvedValue(booking);
 

--- a/src/modules/referral/referral.service.spec.ts
+++ b/src/modules/referral/referral.service.spec.ts
@@ -1,0 +1,846 @@
+import { getQueueToken } from "@nestjs/bullmq";
+import { Test, TestingModule } from "@nestjs/testing";
+import { BookingReferralStatus, ReferralRewardStatus } from "@prisma/client";
+import { Queue } from "bullmq";
+import { REFERRAL_QUEUE } from "src/config/constants";
+import { createBooking } from "src/shared/helper.fixtures";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DatabaseService } from "../database/database.service";
+import { PROCESS_REFERRAL_COMPLETION, ReferralJobData } from "./referral.interface";
+import { ReferralService } from "./referral.service";
+
+describe("ReferralService", () => {
+  let service: ReferralService;
+  let databaseService: DatabaseService;
+  let mockQueue: Partial<Queue<ReferralJobData>>;
+
+  beforeEach(async () => {
+    mockQueue = {
+      add: vi.fn().mockResolvedValue({ id: "job-123" }),
+    };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReferralService,
+        {
+          provide: DatabaseService,
+          useValue: {
+            referralProgramConfig: {
+              findMany: vi.fn(),
+            },
+            booking: {
+              findUnique: vi.fn(),
+              update: vi.fn(),
+            },
+            user: {
+              findUnique: vi.fn(),
+              update: vi.fn(),
+            },
+            referralReward: {
+              findFirst: vi.fn(),
+              update: vi.fn(),
+            },
+            $transaction: vi.fn(),
+            userReferralStats: {
+              upsert: vi.fn(),
+            },
+          },
+        },
+        {
+          provide: getQueueToken(REFERRAL_QUEUE),
+          useValue: mockQueue,
+        },
+      ],
+    }).compile();
+
+    service = module.get<ReferralService>(ReferralService);
+    databaseService = module.get<DatabaseService>(DatabaseService);
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+
+  it("should have all required services injected", () => {
+    expect(databaseService).toBeDefined();
+  });
+
+  describe("processReferralCompletionForBooking - Configuration-Based Early Returns", () => {
+    it("should skip processing when REFERRAL_ENABLED is false", async () => {
+      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
+        { key: "REFERRAL_ENABLED", value: false, updatedAt: new Date(), updatedBy: "system" },
+        {
+          key: "REFERRAL_RELEASE_CONDITION",
+          value: "COMPLETED",
+          updatedAt: new Date(),
+          updatedBy: "system",
+        },
+      ]);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(databaseService.referralProgramConfig.findMany).toHaveBeenCalled();
+      expect(databaseService.booking.findUnique).not.toHaveBeenCalled();
+    });
+
+    it("should skip processing when REFERRAL_RELEASE_CONDITION is PAID (not COMPLETED)", async () => {
+      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
+        { key: "REFERRAL_ENABLED", value: true, updatedAt: new Date(), updatedBy: "system" },
+        {
+          key: "REFERRAL_RELEASE_CONDITION",
+          value: "PAID",
+          updatedAt: new Date(),
+          updatedBy: "system",
+        },
+      ]);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(databaseService.referralProgramConfig.findMany).toHaveBeenCalled();
+      expect(databaseService.booking.findUnique).not.toHaveBeenCalled();
+    });
+
+    it("should skip processing when REFERRAL_ENABLED is false AND REFERRAL_RELEASE_CONDITION is PAID", async () => {
+      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
+        { key: "REFERRAL_ENABLED", value: false, updatedAt: new Date(), updatedBy: "system" },
+        {
+          key: "REFERRAL_RELEASE_CONDITION",
+          value: "PAID",
+          updatedAt: new Date(),
+          updatedBy: "system",
+        },
+      ]);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(databaseService.referralProgramConfig.findMany).toHaveBeenCalled();
+      expect(databaseService.booking.findUnique).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("processReferralCompletionForBooking - Booking Eligibility Checks", () => {
+    beforeEach(() => {
+      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
+        { key: "REFERRAL_ENABLED", value: true, updatedAt: new Date(), updatedBy: "system" },
+        {
+          key: "REFERRAL_RELEASE_CONDITION",
+          value: "COMPLETED",
+          updatedAt: new Date(),
+          updatedBy: "system",
+        },
+      ]);
+    });
+
+    it("should skip processing when booking does not exist", async () => {
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValue(null);
+
+      await service.processReferralCompletionForBooking("non-existent-booking");
+
+      expect(databaseService.booking.findUnique).toHaveBeenCalledWith({
+        where: { id: "non-existent-booking" },
+        select: {
+          id: true,
+          userId: true,
+          referralReferrerUserId: true,
+          referralStatus: true,
+        },
+      });
+      expect(databaseService.$transaction).not.toHaveBeenCalled();
+    });
+
+    it("should skip processing when booking referralStatus is not APPLIED", async () => {
+      const booking = createBooking({ id: "booking-1231" });
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValue(booking);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(databaseService.booking.findUnique).toHaveBeenCalled();
+      expect(databaseService.$transaction).not.toHaveBeenCalled();
+    });
+
+    it("should skip processing when booking has no userId", async () => {
+      const booking = createBooking({ id: "booking-1231" });
+
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValue(booking);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(databaseService.booking.findUnique).toHaveBeenCalled();
+      expect(databaseService.$transaction).not.toHaveBeenCalled();
+    });
+
+    it("should skip processing when booking has no referralReferrerUserId", async () => {
+      const booking = createBooking({ id: "booking-1231" });
+
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValue(booking);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(databaseService.booking.findUnique).toHaveBeenCalled();
+      expect(databaseService.$transaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("processReferralCompletionForBooking - Idempotency and Transaction Logic", () => {
+    beforeEach(() => {
+      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
+        { key: "REFERRAL_ENABLED", value: true, updatedAt: new Date(), updatedBy: "system" },
+        {
+          key: "REFERRAL_RELEASE_CONDITION",
+          value: "COMPLETED",
+          updatedAt: new Date(),
+          updatedBy: "system",
+        },
+        { key: "REFERRAL_EXPIRY_DAYS", value: 0, updatedAt: new Date(), updatedBy: "system" },
+      ]);
+
+      const booking = createBooking({
+        id: "booking-1231",
+        referralStatus: BookingReferralStatus.APPLIED,
+        referralReferrerUserId: "referrer-123",
+      });
+
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValue(booking);
+    });
+
+    it("should skip processing when reward is already released (idempotency)", async () => {
+      const mockTransaction = vi.fn(async (callback) => {
+        const mockTx = {
+          referralReward: {
+            findFirst: vi.fn().mockResolvedValue({
+              id: "reward-already-released",
+              status: ReferralRewardStatus.RELEASED,
+            }),
+          },
+        };
+        return callback(mockTx);
+      });
+
+      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(databaseService.$transaction).toHaveBeenCalled();
+    });
+  });
+
+  describe("processReferralCompletionForBooking - Expiry Window Checks", () => {
+    beforeEach(() => {
+      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
+        { key: "REFERRAL_ENABLED", value: true, updatedAt: new Date(), updatedBy: "system" },
+        {
+          key: "REFERRAL_RELEASE_CONDITION",
+          value: "COMPLETED",
+          updatedAt: new Date(),
+          updatedBy: "system",
+        },
+        { key: "REFERRAL_EXPIRY_DAYS", value: 30, updatedAt: new Date(), updatedBy: "system" },
+      ]);
+
+      const booking = createBooking({
+        id: "booking-1231",
+        referralStatus: BookingReferralStatus.APPLIED,
+        referralReferrerUserId: "referrer-123",
+      });
+
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValue(booking);
+    });
+
+    it("should skip processing when referral has expired", async () => {
+      const fortyDaysAgo = new Date();
+      fortyDaysAgo.setDate(fortyDaysAgo.getDate() - 40);
+
+      const mockTransaction = vi.fn(async (callback) => {
+        const mockTx = {
+          referralReward: {
+            findFirst: vi.fn().mockResolvedValue(null),
+          },
+          user: {
+            findUnique: vi.fn().mockResolvedValue({
+              id: "user-123",
+              referralSignupAt: fortyDaysAgo,
+              referralDiscountUsed: false,
+            }),
+          },
+        };
+        return callback(mockTx);
+      });
+
+      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(databaseService.$transaction).toHaveBeenCalled();
+    });
+
+    it("should process when within expiry window - signup date is 20 days ago (within 30 day window)", async () => {
+      const twentyDaysAgo = new Date();
+      twentyDaysAgo.setDate(twentyDaysAgo.getDate() - 20);
+
+      const mockTransaction = vi.fn(async (callback) => {
+        const mockTx = {
+          referralReward: {
+            findFirst: vi
+              .fn()
+              .mockResolvedValueOnce(null) // First call: check if already released
+              .mockResolvedValueOnce({
+                // Second call: find pending reward
+                id: "reward-123",
+                bookingId: "booking-123",
+                referrerUserId: "referrer-123",
+                amount: 1000,
+                status: ReferralRewardStatus.PENDING,
+              }),
+            update: vi.fn().mockResolvedValue({}),
+          },
+          user: {
+            findUnique: vi.fn().mockResolvedValue({
+              id: "user-123",
+              referralSignupAt: twentyDaysAgo,
+              referralDiscountUsed: false,
+            }),
+            update: vi.fn().mockResolvedValue({}),
+          },
+          booking: {
+            update: vi.fn().mockResolvedValue({}),
+          },
+          userReferralStats: {
+            upsert: vi.fn().mockResolvedValue({}),
+          },
+        };
+        return callback(mockTx);
+      });
+
+      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(databaseService.$transaction).toHaveBeenCalled();
+    });
+
+    it("should process when REFERRAL_EXPIRY_DAYS is 0 (disabled)", async () => {
+      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
+        { key: "REFERRAL_ENABLED", value: true, updatedAt: new Date(), updatedBy: "system" },
+        {
+          key: "REFERRAL_RELEASE_CONDITION",
+          value: "COMPLETED",
+          updatedAt: new Date(),
+          updatedBy: "system",
+        },
+        { key: "REFERRAL_EXPIRY_DAYS", value: 0, updatedAt: new Date(), updatedBy: "system" },
+      ]);
+
+      const veryOldDate = new Date("2020-01-01");
+
+      const mockTransaction = vi.fn(async (callback) => {
+        const mockTx = {
+          referralReward: {
+            findFirst: vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce({
+              id: "reward-123",
+              bookingId: "booking-123",
+              referrerUserId: "referrer-123",
+              amount: 1000,
+              status: ReferralRewardStatus.PENDING,
+            }),
+            update: vi.fn().mockResolvedValue({}),
+          },
+          user: {
+            findUnique: vi.fn().mockResolvedValue({
+              id: "user-123",
+              referralSignupAt: veryOldDate,
+              referralDiscountUsed: false,
+            }),
+            update: vi.fn().mockResolvedValue({}),
+          },
+          booking: {
+            update: vi.fn().mockResolvedValue({}),
+          },
+          userReferralStats: {
+            upsert: vi.fn().mockResolvedValue({}),
+          },
+        };
+        return callback(mockTx);
+      });
+
+      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(databaseService.$transaction).toHaveBeenCalled();
+    });
+
+    it("should process when referee has no referralSignupAt date", async () => {
+      const mockTransaction = vi.fn(async (callback) => {
+        const mockTx = {
+          referralReward: {
+            findFirst: vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce({
+              id: "reward-123",
+              bookingId: "booking-123",
+              referrerUserId: "referrer-123",
+              amount: 1000,
+              status: ReferralRewardStatus.PENDING,
+            }),
+            update: vi.fn().mockResolvedValue({}),
+          },
+          user: {
+            findUnique: vi.fn().mockResolvedValue({
+              id: "user-123",
+              referralSignupAt: null,
+              referralDiscountUsed: false,
+            }),
+            update: vi.fn().mockResolvedValue({}),
+          },
+          booking: {
+            update: vi.fn().mockResolvedValue({}),
+          },
+          userReferralStats: {
+            upsert: vi.fn().mockResolvedValue({}),
+          },
+        };
+        return callback(mockTx);
+      });
+
+      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(databaseService.$transaction).toHaveBeenCalled();
+    });
+  });
+
+  describe("processReferralCompletionForBooking - Pending Reward Checks", () => {
+    beforeEach(() => {
+      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
+        { key: "REFERRAL_ENABLED", value: true, updatedAt: new Date(), updatedBy: "system" },
+        {
+          key: "REFERRAL_RELEASE_CONDITION",
+          value: "COMPLETED",
+          updatedAt: new Date(),
+          updatedBy: "system",
+        },
+        { key: "REFERRAL_EXPIRY_DAYS", value: 0, updatedAt: new Date(), updatedBy: "system" },
+      ]);
+
+      const booking = createBooking({
+        referralReferrerUserId: "referrer-123",
+        referralStatus: BookingReferralStatus.APPLIED,
+      });
+
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValue(booking);
+    });
+
+    it("should skip processing when no pending reward is found", async () => {
+      const mockTransaction = vi.fn(async (callback) => {
+        const mockTx = {
+          referralReward: {
+            findFirst: vi
+              .fn()
+              .mockResolvedValueOnce(null) // Not already released
+              .mockResolvedValueOnce(null), // No pending reward
+          },
+          user: {
+            findUnique: vi.fn().mockResolvedValue({
+              id: "user-123",
+              referralSignupAt: new Date(),
+              referralDiscountUsed: false,
+            }),
+          },
+        };
+        return callback(mockTx);
+      });
+
+      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(databaseService.$transaction).toHaveBeenCalled();
+    });
+
+    it("should skip processing when only non-PENDING rewards exist", async () => {
+      const mockTransaction = vi.fn(async (callback) => {
+        const mockTx = {
+          referralReward: {
+            findFirst: vi
+              .fn()
+              .mockResolvedValueOnce(null) // Not already released
+              .mockResolvedValueOnce(null), // No pending reward (could be CANCELLED)
+          },
+          user: {
+            findUnique: vi.fn().mockResolvedValue({
+              id: "user-123",
+              referralSignupAt: new Date(),
+              referralDiscountUsed: false,
+            }),
+          },
+        };
+        return callback(mockTx);
+      });
+
+      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(databaseService.$transaction).toHaveBeenCalled();
+    });
+  });
+
+  describe("processReferralCompletionForBooking - Discount Usage Marking", () => {
+    beforeEach(() => {
+      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
+        { key: "REFERRAL_ENABLED", value: true, updatedAt: new Date(), updatedBy: "system" },
+        {
+          key: "REFERRAL_RELEASE_CONDITION",
+          value: "COMPLETED",
+          updatedAt: new Date(),
+          updatedBy: "system",
+        },
+        { key: "REFERRAL_EXPIRY_DAYS", value: 0, updatedAt: new Date(), updatedBy: "system" },
+      ]);
+
+      const booking = createBooking({
+        referralReferrerUserId: "referrer-123",
+        referralStatus: BookingReferralStatus.APPLIED,
+      });
+
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValue(booking);
+    });
+
+    it("should mark referee discount as used when not already marked", async () => {
+      const mockUserUpdate = vi.fn().mockResolvedValue({});
+
+      const mockTransaction = vi.fn(async (callback) => {
+        const mockTx = {
+          referralReward: {
+            findFirst: vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce({
+              id: "reward-123",
+              bookingId: "booking-123",
+              referrerUserId: "referrer-123",
+              amount: 1000,
+              status: ReferralRewardStatus.PENDING,
+            }),
+            update: vi.fn().mockResolvedValue({}),
+          },
+          user: {
+            findUnique: vi.fn().mockResolvedValue({
+              id: "user-123",
+              referralSignupAt: new Date(),
+              referralDiscountUsed: false,
+            }),
+            update: mockUserUpdate,
+          },
+          booking: {
+            update: vi.fn().mockResolvedValue({}),
+          },
+          userReferralStats: {
+            upsert: vi.fn().mockResolvedValue({}),
+          },
+        };
+        return callback(mockTx);
+      });
+
+      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(mockUserUpdate).toHaveBeenCalledWith({
+        where: { id: "user-123" },
+        data: { referralDiscountUsed: true },
+      });
+    });
+
+    it("should NOT update discount when already marked as used", async () => {
+      const mockUserUpdate = vi.fn().mockResolvedValue({});
+
+      const mockTransaction = vi.fn(async (callback) => {
+        const mockTx = {
+          referralReward: {
+            findFirst: vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce({
+              id: "reward-123",
+              bookingId: "booking-123",
+              referrerUserId: "referrer-123",
+              amount: 1000,
+              status: ReferralRewardStatus.PENDING,
+            }),
+            update: vi.fn().mockResolvedValue({}),
+          },
+          user: {
+            findUnique: vi.fn().mockResolvedValue({
+              id: "user-123",
+              referralSignupAt: new Date(),
+              referralDiscountUsed: true, // Already used
+            }),
+          },
+        };
+        return callback(mockTx);
+      });
+
+      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(mockUserUpdate).not.toHaveBeenCalled();
+    });
+
+    it("should handle missing referee data gracefully", async () => {
+      const mockTransaction = vi.fn(async (callback) => {
+        const mockTx = {
+          referralReward: {
+            findFirst: vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce({
+              id: "reward-123",
+              bookingId: "booking-123",
+              referrerUserId: "referrer-123",
+              amount: 1000,
+              status: ReferralRewardStatus.PENDING,
+            }),
+          },
+        };
+        return callback(mockTx);
+      });
+
+      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(databaseService.$transaction).toHaveBeenCalled();
+    });
+  });
+
+  describe("processReferralCompletionForBooking - Successful Processing Path", () => {
+    beforeEach(() => {
+      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
+        { key: "REFERRAL_ENABLED", value: true, updatedAt: new Date(), updatedBy: "system" },
+        {
+          key: "REFERRAL_RELEASE_CONDITION",
+          value: "COMPLETED",
+          updatedAt: new Date(),
+          updatedBy: "system",
+        },
+        { key: "REFERRAL_EXPIRY_DAYS", value: 0, updatedAt: new Date(), updatedBy: "system" },
+      ]);
+
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValue(
+        createBooking({
+          referralReferrerUserId: "referrer-123",
+          referralStatus: BookingReferralStatus.APPLIED,
+        }),
+      );
+    });
+
+    it("should successfully release reward and create new referrer stats", async () => {
+      const mockRewardUpdate = vi.fn().mockResolvedValue({});
+      const mockBookingUpdate = vi.fn().mockResolvedValue({});
+      const mockStatsUpsert = vi.fn().mockResolvedValue({});
+
+      const mockTransaction = vi.fn(async (callback) => {
+        const mockTx = {
+          referralReward: {
+            findFirst: vi
+              .fn()
+              .mockResolvedValueOnce(null) // Not already released
+              .mockResolvedValueOnce({
+                // Pending reward exists
+                id: "reward-123",
+                bookingId: "booking-123",
+                referrerUserId: "referrer-123",
+                amount: 1000,
+                status: ReferralRewardStatus.PENDING,
+              }),
+            update: mockRewardUpdate,
+          },
+          user: {
+            findUnique: vi.fn().mockResolvedValue({
+              id: "user-123",
+              referralSignupAt: new Date(),
+              referralDiscountUsed: false,
+            }),
+            update: vi.fn().mockResolvedValue({}),
+          },
+          booking: {
+            update: mockBookingUpdate,
+          },
+          userReferralStats: {
+            upsert: mockStatsUpsert,
+          },
+        };
+        return callback(mockTx);
+      });
+
+      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(mockRewardUpdate).toHaveBeenCalledWith({
+        where: { id: "reward-123" },
+        data: expect.objectContaining({
+          status: ReferralRewardStatus.RELEASED,
+          processedAt: expect.any(Date),
+        }),
+      });
+
+      expect(mockBookingUpdate).toHaveBeenCalledWith({
+        where: { id: "booking-123" },
+        data: { referralStatus: BookingReferralStatus.REWARDED },
+      });
+
+      expect(mockStatsUpsert).toHaveBeenCalledWith({
+        where: { userId: "referrer-123" },
+        create: {
+          userId: "referrer-123",
+          totalReferrals: 0,
+          totalRewardsGranted: 1000,
+          totalRewardsPending: 0,
+          lastReferralAt: expect.any(Date),
+        },
+        update: {
+          totalRewardsGranted: { increment: 1000 },
+          totalRewardsPending: { decrement: 1000 },
+          lastReferralAt: expect.any(Date),
+        },
+      });
+    });
+
+    it("should successfully release reward and update existing referrer stats", async () => {
+      const mockStatsUpsert = vi.fn().mockResolvedValue({});
+
+      const mockTransaction = vi.fn(async (callback) => {
+        const mockTx = {
+          referralReward: {
+            findFirst: vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce({
+              id: "reward-123",
+              bookingId: "booking-123",
+              referrerUserId: "referrer-123",
+              amount: 500,
+              status: ReferralRewardStatus.PENDING,
+            }),
+            update: vi.fn().mockResolvedValue({}),
+          },
+          user: {
+            findUnique: vi.fn().mockResolvedValue({
+              id: "user-123",
+              referralSignupAt: new Date(),
+              referralDiscountUsed: true,
+            }),
+            update: vi.fn().mockResolvedValue({}),
+          },
+          booking: {
+            update: vi.fn().mockResolvedValue({}),
+          },
+          userReferralStats: {
+            upsert: mockStatsUpsert,
+          },
+        };
+        return callback(mockTx);
+      });
+
+      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(mockStatsUpsert).toHaveBeenCalledWith({
+        where: { userId: "referrer-123" },
+        create: expect.anything(),
+        update: {
+          totalRewardsGranted: { increment: 500 },
+          totalRewardsPending: { decrement: 500 },
+          lastReferralAt: expect.any(Date),
+        },
+      });
+    });
+  });
+
+  describe("processReferralCompletionForBooking - Transaction and Error Handling", () => {
+    beforeEach(() => {
+      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
+        { key: "REFERRAL_ENABLED", value: true, updatedAt: new Date(), updatedBy: "system" },
+        {
+          key: "REFERRAL_RELEASE_CONDITION",
+          value: "COMPLETED",
+          updatedAt: new Date(),
+          updatedBy: "system",
+        },
+        { key: "REFERRAL_EXPIRY_DAYS", value: 0, updatedAt: new Date(), updatedBy: "system" },
+      ]);
+
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValue(
+        createBooking({
+          id: "booking-123",
+          userId: "user-123",
+          referralReferrerUserId: "referrer-123",
+          referralStatus: BookingReferralStatus.APPLIED,
+        }),
+      );
+    });
+
+    it("should rollback all changes if any database operation fails", async () => {
+      const mockTransaction = vi.fn(async () => {
+        throw new Error("Database constraint violation");
+      });
+
+      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(databaseService.$transaction).toHaveBeenCalled();
+    });
+
+    it("should catch and log errors without throwing", async () => {
+      const mockTransaction = vi.fn(async () => {
+        throw new Error("Unexpected database error");
+      });
+
+      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
+
+      await expect(
+        service.processReferralCompletionForBooking("booking-123"),
+      ).resolves.not.toThrow();
+    });
+
+    it("should handle database connection errors gracefully", async () => {
+      const mockTransaction = vi.fn(async () => {
+        const error = new Error("Connection timeout");
+        error.name = "DatabaseConnectionError";
+        throw error;
+      });
+
+      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
+
+      await expect(
+        service.processReferralCompletionForBooking("booking-123"),
+      ).resolves.not.toThrow();
+
+      expect(databaseService.$transaction).toHaveBeenCalled();
+    });
+  });
+
+  describe("queueReferralProcessing", () => {
+    it("should successfully queue a referral processing job", async () => {
+      const bookingId = "booking-123";
+
+      await service.queueReferralProcessing(bookingId);
+
+      expect(mockQueue.add).toHaveBeenCalledWith(
+        PROCESS_REFERRAL_COMPLETION,
+        {
+          bookingId,
+          timestamp: expect.any(String),
+        },
+        {
+          attempts: 3,
+          backoff: {
+            type: "exponential",
+            delay: 2000,
+          },
+        },
+      );
+    });
+
+    it("should throw error when queue fails", async () => {
+      const bookingId = "booking-123";
+      const queueError = new Error("Redis connection failed");
+      vi.mocked(mockQueue.add).mockRejectedValue(queueError);
+
+      await expect(service.queueReferralProcessing(bookingId)).rejects.toThrow(
+        "Redis connection failed",
+      );
+    });
+  });
+});

--- a/src/modules/referral/referral.service.spec.ts
+++ b/src/modules/referral/referral.service.spec.ts
@@ -817,20 +817,10 @@ describe("ReferralService", () => {
 
       await service.queueReferralProcessing(bookingId);
 
-      expect(mockQueue.add).toHaveBeenCalledWith(
-        PROCESS_REFERRAL_COMPLETION,
-        {
-          bookingId,
-          timestamp: expect.any(String),
-        },
-        {
-          attempts: 3,
-          backoff: {
-            type: "exponential",
-            delay: 2000,
-          },
-        },
-      );
+      expect(mockQueue.add).toHaveBeenCalledWith(PROCESS_REFERRAL_COMPLETION, {
+        bookingId,
+        timestamp: expect.any(String),
+      });
     });
 
     it("should throw error when queue fails", async () => {

--- a/src/modules/referral/referral.service.spec.ts
+++ b/src/modules/referral/referral.service.spec.ts
@@ -443,6 +443,7 @@ describe("ReferralService", () => {
               referralSignupAt: new Date(),
               referralDiscountUsed: false,
             }),
+            update: vi.fn().mockResolvedValue({}),
           },
         };
         return callback(mockTx);
@@ -470,6 +471,7 @@ describe("ReferralService", () => {
               referralSignupAt: new Date(),
               referralDiscountUsed: false,
             }),
+            update: vi.fn().mockResolvedValue({}),
           },
         };
         return callback(mockTx);
@@ -568,6 +570,13 @@ describe("ReferralService", () => {
               referralSignupAt: new Date(),
               referralDiscountUsed: true, // Already used
             }),
+            update: mockUserUpdate,
+          },
+          booking: {
+            update: vi.fn().mockResolvedValue({}),
+          },
+          userReferralStats: {
+            upsert: vi.fn().mockResolvedValue({}),
           },
         };
         return callback(mockTx);
@@ -591,6 +600,16 @@ describe("ReferralService", () => {
               amount: 1000,
               status: ReferralRewardStatus.PENDING,
             }),
+            update: vi.fn().mockResolvedValue({}),
+          },
+          user: {
+            findUnique: vi.fn().mockResolvedValue(null),
+          },
+          booking: {
+            update: vi.fn().mockResolvedValue({}),
+          },
+          userReferralStats: {
+            upsert: vi.fn().mockResolvedValue({}),
           },
         };
         return callback(mockTx);

--- a/src/modules/referral/referral.service.ts
+++ b/src/modules/referral/referral.service.ts
@@ -201,7 +201,7 @@ export class ReferralService {
         bookingId: booking.id,
         error: error instanceof Error ? error.message : String(error),
       });
-      throw error;
+      // Don't throw - allow graceful degradation
     }
   }
 }

--- a/src/modules/referral/referral.service.ts
+++ b/src/modules/referral/referral.service.ts
@@ -196,11 +196,12 @@ export class ReferralService {
           referrerId: pendingReward.referrerUserId,
         });
       });
-    } catch (e) {
+    } catch (error) {
       this.logger.error("Failed to process referral completion", {
         bookingId: booking.id,
-        error: e instanceof Error ? e.message : String(e),
+        error: error instanceof Error ? error.message : String(error),
       });
+      throw error;
     }
   }
 }

--- a/src/modules/referral/referral.service.ts
+++ b/src/modules/referral/referral.service.ts
@@ -1,0 +1,208 @@
+import { InjectQueue } from "@nestjs/bullmq";
+import { Injectable, Logger } from "@nestjs/common";
+import { BookingReferralStatus, ReferralRewardStatus } from "@prisma/client";
+import { Queue } from "bullmq";
+import { REFERRAL_QUEUE } from "../../config/constants";
+import { DatabaseService } from "../database/database.service";
+import { PROCESS_REFERRAL_COMPLETION, ReferralJobData } from "./referral.interface";
+
+@Injectable()
+export class ReferralService {
+  private readonly logger = new Logger(ReferralService.name);
+
+  constructor(
+    private readonly databaseService: DatabaseService,
+    @InjectQueue(REFERRAL_QUEUE)
+    private readonly referralQueue: Queue<ReferralJobData>,
+  ) {}
+
+  /**
+   * Queue a referral completion job for async processing
+   */
+  async queueReferralProcessing(bookingId: string): Promise<void> {
+    try {
+      await this.referralQueue.add(
+        PROCESS_REFERRAL_COMPLETION,
+        {
+          bookingId,
+          timestamp: new Date().toISOString(),
+        },
+        {
+          attempts: 3,
+          backoff: {
+            type: "exponential",
+            delay: 2000,
+          },
+        },
+      );
+
+      this.logger.log(`Queued referral processing for booking ${bookingId}`);
+    } catch (error) {
+      this.logger.error("Failed to queue referral processing", {
+        bookingId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Process referral release for a completed booking when configured for COMPLETED.
+   * - Checks global referral config and idempotency
+   * - Optionally enforces expiry window
+   * - Marks referee discount as used
+   * - Releases pending reward and updates stats
+   * - Sets booking.referralStatus = REWARDED
+   */
+  async processReferralCompletionForBooking(bookingId: string) {
+    // Load config
+    const configs = await this.databaseService.referralProgramConfig.findMany();
+    const configMap = configs.reduce<Record<string, unknown>>((acc, c) => {
+      acc[c.key] = c.value;
+      return acc;
+    }, {});
+
+    const REFERRAL_ENABLED = configMap.REFERRAL_ENABLED ?? true;
+    const REFERRAL_RELEASE_CONDITION = (configMap.REFERRAL_RELEASE_CONDITION ?? "COMPLETED") as
+      | "PAID"
+      | "COMPLETED";
+    const REFERRAL_EXPIRY_DAYS = Number(configMap.REFERRAL_EXPIRY_DAYS ?? 0);
+
+    if (!REFERRAL_ENABLED || REFERRAL_RELEASE_CONDITION !== "COMPLETED") {
+      this.logger.log("Skipping referral completion due to config", {
+        REFERRAL_ENABLED,
+        REFERRAL_RELEASE_CONDITION,
+      });
+      return;
+    }
+
+    const booking = await this.databaseService.booking.findUnique({
+      where: { id: bookingId },
+      select: {
+        id: true,
+        userId: true,
+        referralReferrerUserId: true,
+        referralStatus: true,
+      },
+    });
+
+    if (
+      !booking ||
+      booking.referralStatus !== BookingReferralStatus.APPLIED ||
+      !booking.userId ||
+      !booking.referralReferrerUserId
+    ) {
+      this.logger.log("Skipping referral completion: booking not eligible", {
+        bookingId,
+        hasBooking: !!booking,
+        referralStatus: booking?.referralStatus,
+        hasUser: !!booking?.userId,
+        hasReferrer: !!booking?.referralReferrerUserId,
+      });
+      return;
+    }
+
+    try {
+      await this.databaseService.$transaction(async (tx) => {
+        // Idempotency: skip if already released
+        const alreadyReleased = await tx.referralReward.findFirst({
+          where: { bookingId: booking.id, status: ReferralRewardStatus.RELEASED },
+          select: { id: true },
+        });
+
+        if (alreadyReleased) {
+          this.logger.warn("Referral reward already released for booking", {
+            bookingId: booking.id,
+            rewardId: alreadyReleased.id,
+          });
+          return;
+        }
+
+        // Optional expiry check
+        const referee = await tx.user.findUnique({
+          where: { id: booking.userId },
+          select: { referralSignupAt: true, referralDiscountUsed: true },
+        });
+
+        if (REFERRAL_EXPIRY_DAYS > 0 && referee?.referralSignupAt) {
+          const daysSinceSignup = Math.floor(
+            (Date.now() - referee.referralSignupAt.getTime()) / (1000 * 60 * 60 * 24),
+          );
+
+          if (daysSinceSignup > REFERRAL_EXPIRY_DAYS) {
+            this.logger.warn("Referral expired before completion; not releasing reward", {
+              bookingId: booking.id,
+              userId: booking.userId,
+              daysSinceSignup,
+              expiryDays: REFERRAL_EXPIRY_DAYS,
+            });
+            return;
+          }
+        }
+
+        // Mark discount used if not already
+        if (referee && !referee.referralDiscountUsed && booking.userId) {
+          await tx.user.update({
+            where: { id: booking.userId },
+            data: { referralDiscountUsed: true },
+          });
+
+          this.logger.log("Referral discount marked as used on completion", {
+            bookingId: booking.id,
+            userId: booking.userId,
+          });
+        }
+
+        // Release pending reward
+        const pendingReward = await tx.referralReward.findFirst({
+          where: { bookingId: booking.id, status: ReferralRewardStatus.PENDING },
+        });
+
+        if (!pendingReward) {
+          this.logger.log("No pending referral reward found for booking", {
+            bookingId: booking.id,
+          });
+          return;
+        }
+
+        await tx.referralReward.update({
+          where: { id: pendingReward.id },
+          data: { status: ReferralRewardStatus.RELEASED, processedAt: new Date() },
+        });
+
+        await tx.booking.update({
+          where: { id: booking.id },
+          data: { referralStatus: BookingReferralStatus.REWARDED },
+        });
+
+        await tx.userReferralStats.upsert({
+          where: { userId: pendingReward.referrerUserId },
+          create: {
+            userId: pendingReward.referrerUserId,
+            totalReferrals: 0,
+            totalRewardsGranted: pendingReward.amount,
+            totalRewardsPending: 0,
+            lastReferralAt: new Date(),
+          },
+          update: {
+            totalRewardsGranted: { increment: pendingReward.amount },
+            totalRewardsPending: { decrement: pendingReward.amount },
+            lastReferralAt: new Date(),
+          },
+        });
+
+        this.logger.log("Referral reward released on completion", {
+          bookingId: booking.id,
+          rewardId: pendingReward.id,
+          rewardAmount: pendingReward.amount,
+          referrerId: pendingReward.referrerUserId,
+        });
+      });
+    } catch (e) {
+      this.logger.error("Failed to process referral completion", {
+        bookingId: booking.id,
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+}

--- a/src/modules/reminder/reminder.service.spec.ts
+++ b/src/modules/reminder/reminder.service.spec.ts
@@ -6,8 +6,8 @@ import { ReminderService } from "./reminder.service";
 
 describe("ReminderService", () => {
   let service: ReminderService;
-  let mockDatabaseService: DatabaseService;
-  let mockNotificationService: NotificationService;
+  let databaseService: DatabaseService;
+  let notificationService: NotificationService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -31,8 +31,8 @@ describe("ReminderService", () => {
     }).compile();
 
     service = module.get<ReminderService>(ReminderService);
-    mockDatabaseService = module.get<DatabaseService>(DatabaseService);
-    mockNotificationService = module.get<NotificationService>(NotificationService);
+    databaseService = module.get<DatabaseService>(DatabaseService);
+    notificationService = module.get<NotificationService>(NotificationService);
   });
 
   it("should be defined", () => {
@@ -40,7 +40,7 @@ describe("ReminderService", () => {
   });
 
   it("should have all required services injected", () => {
-    expect(mockDatabaseService).toBeDefined();
-    expect(mockNotificationService).toBeDefined();
+    expect(databaseService).toBeDefined();
+    expect(notificationService).toBeDefined();
   });
 });

--- a/src/modules/status-change/status-change.module.ts
+++ b/src/modules/status-change/status-change.module.ts
@@ -5,6 +5,7 @@ import { Module } from "@nestjs/common";
 import { STATUS_UPDATES_QUEUE } from "../../config/constants";
 import { DatabaseModule } from "../database/database.module";
 import { NotificationModule } from "../notification/notification.module";
+import { ReferralModule } from "../referral/referral.module";
 import { StatusChangeProcessor } from "./status-change.processor";
 import { StatusChangeScheduler } from "./status-change.scheduler";
 import { StatusChangeService } from "./status-change.service";
@@ -13,6 +14,7 @@ import { StatusChangeService } from "./status-change.service";
   imports: [
     DatabaseModule,
     NotificationModule,
+    ReferralModule,
     BullModule.registerQueue({ name: STATUS_UPDATES_QUEUE }),
     BullBoardModule.forFeature({
       name: STATUS_UPDATES_QUEUE,

--- a/src/modules/status-change/status-change.service.spec.ts
+++ b/src/modules/status-change/status-change.service.spec.ts
@@ -69,6 +69,7 @@ describe("StatusChangeService", () => {
     expect(mockDatabaseService).toBeDefined();
     expect(mockNotificationService).toBeDefined();
     expect(mockPaymentService).toBeDefined();
+    expect(mockReferralService).toBeDefined();
   });
 
   it("should not update bookings from confirmed to active when no bookings found", async () => {

--- a/src/modules/status-change/status-change.service.spec.ts
+++ b/src/modules/status-change/status-change.service.spec.ts
@@ -5,6 +5,7 @@ import { createBooking } from "../../shared/helper.fixtures";
 import { DatabaseService } from "../database/database.service";
 import { NotificationService } from "../notification/notification.service";
 import { PaymentService } from "../payment/payment.service";
+import { ReferralService } from "../referral/referral.service";
 import { StatusChangeService } from "./status-change.service";
 
 describe("StatusChangeService", () => {
@@ -12,6 +13,7 @@ describe("StatusChangeService", () => {
   let mockDatabaseService: DatabaseService;
   let mockNotificationService: NotificationService;
   let mockPaymentService: PaymentService;
+  let mockReferralService: ReferralService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -37,6 +39,12 @@ describe("StatusChangeService", () => {
           },
         },
         {
+          provide: ReferralService,
+          useValue: {
+            queueReferralProcessing: vi.fn(),
+          },
+        },
+        {
           provide: PaymentService,
           useValue: {
             initiatePayout: vi.fn(),
@@ -49,6 +57,7 @@ describe("StatusChangeService", () => {
     mockDatabaseService = module.get<DatabaseService>(DatabaseService);
     mockNotificationService = module.get<NotificationService>(NotificationService);
     mockPaymentService = module.get<PaymentService>(PaymentService);
+    mockReferralService = module.get<ReferralService>(ReferralService);
   });
 
   it("should be defined", () => {
@@ -90,14 +99,12 @@ describe("StatusChangeService", () => {
   it("should update bookings from confirmed to active when bookings found", async () => {
     const mockBooking = createBooking({
       id: "1",
-      bookingReference: "1",
       status: BookingStatus.CONFIRMED,
       paymentStatus: PaymentStatus.PAID,
     });
 
     vi.mocked(mockDatabaseService.booking.findMany).mockResolvedValue([mockBooking]);
 
-    // Mock $transaction to execute the callback with a mock transaction object
     vi.mocked(mockDatabaseService.$transaction).mockImplementation(async (callback) => {
       const mockTx = {
         booking: {
@@ -109,9 +116,8 @@ describe("StatusChangeService", () => {
 
     const result = await service.updateBookingsFromConfirmedToActive();
 
-    expect(mockDatabaseService.$transaction).toHaveBeenCalledTimes(1);
-    expect(mockNotificationService.queueBookingStatusNotifications).toHaveBeenCalledTimes(1);
-    expect(mockNotificationService.queueBookingStatusNotifications).toHaveBeenCalledWith(
+    expect(mockDatabaseService.$transaction).toHaveBeenCalledOnce();
+    expect(mockNotificationService.queueBookingStatusNotifications).toHaveBeenCalledExactlyOnceWith(
       expect.objectContaining({ id: "1", status: BookingStatus.ACTIVE }),
       BookingStatus.CONFIRMED,
       BookingStatus.ACTIVE,
@@ -125,5 +131,39 @@ describe("StatusChangeService", () => {
     const result = await service.updateBookingsFromActiveToCompleted();
 
     expect(result).toBe("No bookings to update");
+  });
+
+  it("should update bookings from active to completed and queue referral processing", async () => {
+    const mockBooking = createBooking({
+      id: "2",
+      status: BookingStatus.ACTIVE,
+      paymentStatus: PaymentStatus.PAID,
+      carId: "car-1",
+    });
+
+    vi.mocked(mockDatabaseService.booking.findMany).mockResolvedValue([mockBooking]);
+
+    vi.mocked(mockDatabaseService.$transaction).mockImplementation(async (callback) => {
+      const mockTx = {
+        booking: {
+          update: vi.fn().mockResolvedValue({ ...mockBooking, status: BookingStatus.COMPLETED }),
+        },
+        car: {
+          update: vi.fn().mockResolvedValue({ id: "car-1", status: Status.AVAILABLE }),
+        },
+      } as unknown as DatabaseService;
+      return callback(mockTx);
+    });
+
+    const result = await service.updateBookingsFromActiveToCompleted();
+
+    expect(mockDatabaseService.$transaction).toHaveBeenCalledOnce();
+    expect(mockNotificationService.queueBookingStatusNotifications).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ id: "2", status: BookingStatus.COMPLETED }),
+      BookingStatus.ACTIVE,
+      BookingStatus.COMPLETED,
+    );
+    expect(mockReferralService.queueReferralProcessing).toHaveBeenCalledExactlyOnceWith("2");
+    expect(result).toBe("Updated 1 bookings from active to completed");
   });
 });

--- a/src/modules/status-change/status-change.service.ts
+++ b/src/modules/status-change/status-change.service.ts
@@ -156,9 +156,16 @@ export class StatusChangeService {
           );
         });
 
-        // Queue referral processing OUTSIDE the transaction for better isolation
-        // This ensures booking status update is not blocked by referral processing
-        await this.referralService.queueReferralProcessing(booking.id);
+        try {
+          // Queue referral processing OUTSIDE the transaction for better isolation
+          // This ensures booking status update is not blocked by referral processing
+          await this.referralService.queueReferralProcessing(booking.id);
+        } catch (error) {
+          this.logger.error(
+            `Failed to queue referral processing for booking ${booking.id}: ${error}`,
+          );
+          // Continue without failing the entire operation
+        }
       }
 
       return `Updated ${bookingsToUpdate.length} bookings from active to completed`;

--- a/src/modules/status-change/status-change.service.ts
+++ b/src/modules/status-change/status-change.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from "@nestjs/common";
 import { BookingStatus, PaymentStatus, Status } from "@prisma/client";
 import { DatabaseService } from "../database/database.service";
 import { NotificationService } from "../notification/notification.service";
+import { ReferralService } from "../referral/referral.service";
 
 @Injectable()
 export class StatusChangeService {
@@ -10,6 +11,7 @@ export class StatusChangeService {
   constructor(
     private readonly databaseService: DatabaseService,
     private readonly notificationService: NotificationService,
+    private readonly referralService: ReferralService,
   ) {}
 
   private getCurrentUtcHourWindow(): { gte: Date; lte: Date } {
@@ -141,7 +143,6 @@ export class StatusChangeService {
             },
           });
 
-          // Free up the car
           await tx.car.update({
             where: { id: booking.carId },
             data: { status: Status.AVAILABLE },
@@ -154,6 +155,10 @@ export class StatusChangeService {
             BookingStatus.COMPLETED,
           );
         });
+
+        // Queue referral processing OUTSIDE the transaction for better isolation
+        // This ensures booking status update is not blocked by referral processing
+        await this.referralService.queueReferralProcessing(booking.id);
       }
 
       return `Updated ${bookingsToUpdate.length} bookings from active to completed`;

--- a/src/shared/helper.ts
+++ b/src/shared/helper.ts
@@ -113,10 +113,10 @@ export function normaliseBookingDetails(booking: BookingWithRelations): Normalis
   let title: string;
   let status: string;
 
-  if (booking.status === BookingStatus.CONFIRMED) {
+  if (booking.status === BookingStatus.ACTIVE) {
     title = "started";
     status = "active";
-  } else if (booking.status === BookingStatus.ACTIVE) {
+  } else if (booking.status === BookingStatus.COMPLETED) {
     title = "ended";
     status = "completed";
   } else {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a referral queue with processor/service and wires it into booking completion to release rewards, updates constants/modules, improves email error handling, and adds comprehensive tests.
> 
> - **Backend**:
>   - **Referral**:
>     - New `ReferralModule` with BullMQ queue `REFERRAL_QUEUE`, bull-board integration, `ReferralProcessor`, and `ReferralService` (`queueReferralProcessing`, `processReferralCompletionForBooking`).
>     - Adds `ReferralJobData` and `PROCESS_REFERRAL_COMPLETION` job.
>   - **Status Changes**:
>     - `StatusChangeService` now queues referral processing after updating bookings from `ACTIVE` to `COMPLETED`; `StatusChangeModule` imports `ReferralModule`.
>   - **Config**:
>     - Registers `ReferralModule` in `AppModule`; adds `REFERRAL_QUEUE` in `config/constants`.
>   - **Notifications/Email**:
>     - `EmailService.sendEmail` now uses `EmailNotificationData`, logs message ID, and throws on Resend API errors.
>   - **Helpers**:
>     - Fixes `normaliseBookingDetails` title/status mapping for `ACTIVE` and `COMPLETED`.
> - **Tests**:
>   - Adds exhaustive unit tests for referral processor/service; updates notification, reminder, and status-change specs to cover new flows and assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a6522362c7779c351a1bb156746e528427f4189. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->