### PR TITLE
refactor: simplify Redis configuration to use single REDIS_URL

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -26,42 +26,19 @@ import { StatusChangeModule } from "./modules/status-change/status-change.module
       imports: [ConfigModule],
       useFactory: (configService: ConfigService) => {
         const redisUrl = configService.get<string>("REDIS_URL");
-
-        // If REDIS_URL is provided (local/test), use it
-        if (redisUrl) {
-          const url = new URL(redisUrl);
-          return {
-            connection: {
-              host: url.hostname,
-              port: Number.parseInt(url.port) || 6379,
-              password: url.password || undefined,
-              tls: {
-                rejectUnauthorized: false,
-              },
-            },
-          };
-        }
-
-        // Otherwise, use Upstash (production)
-        const upstashUrl = configService.get<string>("UPSTASH_REDIS_REST_URL");
-        const upstashToken = configService.get<string>("UPSTASH_REDIS_REST_TOKEN");
-
-        if (!upstashUrl || !upstashToken) {
-          throw new Error(
-            "UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN are required when REDIS_URL is not provided",
-          );
-        }
-
-        const url = new URL(upstashUrl);
+        const url = new URL(redisUrl);
+        const isTls = url.protocol === "rediss:";
 
         return {
           connection: {
             host: url.hostname,
             port: Number.parseInt(url.port) || 6379,
-            password: upstashToken,
-            tls: {
-              rejectUnauthorized: true,
-            },
+            password: url.password || undefined,
+            ...(isTls && {
+              tls: {
+                rejectUnauthorized: false,
+              },
+            }),
           },
         };
       },

--- a/src/config/env.config.ts
+++ b/src/config/env.config.ts
@@ -3,69 +3,52 @@ import { z } from "zod";
 
 const logger = new Logger("EnvConfig");
 
-export const envSchema = z
-  .object({
-    DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
-    // Redis: Either REDIS_URL (local/test) OR Upstash (production)
-    REDIS_URL: z.url("REDIS_URL must be a valid URL").optional(),
-    UPSTASH_REDIS_REST_URL: z.url("UPSTASH_REDIS_REST_URL must be a valid URL").optional(),
-    UPSTASH_REDIS_REST_TOKEN: z
-      .string()
-      .min(1, "UPSTASH_REDIS_REST_TOKEN cannot be empty")
-      .optional(),
-    RESEND_API_KEY: z.string().min(1, "RESEND_API_KEY is required"),
-    RESEND_FROM_EMAIL: z.email("RESEND_FROM_EMAIL must be a valid email"),
-    APP_NAME: z.string().min(1, "APP_NAME is required"),
-    PORT: z.coerce.number().default(3000),
-    TZ: z
-      .string()
-      .default("Africa/Lagos")
-      .refine(
-        (tz) => {
-          try {
-            Intl.DateTimeFormat(undefined, { timeZone: tz });
-            return true;
-          } catch {
-            return false;
-          }
-        },
-        {
-          error: "TIMEZONE must be a valid IANA timezone (e.g., Africa/Lagos, America/New_York)",
-        },
-      ),
+export const envSchema = z.object({
+  DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
+  REDIS_URL: z.string().min(1, "REDIS_URL is required"),
 
-    TWILIO_ACCOUNT_SID: z.string().min(1, "TWILIO_ACCOUNT_SID is required"),
-    TWILIO_AUTH_TOKEN: z.string().min(1, "TWILIO_AUTH_TOKEN is required"),
-    TWILIO_SECRET: z.string().min(1, "TWILIO_SECRET is required"),
-    TWILIO_WHATSAPP_NUMBER: z.string().min(1, "TWILIO_WHATSAPP_NUMBER is required"),
-    TWILIO_WEBHOOK_URL: z.url("TWILIO_WEBHOOK_URL must be a valid URL").optional(),
+  RESEND_API_KEY: z.string().min(1, "RESEND_API_KEY is required"),
+  RESEND_FROM_EMAIL: z.email("RESEND_FROM_EMAIL must be a valid email"),
 
-    FLUTTERWAVE_SECRET_KEY: z.string().min(1, "FLUTTERWAVE_SECRET_KEY is required"),
-    FLUTTERWAVE_PUBLIC_KEY: z.string().min(1, "FLUTTERWAVE_PUBLIC_KEY is required"),
-    FLUTTERWAVE_BASE_URL: z.url("FLUTTERWAVE_BASE_URL must be a valid URL"),
-    FLUTTERWAVE_WEBHOOK_SECRET: z.string().min(1, "FLUTTERWAVE_WEBHOOK_SECRET is required"),
-    FLUTTERWAVE_WEBHOOK_URL: z.url("FLUTTERWAVE_WEBHOOK_URL must be a valid URL"),
+  APP_NAME: z.string().min(1, "APP_NAME is required"),
+  PORT: z.coerce.number().default(3000),
+  TZ: z
+    .string()
+    .default("Africa/Lagos")
+    .refine(
+      (tz) => {
+        try {
+          Intl.DateTimeFormat(undefined, { timeZone: tz });
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      {
+        error: "TIMEZONE must be a valid IANA timezone (e.g., Africa/Lagos, America/New_York)",
+      },
+    ),
 
-    ENABLE_MANUAL_TRIGGERS: z
-      .union([z.boolean(), z.string()])
-      .transform((val) => {
-        if (typeof val === "boolean") return val;
-        return val.toLowerCase() === "true";
-      })
-      .default(false),
-  })
-  .refine(
-    (data) => {
-      // Either REDIS_URL OR (UPSTASH_REDIS_REST_URL AND UPSTASH_REDIS_REST_TOKEN) must be provided
-      const hasRedisUrl = !!data.REDIS_URL;
-      const hasUpstash = !!(data.UPSTASH_REDIS_REST_URL && data.UPSTASH_REDIS_REST_TOKEN);
-      return hasRedisUrl || hasUpstash;
-    },
-    {
-      error:
-        "Either REDIS_URL or both UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN must be provided",
-    },
-  );
+  TWILIO_ACCOUNT_SID: z.string().min(1, "TWILIO_ACCOUNT_SID is required"),
+  TWILIO_AUTH_TOKEN: z.string().min(1, "TWILIO_AUTH_TOKEN is required"),
+  TWILIO_SECRET: z.string().min(1, "TWILIO_SECRET is required"),
+  TWILIO_WHATSAPP_NUMBER: z.string().min(1, "TWILIO_WHATSAPP_NUMBER is required"),
+  TWILIO_WEBHOOK_URL: z.url("TWILIO_WEBHOOK_URL must be a valid URL").optional(),
+
+  FLUTTERWAVE_SECRET_KEY: z.string().min(1, "FLUTTERWAVE_SECRET_KEY is required"),
+  FLUTTERWAVE_PUBLIC_KEY: z.string().min(1, "FLUTTERWAVE_PUBLIC_KEY is required"),
+  FLUTTERWAVE_BASE_URL: z.url("FLUTTERWAVE_BASE_URL must be a valid URL"),
+  FLUTTERWAVE_WEBHOOK_SECRET: z.string().min(1, "FLUTTERWAVE_WEBHOOK_SECRET is required"),
+  FLUTTERWAVE_WEBHOOK_URL: z.url("FLUTTERWAVE_WEBHOOK_URL must be a valid URL"),
+
+  ENABLE_MANUAL_TRIGGERS: z
+    .union([z.boolean(), z.string()])
+    .transform((val) => {
+      if (typeof val === "boolean") return val;
+      return val.toLowerCase() === "true";
+    })
+    .default(false),
+});
 
 export type EnvConfig = z.infer<typeof envSchema>;
 


### PR DESCRIPTION
- Remove UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN from env schema
- Use REDIS_URL for all environments (local, test, production)
- Automatically detect TLS based on URL protocol (rediss:// vs redis://)
- Update deploy-secrets.sh to use REDIS_URL instead of Upstash vars
- Simplify BullMQ connection configuration