### PR TITLE
feat(payments): add async payouts queue and initiate fleet owner payouts on completion

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -4,6 +4,7 @@ export const NOTIFICATIONS_QUEUE = "notifications-queue";
 export const STATUS_UPDATES_QUEUE = "status-updates-queue";
 export const REMINDERS_QUEUE = "reminders-queue";
 export const REFERRAL_QUEUE = "referral-queue";
+export const PAYOUTS_QUEUE = "payouts-queue";
 
 export const EVERY_HOUR = "0 * * * *";
 export const CONFIRMED_TO_ACTIVE = "confirmed-to-active";

--- a/src/modules/payment/payment.interface.ts
+++ b/src/modules/payment/payment.interface.ts
@@ -1,0 +1,8 @@
+export const PROCESS_PAYOUT_FOR_BOOKING = "process-payout-for-booking";
+
+export interface PayoutJobData {
+  bookingId: string;
+  timestamp: string;
+}
+
+

--- a/src/modules/payment/payment.module.ts
+++ b/src/modules/payment/payment.module.ts
@@ -1,11 +1,14 @@
+import { BullModule } from "@nestjs/bullmq";
 import { Module } from "@nestjs/common";
+import { PAYOUTS_QUEUE } from "../../config/constants";
 import { DatabaseModule } from "../database/database.module";
 import { FlutterwaveModule } from "../flutterwave/flutterwave.module";
+import { PaymentProcessor } from "./payment.processor";
 import { PaymentService } from "./payment.service";
 
 @Module({
-  imports: [FlutterwaveModule, DatabaseModule],
-  providers: [PaymentService],
+  imports: [FlutterwaveModule, DatabaseModule, BullModule.registerQueue({ name: PAYOUTS_QUEUE })],
+  providers: [PaymentService, PaymentProcessor],
   exports: [PaymentService],
 })
 export class PaymentModule {}

--- a/src/modules/payment/payment.processor.spec.ts
+++ b/src/modules/payment/payment.processor.spec.ts
@@ -1,0 +1,80 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { BookingStatus } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DatabaseService } from "../database/database.service";
+import { PayoutJobData, PROCESS_PAYOUT_FOR_BOOKING } from "./payment.interface";
+import { PaymentProcessor } from "./payment.processor";
+import { PaymentService } from "./payment.service";
+
+describe("PaymentProcessor", () => {
+  let processor: PaymentProcessor;
+  let databaseService: DatabaseService;
+  let paymentService: PaymentService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PaymentProcessor,
+        {
+          provide: DatabaseService,
+          useValue: {
+            booking: {
+              findUnique: vi.fn(),
+            },
+          },
+        },
+        {
+          provide: PaymentService,
+          useValue: {
+            initiatePayout: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    processor = module.get<PaymentProcessor>(PaymentProcessor);
+    databaseService = module.get<DatabaseService>(DatabaseService);
+    paymentService = module.get<PaymentService>(PaymentService);
+  });
+
+  it("should process payout job and call initiatePayout when booking exists", async () => {
+    const job: any = {
+      name: PROCESS_PAYOUT_FOR_BOOKING,
+      data: { bookingId: "booking-1", timestamp: new Date().toISOString() } as PayoutJobData,
+    };
+
+    (
+      databaseService.booking.findUnique as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({
+      id: "booking-1",
+      status: BookingStatus.COMPLETED,
+    });
+
+    const result = await processor.process(job);
+
+    expect(databaseService.booking.findUnique).toHaveBeenCalledWith({
+      where: { id: "booking-1" },
+      include: expect.any(Object),
+    });
+    expect(paymentService.initiatePayout).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ id: "booking-1" }),
+    );
+    expect(result).toEqual({ success: true });
+  });
+
+  it("should not call initiatePayout when booking is not found", async () => {
+    const job: any = {
+      name: PROCESS_PAYOUT_FOR_BOOKING,
+      data: { bookingId: "missing-booking", timestamp: new Date().toISOString() } as PayoutJobData,
+    };
+
+    (
+      databaseService.booking.findUnique as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce(null);
+
+    const result = await processor.process(job);
+
+    expect(paymentService.initiatePayout).not.toHaveBeenCalled();
+    expect(result).toEqual({ success: false, reason: "BOOKING_NOT_FOUND" });
+  });
+});

--- a/src/modules/payment/payment.processor.spec.ts
+++ b/src/modules/payment/payment.processor.spec.ts
@@ -77,4 +77,15 @@ describe("PaymentProcessor", () => {
     expect(paymentService.initiatePayout).not.toHaveBeenCalled();
     expect(result).toEqual({ success: false, reason: "BOOKING_NOT_FOUND" });
   });
+
+  it("should throw error for unknown job type", async () => {
+    const job: any = {
+      name: "unknown-job-type",
+      data: { bookingId: "booking-1", timestamp: new Date().toISOString() },
+    };
+
+    await expect(processor.process(job)).rejects.toThrow(
+      "Unknown payout job type: unknown-job-type",
+    );
+  });
 });

--- a/src/modules/payment/payment.processor.ts
+++ b/src/modules/payment/payment.processor.ts
@@ -1,0 +1,85 @@
+import { OnWorkerEvent, Processor, WorkerHost } from "@nestjs/bullmq";
+import { Injectable, Logger } from "@nestjs/common";
+import { Job } from "bullmq";
+import { PAYOUTS_QUEUE } from "../../config/constants";
+import { DatabaseService } from "../database/database.service";
+import { PaymentService } from "./payment.service";
+import { PayoutJobData, PROCESS_PAYOUT_FOR_BOOKING } from "./payment.interface";
+
+@Processor(PAYOUTS_QUEUE)
+@Injectable()
+export class PaymentProcessor extends WorkerHost {
+  private readonly logger = new Logger(PaymentProcessor.name);
+
+  constructor(
+    private readonly databaseService: DatabaseService,
+    private readonly paymentService: PaymentService,
+  ) {
+    super();
+  }
+
+  async process(job: Job<PayoutJobData, any, string>) {
+    this.logger.log(`Processing payout job: ${job.name}`, job.data);
+
+    if (job.name !== PROCESS_PAYOUT_FOR_BOOKING) {
+      throw new Error(`Unknown payout job type: ${job.name}`);
+    }
+
+    const { bookingId } = job.data;
+
+    try {
+      const booking = await this.databaseService.booking.findUnique({
+        where: { id: bookingId },
+        include: {
+          chauffeur: true,
+          user: true,
+          car: { include: { owner: true } },
+          legs: {
+            include: {
+              extensions: true,
+            },
+          },
+        },
+      });
+
+      if (!booking) {
+        this.logger.warn(`Booking ${bookingId} not found when processing payout job`);
+        return { success: false, reason: "BOOKING_NOT_FOUND" };
+      }
+
+      await this.paymentService.initiatePayout(booking);
+
+      return { success: true };
+    } catch (error) {
+      this.logger.error(
+        `Failed to process payout for booking ${bookingId}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      throw error;
+    }
+  }
+
+  @OnWorkerEvent("completed")
+  onCompleted(job: Job<PayoutJobData>) {
+    const duration = job.finishedOn && job.processedOn ? job.finishedOn - job.processedOn : "N/A";
+    this.logger.log(`Payout job completed: ${job.name} [${job.id}] - Duration: ${duration}ms`);
+  }
+
+  @OnWorkerEvent("failed")
+  onFailed(job: Job<PayoutJobData>, error: Error) {
+    this.logger.error(`Payout job failed: ${job.name} [${job.id}]`, {
+      error: error.message,
+      stack: error.stack,
+      attempts: job.attemptsMade,
+      maxAttempts: job.opts.attempts,
+    });
+  }
+
+  @OnWorkerEvent("active")
+  onActive(job: Job<PayoutJobData>) {
+    this.logger.log(`Payout job started: ${job.name} [${job.id}] - Attempt ${job.attemptsMade + 1}`);
+  }
+}
+
+

--- a/src/modules/payment/payment.service.spec.ts
+++ b/src/modules/payment/payment.service.spec.ts
@@ -1,5 +1,7 @@
+import { getQueueToken } from "@nestjs/bullmq";
 import { Test, TestingModule } from "@nestjs/testing";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PAYOUTS_QUEUE } from "../../config/constants";
 import { DatabaseService } from "../database/database.service";
 import { FlutterwaveService } from "../flutterwave/flutterwave.service";
 import { PaymentService } from "./payment.service";
@@ -42,6 +44,12 @@ describe("PaymentService", () => {
               success: true,
               data: { id: 12345 },
             }),
+          },
+        },
+        {
+          provide: getQueueToken(PAYOUTS_QUEUE),
+          useValue: {
+            add: vi.fn(),
           },
         },
       ],

--- a/src/modules/payment/payment.service.spec.ts
+++ b/src/modules/payment/payment.service.spec.ts
@@ -104,20 +104,22 @@ describe("PaymentService", () => {
     expect(callArgs.reference).toBe("payout_payout-123");
   });
 
-  // test that payout job is queued when initiatePayout is called
-  it("should queue payout job when initiatePayout is called", async () => {
-    const booking: any = {
-      id: "booking-123",
-      bookingReference: "BR-booking-123",
-      fleetOwnerPayoutAmountNet: { isZero: () => false, toNumber: () => 15000 },
-      car: { owner: { id: "owner-1" } },
-    };
-
-    await service.initiatePayout(booking);
+  // test that payout job is queued when queuePayoutForBooking is called
+  it("should queue payout job when queuePayoutForBooking is called", async () => {
+    const bookingId = "booking-123";
+    await service.queuePayoutForBooking(bookingId);
 
     expect(payoutsQueue.add).toHaveBeenCalledWith(
       PROCESS_PAYOUT_FOR_BOOKING,
-      expect.objectContaining({ bookingId: "booking-123" }),
+      expect.objectContaining({ bookingId, timestamp: expect.any(String) }),
+      {
+        jobId: `payout-${bookingId}`,
+        attempts: 3,
+        backoff: {
+          type: "exponential",
+          delay: 5000,
+        },
+      },
     );
   });
 

--- a/src/modules/payment/payment.service.ts
+++ b/src/modules/payment/payment.service.ts
@@ -1,8 +1,12 @@
 import { Injectable, Logger } from "@nestjs/common";
+import { InjectQueue } from "@nestjs/bullmq";
+import { Queue } from "bullmq";
+import { PAYOUTS_QUEUE } from "../../config/constants";
 import { PayoutTransaction } from "@prisma/client";
 import { BookingWithRelations } from "../../types";
 import { DatabaseService } from "../database/database.service";
 import { FlutterwaveService } from "../flutterwave/flutterwave.service";
+import { PayoutJobData, PROCESS_PAYOUT_FOR_BOOKING } from "./payment.interface";
 
 @Injectable()
 export class PaymentService {
@@ -11,6 +15,8 @@ export class PaymentService {
   constructor(
     private readonly databaseService: DatabaseService,
     private readonly flutterwaveService: FlutterwaveService,
+    @InjectQueue(PAYOUTS_QUEUE)
+    private readonly payoutsQueue: Queue<PayoutJobData>,
   ) {}
 
   private hasNoPayoutAmount(booking: BookingWithRelations): boolean {
@@ -266,6 +272,27 @@ export class PaymentService {
       } else {
         this.logger.error(`Failed to initiate payout: ${String(error)}`);
       }
+      throw error;
+    }
+  }
+
+  /**
+   * Queue payout processing for a completed booking.
+   * This allows payouts to be processed asynchronously via BullMQ.
+   */
+  async queuePayoutForBooking(bookingId: string) {
+    try {
+      await this.payoutsQueue.add(PROCESS_PAYOUT_FOR_BOOKING, {
+        bookingId,
+        timestamp: new Date().toISOString(),
+      });
+
+      this.logger.log(`Queued payout processing for booking ${bookingId}`);
+    } catch (error) {
+      this.logger.error("Failed to queue payout processing", {
+        bookingId,
+        error: error instanceof Error ? error.message : String(error),
+      });
       throw error;
     }
   }

--- a/src/modules/status-change/status-change.service.spec.ts
+++ b/src/modules/status-change/status-change.service.spec.ts
@@ -48,7 +48,6 @@ describe("StatusChangeService", () => {
         {
           provide: PaymentService,
           useValue: {
-            initiatePayout: vi.fn(),
             queuePayoutForBooking: vi.fn(),
           },
         },

--- a/src/modules/status-change/status-change.service.spec.ts
+++ b/src/modules/status-change/status-change.service.spec.ts
@@ -49,6 +49,7 @@ describe("StatusChangeService", () => {
           provide: PaymentService,
           useValue: {
             initiatePayout: vi.fn(),
+            queuePayoutForBooking: vi.fn(),
           },
         },
       ],
@@ -170,11 +171,6 @@ describe("StatusChangeService", () => {
       return callback(mockTx);
     });
 
-    vi.mocked(mockDatabaseService.booking.findUnique).mockResolvedValue({
-      ...mockBooking,
-      status: BookingStatus.COMPLETED,
-    });
-
     const result = await service.updateBookingsFromActiveToCompleted();
 
     expect(mockDatabaseService.$transaction).toHaveBeenCalledOnce();
@@ -198,9 +194,7 @@ describe("StatusChangeService", () => {
       BookingStatus.COMPLETED,
     );
     expect(mockReferralService.queueReferralProcessing).toHaveBeenCalledExactlyOnceWith("2");
-    expect(mockPaymentService.initiatePayout).toHaveBeenCalledExactlyOnceWith(
-      expect.objectContaining({ id: "2", status: BookingStatus.COMPLETED }),
-    );
+    expect(mockPaymentService.queuePayoutForBooking).toHaveBeenCalledExactlyOnceWith("2");
     expect(result).toBe("Updated 1 bookings from active to completed");
   });
 });


### PR DESCRIPTION
- Add PAYOUTS_QUEUE constant and BullMQ-backed PaymentProcessor to handle payout jobs
- Extend PaymentService with deterministic Flutterwave reference, queuePayoutForBooking, and tests
- Trigger payout job enqueue when bookings move from ACTIVE to COMPLETED in StatusChangeService
- Keep referral processing and payouts outside the main status-change transaction for better isolation
- Add unit tests for PaymentProcessor and StatusChangeService to cover queuing and idempotent behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a BullMQ-backed payouts queue and processor, and queues fleet-owner payouts when bookings move to COMPLETED.
> 
> - **Payments**:
>   - **Queue + Processor**: Add `PAYOUTS_QUEUE` and `PaymentProcessor` to handle `PROCESS_PAYOUT_FOR_BOOKING` jobs; fetch booking and call `PaymentService.initiatePayout`.
>   - **Service updates**: Inject BullMQ queue into `PaymentService` and add `queuePayoutForBooking(bookingId)`; keep existing `initiatePayout` logic with deterministic Flutterwave reference.
>   - **Module**: Register BullMQ queue in `PaymentModule` and provide `PaymentProcessor`.
> - **Status Changes**:
>   - On ACTIVE → COMPLETED, enqueue `queuePayoutForBooking` (and keep referral queuing) outside the transaction.
> - **Tests**:
>   - Add unit tests for `PaymentProcessor` and extend `PaymentService` and `StatusChangeService` tests to cover payout queuing and deterministic reference behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca54289f02cfaa085f1edfcf1d9632c16333bc57. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->