### PR TITLE
chore: migrate from REDIS_URL to Upstash Redis

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -57,7 +57,7 @@ import { StatusChangeModule } from "./modules/status-change/status-change.module
             port: Number.parseInt(url.port) || 6379,
             password: upstashToken,
             tls: {
-              rejectUnauthorized: false,
+              rejectUnauthorized: true,
             },
           },
         };

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -25,14 +25,18 @@ import { StatusChangeModule } from "./modules/status-change/status-change.module
     BullModule.forRootAsync({
       imports: [ConfigModule],
       useFactory: (configService: ConfigService) => {
-        const redisUrl = configService.get<string>("REDIS_URL");
+        const redisUrl = configService.get<string>("UPSTASH_REDIS_REST_URL");
+        const redisToken = configService.get<string>("UPSTASH_REDIS_REST_TOKEN");
         const url = new URL(redisUrl);
 
         return {
           connection: {
             host: url.hostname,
             port: Number.parseInt(url.port) || 6379,
-            password: url.password || undefined,
+            password: redisToken,
+            tls: {
+              rejectUnauthorized: false,
+            },
           },
         };
       },

--- a/src/config/env.config.ts
+++ b/src/config/env.config.ts
@@ -2,7 +2,8 @@ import { z } from "zod";
 
 export const envSchema = z.object({
   DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
-  REDIS_URL: z.url("REDIS_URL must be a valid URL"),
+  UPSTASH_REDIS_REST_URL: z.url("UPSTASH_REDIS_REST_URL must be a valid URL"),
+  UPSTASH_REDIS_REST_TOKEN: z.string().min(1, "UPSTASH_REDIS_REST_TOKEN is required"),
   RESEND_API_KEY: z.string().min(1, "RESEND_API_KEY is required"),
   RESEND_FROM_EMAIL: z.email("RESEND_FROM_EMAIL must be a valid email"),
   APP_NAME: z.string().min(1, "APP_NAME is required"),

--- a/src/config/env.config.ts
+++ b/src/config/env.config.ts
@@ -1,4 +1,7 @@
+import { Logger } from "@nestjs/common";
 import { z } from "zod";
+
+const logger = new Logger("EnvConfig");
 
 export const envSchema = z
   .object({
@@ -24,7 +27,7 @@ export const envSchema = z
           }
         },
         {
-          message: "TIMEZONE must be a valid IANA timezone (e.g., Africa/Lagos, America/New_York)",
+          error: "TIMEZONE must be a valid IANA timezone (e.g., Africa/Lagos, America/New_York)",
         },
       ),
 
@@ -56,7 +59,7 @@ export const envSchema = z
       return hasRedisUrl || hasUpstash;
     },
     {
-      message:
+      error:
         "Either REDIS_URL or both UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN must be provided",
     },
   );
@@ -74,6 +77,6 @@ export function validateEnvironment(config: Record<string, unknown>): EnvConfig 
     throw new Error(`Invalid environment configuration. Please check your .env file. ${errors}`);
   }
 
-  console.log("Environment variables validated successfully");
+  logger.log("Environment variables validated successfully");
   return result.data;
 }

--- a/src/config/env.config.ts
+++ b/src/config/env.config.ts
@@ -9,7 +9,10 @@ export const envSchema = z
     // Redis: Either REDIS_URL (local/test) OR Upstash (production)
     REDIS_URL: z.url("REDIS_URL must be a valid URL").optional(),
     UPSTASH_REDIS_REST_URL: z.url("UPSTASH_REDIS_REST_URL must be a valid URL").optional(),
-    UPSTASH_REDIS_REST_TOKEN: z.string().optional(),
+    UPSTASH_REDIS_REST_TOKEN: z
+      .string()
+      .min(1, "UPSTASH_REDIS_REST_TOKEN cannot be empty")
+      .optional(),
     RESEND_API_KEY: z.string().min(1, "RESEND_API_KEY is required"),
     RESEND_FROM_EMAIL: z.email("RESEND_FROM_EMAIL must be a valid email"),
     APP_NAME: z.string().min(1, "APP_NAME is required"),

--- a/src/config/env.config.ts
+++ b/src/config/env.config.ts
@@ -1,48 +1,65 @@
 import { z } from "zod";
 
-export const envSchema = z.object({
-  DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
-  UPSTASH_REDIS_REST_URL: z.url("UPSTASH_REDIS_REST_URL must be a valid URL"),
-  UPSTASH_REDIS_REST_TOKEN: z.string().min(1, "UPSTASH_REDIS_REST_TOKEN is required"),
-  RESEND_API_KEY: z.string().min(1, "RESEND_API_KEY is required"),
-  RESEND_FROM_EMAIL: z.email("RESEND_FROM_EMAIL must be a valid email"),
-  APP_NAME: z.string().min(1, "APP_NAME is required"),
-  PORT: z.coerce.number().default(3000),
-  TZ: z
-    .string()
-    .default("Africa/Lagos")
-    .refine(
-      (tz) => {
-        try {
-          Intl.DateTimeFormat(undefined, { timeZone: tz });
-          return true;
-        } catch {
-          return false;
-        }
-      },
-      { message: "TIMEZONE must be a valid IANA timezone (e.g., Africa/Lagos, America/New_York)" },
-    ),
+export const envSchema = z
+  .object({
+    DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
+    // Redis: Either REDIS_URL (local/test) OR Upstash (production)
+    REDIS_URL: z.url("REDIS_URL must be a valid URL").optional(),
+    UPSTASH_REDIS_REST_URL: z.url("UPSTASH_REDIS_REST_URL must be a valid URL").optional(),
+    UPSTASH_REDIS_REST_TOKEN: z.string().optional(),
+    RESEND_API_KEY: z.string().min(1, "RESEND_API_KEY is required"),
+    RESEND_FROM_EMAIL: z.email("RESEND_FROM_EMAIL must be a valid email"),
+    APP_NAME: z.string().min(1, "APP_NAME is required"),
+    PORT: z.coerce.number().default(3000),
+    TZ: z
+      .string()
+      .default("Africa/Lagos")
+      .refine(
+        (tz) => {
+          try {
+            Intl.DateTimeFormat(undefined, { timeZone: tz });
+            return true;
+          } catch {
+            return false;
+          }
+        },
+        {
+          message: "TIMEZONE must be a valid IANA timezone (e.g., Africa/Lagos, America/New_York)",
+        },
+      ),
 
-  TWILIO_ACCOUNT_SID: z.string().min(1, "TWILIO_ACCOUNT_SID is required"),
-  TWILIO_AUTH_TOKEN: z.string().min(1, "TWILIO_AUTH_TOKEN is required"),
-  TWILIO_SECRET: z.string().min(1, "TWILIO_SECRET is required"),
-  TWILIO_WHATSAPP_NUMBER: z.string().min(1, "TWILIO_WHATSAPP_NUMBER is required"),
-  TWILIO_WEBHOOK_URL: z.url("TWILIO_WEBHOOK_URL must be a valid URL").optional(),
+    TWILIO_ACCOUNT_SID: z.string().min(1, "TWILIO_ACCOUNT_SID is required"),
+    TWILIO_AUTH_TOKEN: z.string().min(1, "TWILIO_AUTH_TOKEN is required"),
+    TWILIO_SECRET: z.string().min(1, "TWILIO_SECRET is required"),
+    TWILIO_WHATSAPP_NUMBER: z.string().min(1, "TWILIO_WHATSAPP_NUMBER is required"),
+    TWILIO_WEBHOOK_URL: z.url("TWILIO_WEBHOOK_URL must be a valid URL").optional(),
 
-  FLUTTERWAVE_SECRET_KEY: z.string().min(1, "FLUTTERWAVE_SECRET_KEY is required"),
-  FLUTTERWAVE_PUBLIC_KEY: z.string().min(1, "FLUTTERWAVE_PUBLIC_KEY is required"),
-  FLUTTERWAVE_BASE_URL: z.url("FLUTTERWAVE_BASE_URL must be a valid URL"),
-  FLUTTERWAVE_WEBHOOK_SECRET: z.string().min(1, "FLUTTERWAVE_WEBHOOK_SECRET is required"),
-  FLUTTERWAVE_WEBHOOK_URL: z.url("FLUTTERWAVE_WEBHOOK_URL must be a valid URL"),
+    FLUTTERWAVE_SECRET_KEY: z.string().min(1, "FLUTTERWAVE_SECRET_KEY is required"),
+    FLUTTERWAVE_PUBLIC_KEY: z.string().min(1, "FLUTTERWAVE_PUBLIC_KEY is required"),
+    FLUTTERWAVE_BASE_URL: z.url("FLUTTERWAVE_BASE_URL must be a valid URL"),
+    FLUTTERWAVE_WEBHOOK_SECRET: z.string().min(1, "FLUTTERWAVE_WEBHOOK_SECRET is required"),
+    FLUTTERWAVE_WEBHOOK_URL: z.url("FLUTTERWAVE_WEBHOOK_URL must be a valid URL"),
 
-  ENABLE_MANUAL_TRIGGERS: z
-    .union([z.boolean(), z.string()])
-    .transform((val) => {
-      if (typeof val === "boolean") return val;
-      return val.toLowerCase() === "true";
-    })
-    .default(false),
-});
+    ENABLE_MANUAL_TRIGGERS: z
+      .union([z.boolean(), z.string()])
+      .transform((val) => {
+        if (typeof val === "boolean") return val;
+        return val.toLowerCase() === "true";
+      })
+      .default(false),
+  })
+  .refine(
+    (data) => {
+      // Either REDIS_URL OR (UPSTASH_REDIS_REST_URL AND UPSTASH_REDIS_REST_TOKEN) must be provided
+      const hasRedisUrl = !!data.REDIS_URL;
+      const hasUpstash = !!(data.UPSTASH_REDIS_REST_URL && data.UPSTASH_REDIS_REST_TOKEN);
+      return hasRedisUrl || hasUpstash;
+    },
+    {
+      message:
+        "Either REDIS_URL or both UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN must be provided",
+    },
+  );
 
 export type EnvConfig = z.infer<typeof envSchema>;
 


### PR DESCRIPTION
- Use REDIS_URL for local/dev/test and UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN for prod
- Update BullMQ configuration to use Upstash Redis with TLS
- Update env schema validation to include Upstash credentials