### PR TITLE
feat(payments): initiate fleet owner payout on booking completion with idempotent Flutterwave reference and tests

### DIFF
--- a/src/modules/flutterwave/flutterwave.interface.ts
+++ b/src/modules/flutterwave/flutterwave.interface.ts
@@ -58,6 +58,7 @@ export interface PayoutRequest {
   amount: number;
   reference: string;
   bookingId: string;
+  bookingReference: string;
 }
 
 export interface PayoutResponse {

--- a/src/modules/flutterwave/flutterwave.service.ts
+++ b/src/modules/flutterwave/flutterwave.service.ts
@@ -81,6 +81,7 @@ export class FlutterwaveService {
       this.logger.error("Failed to initiate payout via Flutterwave", {
         error: String(error),
         bookingId,
+        bookingReference,
       });
 
       if (error instanceof FlutterwaveError) {

--- a/src/modules/flutterwave/flutterwave.service.ts
+++ b/src/modules/flutterwave/flutterwave.service.ts
@@ -40,13 +40,13 @@ export class FlutterwaveService {
   }
 
   async initiatePayout(request: PayoutRequest): Promise<PayoutResponse> {
-    const { bankDetails, amount, reference, bookingId } = request;
+    const { bankDetails, amount, reference, bookingId, bookingReference } = request;
 
     const payload = {
       account_bank: bankDetails.bankCode,
       account_number: bankDetails.accountNumber,
       amount: amount,
-      narration: `Payout for booking ${bookingId}`,
+      narration: `Payout for booking ${bookingReference} - ${bookingId}`,
       currency: "NGN",
       reference: reference,
       callback_url: `${this.config.webhookUrl}/api/payments/webhook/flutterwave`,

--- a/src/modules/payment/payment.service.spec.ts
+++ b/src/modules/payment/payment.service.spec.ts
@@ -50,6 +50,16 @@ describe("PaymentService", () => {
     service = module.get<PaymentService>(PaymentService);
     databaseService = module.get<DatabaseService>(DatabaseService);
     flutterwaveService = module.get<FlutterwaveService>(FlutterwaveService);
+
+    // Mock Prisma-style $transaction helper used in PaymentService
+    (
+      databaseService as unknown as {
+        $transaction: (cb: (tx: unknown) => unknown) => Promise<unknown>;
+      }
+    ).$transaction = vi.fn(async (callback: (tx: unknown) => unknown) =>
+      // In tests we don't need a separate transactional client; reuse the same mock.
+      callback(databaseService),
+    );
   });
 
   it("should be defined", () => {

--- a/src/modules/payment/payment.service.spec.ts
+++ b/src/modules/payment/payment.service.spec.ts
@@ -6,6 +6,8 @@ import { PaymentService } from "./payment.service";
 
 describe("PaymentService", () => {
   let service: PaymentService;
+  let databaseService: DatabaseService;
+  let flutterwaveService: FlutterwaveService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -46,6 +48,8 @@ describe("PaymentService", () => {
     }).compile();
 
     service = module.get<PaymentService>(PaymentService);
+    databaseService = module.get<DatabaseService>(DatabaseService);
+    flutterwaveService = module.get<FlutterwaveService>(FlutterwaveService);
   });
 
   it("should be defined", () => {
@@ -53,7 +57,47 @@ describe("PaymentService", () => {
   });
 
   it("should have database and flutterwave services injected", () => {
-    expect(service).toHaveProperty("databaseService");
-    expect(service).toHaveProperty("flutterwaveService");
+    expect(databaseService).toBeDefined();
+    expect(flutterwaveService).toBeDefined();
+  });
+
+  it("should use a deterministic reference derived from payout transaction id", async () => {
+    const booking: any = {
+      id: "booking-123",
+      fleetOwnerPayoutAmountNet: { isZero: () => false, toNumber: () => 15000 },
+      car: { owner: { id: "owner-1" } },
+    };
+
+    (flutterwaveService.initiatePayout as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      success: true,
+      data: { id: 12345 },
+    });
+
+    await service.initiatePayout(booking);
+
+    expect(flutterwaveService.initiatePayout).toHaveBeenCalledTimes(1);
+    const callArgs = (flutterwaveService.initiatePayout as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    expect(callArgs.reference).toBe("payout_payout-123");
+  });
+
+  it("should not retry payout when status is PROCESSING or PAID_OUT", async () => {
+    const booking: any = {
+      id: "booking-123",
+      fleetOwnerPayoutAmountNet: { isZero: () => false, toNumber: () => 15000 },
+      car: { owner: { id: "owner-1" } },
+    };
+
+    // Simulate existing payout transaction already in a terminal/processing state
+    (databaseService.payoutTransaction.create as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      {
+        id: "payout-123",
+        status: "PROCESSING",
+      },
+    );
+
+    await service.initiatePayout(booking);
+
+    expect(flutterwaveService.initiatePayout).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/payment/payment.service.spec.ts
+++ b/src/modules/payment/payment.service.spec.ts
@@ -64,11 +64,14 @@ describe("PaymentService", () => {
   it("should use a deterministic reference derived from payout transaction id", async () => {
     const booking: any = {
       id: "booking-123",
+      bookingReference: "BR-booking-123",
       fleetOwnerPayoutAmountNet: { isZero: () => false, toNumber: () => 15000 },
       car: { owner: { id: "owner-1" } },
     };
 
-    (flutterwaveService.initiatePayout as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    (
+      flutterwaveService.initiatePayout as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({
       success: true,
       data: { id: 12345 },
     });
@@ -84,17 +87,18 @@ describe("PaymentService", () => {
   it("should not retry payout when status is PROCESSING or PAID_OUT", async () => {
     const booking: any = {
       id: "booking-123",
+      bookingReference: "BR-booking-123",
       fleetOwnerPayoutAmountNet: { isZero: () => false, toNumber: () => 15000 },
       car: { owner: { id: "owner-1" } },
     };
 
     // Simulate existing payout transaction already in a terminal/processing state
-    (databaseService.payoutTransaction.create as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
-      {
-        id: "payout-123",
-        status: "PROCESSING",
-      },
-    );
+    (
+      databaseService.payoutTransaction.create as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({
+      id: "payout-123",
+      status: "PROCESSING",
+    });
 
     await service.initiatePayout(booking);
 

--- a/src/modules/status-change/status-change.module.ts
+++ b/src/modules/status-change/status-change.module.ts
@@ -6,6 +6,7 @@ import { STATUS_UPDATES_QUEUE } from "../../config/constants";
 import { DatabaseModule } from "../database/database.module";
 import { NotificationModule } from "../notification/notification.module";
 import { ReferralModule } from "../referral/referral.module";
+import { PaymentModule } from "../payment/payment.module";
 import { StatusChangeProcessor } from "./status-change.processor";
 import { StatusChangeScheduler } from "./status-change.scheduler";
 import { StatusChangeService } from "./status-change.service";
@@ -15,6 +16,7 @@ import { StatusChangeService } from "./status-change.service";
     DatabaseModule,
     NotificationModule,
     ReferralModule,
+    PaymentModule,
     BullModule.registerQueue({ name: STATUS_UPDATES_QUEUE }),
     BullBoardModule.forFeature({
       name: STATUS_UPDATES_QUEUE,

--- a/src/modules/status-change/status-change.service.spec.ts
+++ b/src/modules/status-change/status-change.service.spec.ts
@@ -24,6 +24,7 @@ describe("StatusChangeService", () => {
           useValue: {
             booking: {
               findMany: vi.fn(),
+              findUnique: vi.fn(),
               update: vi.fn(),
             },
             car: {
@@ -169,6 +170,11 @@ describe("StatusChangeService", () => {
       return callback(mockTx);
     });
 
+    vi.mocked(mockDatabaseService.booking.findUnique).mockResolvedValue({
+      ...mockBooking,
+      status: BookingStatus.COMPLETED,
+    });
+
     const result = await service.updateBookingsFromActiveToCompleted();
 
     expect(mockDatabaseService.$transaction).toHaveBeenCalledOnce();
@@ -192,6 +198,9 @@ describe("StatusChangeService", () => {
       BookingStatus.COMPLETED,
     );
     expect(mockReferralService.queueReferralProcessing).toHaveBeenCalledExactlyOnceWith("2");
+    expect(mockPaymentService.initiatePayout).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ id: "2", status: BookingStatus.COMPLETED }),
+    );
     expect(result).toBe("Updated 1 bookings from active to completed");
   });
 });

--- a/src/modules/status-change/status-change.service.ts
+++ b/src/modules/status-change/status-change.service.ts
@@ -215,7 +215,7 @@ export class StatusChangeService {
             include: {
               chauffeur: true,
               user: true,
-              car: { include: { owner: true } },
+              car: { include: { owner: { include: { bankDetails: true } } } },
               legs: {
                 include: {
                   extensions: true,

--- a/src/modules/status-change/status-change.service.ts
+++ b/src/modules/status-change/status-change.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from "@nestjs/common";
 import { BookingStatus, PaymentStatus, Status } from "@prisma/client";
 import { DatabaseService } from "../database/database.service";
 import { NotificationService } from "../notification/notification.service";
+import { PaymentService } from "../payment/payment.service";
 import { ReferralService } from "../referral/referral.service";
 
 @Injectable()
@@ -11,6 +12,7 @@ export class StatusChangeService {
   constructor(
     private readonly databaseService: DatabaseService,
     private readonly notificationService: NotificationService,
+    private readonly paymentService: PaymentService,
     private readonly referralService: ReferralService,
   ) {}
 
@@ -121,7 +123,6 @@ export class StatusChangeService {
           paymentStatus: PaymentStatus.PAID,
           endDate,
           car: {
-            id: { not: null },
             status: Status.BOOKED,
           },
         },
@@ -205,6 +206,38 @@ export class StatusChangeService {
             `Failed to queue referral processing for booking ${booking.id}: ${error}`,
           );
           // Continue without failing the entire operation
+        }
+
+        try {
+          // Fetch the completed booking with the relations required by PaymentService
+          const completedBooking = await this.databaseService.booking.findUnique({
+            where: { id: booking.id },
+            include: {
+              chauffeur: true,
+              user: true,
+              car: { include: { owner: true } },
+              legs: {
+                include: {
+                  extensions: true,
+                },
+              },
+            },
+          });
+
+          if (!completedBooking) {
+            this.logger.error(
+              `Completed booking ${booking.id} not found when attempting to initiate payout`,
+            );
+          } else {
+            await this.paymentService.initiatePayout(completedBooking);
+          }
+        } catch (error) {
+          this.logger.error(
+            `Failed to initiate payout for completed booking ${booking.id}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+          // Do not throw so that other bookings can continue processing
         }
       }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors payout flow to create/update payout transactions and trigger Flutterwave with a deterministic reference when bookings complete, integrating into the status-change pipeline and adding targeted tests.
> 
> - **Payments**:
>   - **Refactor `PaymentService`**: Extract helpers for validation, transaction creation/update, status handling, and success/failure updates; generate deterministic `reference` as `payout_<payoutTransaction.id>`.
>   - **Flutterwave**: Extend `PayoutRequest` with `bookingReference` and include it in payout narration; pass through from `PaymentService`.
> - **Status Change**:
>   - Inject `PaymentService` via `PaymentModule` and, after marking bookings COMPLETED, fetch full booking and call `paymentService.initiatePayout`.
> - **Tests**:
>   - Add/extend specs for `PaymentService` (deterministic reference; no retry when status is PROCESSING/PAID_OUT) and `StatusChangeService` to assert payout initiation on completion.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c72b65478f516a676fbbd1381be6b76fb123185f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->