### PR TITLE
test: add unit tests for processor modules

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.projectName=Hyre Worker NestJS
 
 # Source code location
 sonar.sources=src
-sonar.exclusions=**/node_modules/**,**/dist/**,**/coverage/**
+sonar.exclusions=**/node_modules/**,**/dist/**,**/coverage/**,src/config/**,src/templates/**
 
 # Test files
 sonar.tests=src

--- a/src/modules/notification/notification.processor.spec.ts
+++ b/src/modules/notification/notification.processor.spec.ts
@@ -1,0 +1,412 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { Job } from "bullmq";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as emailTemplates from "../../templates/emails";
+import { EmailService } from "./email.service";
+import { CLIENT_RECIPIENT_TYPE } from "./notification.const";
+import {
+  NotificationChannel,
+  NotificationJobData,
+  NotificationResult,
+  NotificationType,
+} from "./notification.interface";
+import { NotificationProcessor } from "./notification.processor";
+import { WhatsAppService } from "./whatsapp.service";
+
+describe("NotificationProcessor", () => {
+  let processor: NotificationProcessor;
+  let emailService: EmailService;
+  let whatsAppService: WhatsAppService;
+
+  beforeEach(async () => {
+    // Spy on the template functions
+    vi.spyOn(emailTemplates, "renderBookingStatusUpdateEmail").mockResolvedValue(
+      "<html>Status email</html>",
+    );
+
+    vi.spyOn(emailTemplates, "renderBookingReminderEmail").mockResolvedValue(
+      "<html>Reminder email</html>",
+    );
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationProcessor,
+        {
+          provide: EmailService,
+          useValue: {
+            sendEmail: vi.fn(),
+          },
+        },
+        {
+          provide: WhatsAppService,
+          useValue: {
+            sendMessage: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    processor = module.get<NotificationProcessor>(NotificationProcessor);
+    emailService = module.get<EmailService>(EmailService);
+    whatsAppService = module.get<WhatsAppService>(WhatsAppService);
+  });
+
+  it("should process notification job with EMAIL channel successfully", async () => {
+    const job = {
+      id: "job-1",
+      name: "send-notification",
+      data: {
+        id: "notification-1",
+        type: NotificationType.BOOKING_STATUS_CHANGE,
+        channels: [NotificationChannel.EMAIL],
+        bookingId: "booking-123",
+        recipients: {
+          [CLIENT_RECIPIENT_TYPE]: {
+            email: "client@example.com",
+          },
+        },
+        templateData: {
+          id: "booking-123",
+          bookingReference: "BR-123",
+          customerName: "John Doe",
+          ownerName: "Owner Name",
+          chauffeurName: "Chauffeur Name",
+          chauffeurPhoneNumber: "1234567890",
+          carName: "Car Name",
+          pickupLocation: "Pickup Location",
+          returnLocation: "Return Location",
+          startDate: "2024-01-01",
+          endDate: "2024-01-02",
+          totalAmount: "10000",
+          title: "Booking Title",
+          status: "ACTIVE",
+          cancellationReason: "",
+          subject: "Booking Status Update",
+          oldStatus: "CONFIRMED",
+          newStatus: "ACTIVE",
+        },
+      },
+    } as Job<NotificationJobData, NotificationResult[], string>;
+
+    vi.mocked(emailService.sendEmail).mockResolvedValueOnce(undefined);
+
+    const results = await processor.process(job);
+
+    expect(emailService.sendEmail).toHaveBeenCalledWith({
+      to: "client@example.com",
+      subject: "Booking Status Update",
+      html: "<html>Status email</html>",
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual({
+      channel: NotificationChannel.EMAIL,
+      success: true,
+      messageId: "email-sent",
+    });
+  });
+
+  it("should process notification job with WHATSAPP channel successfully", async () => {
+    const job = {
+      id: "job-2",
+      name: "send-notification",
+      data: {
+        id: "notification-2",
+        type: NotificationType.BOOKING_REMINDER_START,
+        channels: [NotificationChannel.WHATSAPP],
+        bookingId: "booking-456",
+        recipients: {
+          [CLIENT_RECIPIENT_TYPE]: {
+            phoneNumber: "+1234567890",
+          },
+        },
+        templateData: {
+          bookingLegId: "leg-1",
+          bookingId: "booking-456",
+          customerName: "John Doe",
+          chauffeurName: "Chauffeur Name",
+          customerPhone: "+1234567890",
+          legDate: "2024-01-01",
+          legStartTime: "10:00",
+          legEndTime: "18:00",
+          carName: "Car Name",
+          pickupLocation: "Pickup Location",
+          returnLocation: "Return Location",
+          subject: "Booking Reminder",
+          recipientType: CLIENT_RECIPIENT_TYPE,
+        },
+      },
+    } as Job<NotificationJobData, NotificationResult[], string>;
+
+    vi.mocked(whatsAppService.sendMessage).mockResolvedValueOnce(undefined);
+
+    const results = await processor.process(job);
+
+    expect(whatsAppService.sendMessage).toHaveBeenCalledWith({
+      to: "+1234567890",
+      templateKey: expect.any(String),
+      variables: expect.objectContaining({
+        "1": "John Doe",
+        "2": "Car Name",
+        "3": "10:00",
+        "4": "18:00",
+        "5": "Pickup Location",
+        "6": "Return Location",
+        "7": "Chauffeur Name",
+      }),
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual({
+      channel: NotificationChannel.WHATSAPP,
+      success: true,
+      messageId: "whatsapp-sent",
+    });
+  });
+
+  it("should process notification job with both EMAIL and WHATSAPP channels", async () => {
+    const job = {
+      id: "job-3",
+      name: "send-notification",
+      data: {
+        id: "notification-3",
+        type: NotificationType.BOOKING_REMINDER_END,
+        channels: [NotificationChannel.EMAIL, NotificationChannel.WHATSAPP],
+        bookingId: "booking-789",
+        recipients: {
+          [CLIENT_RECIPIENT_TYPE]: {
+            email: "client@example.com",
+            phoneNumber: "+1234567890",
+          },
+        },
+        templateData: {
+          bookingLegId: "leg-1",
+          bookingId: "booking-789",
+          customerName: "John Doe",
+          chauffeurName: "Chauffeur Name",
+          customerPhone: "+1234567890",
+          legDate: "2024-01-01",
+          legStartTime: "10:00",
+          legEndTime: "18:00",
+          carName: "Car Name",
+          pickupLocation: "Pickup Location",
+          returnLocation: "Return Location",
+          subject: "Booking End Reminder",
+          recipientType: CLIENT_RECIPIENT_TYPE,
+        },
+      },
+    } as Job<NotificationJobData, NotificationResult[], string>;
+
+    vi.mocked(emailService.sendEmail).mockResolvedValueOnce(undefined);
+    vi.mocked(whatsAppService.sendMessage).mockResolvedValueOnce(undefined);
+
+    const results = await processor.process(job);
+
+    expect(emailService.sendEmail).toHaveBeenCalledWith({
+      to: "client@example.com",
+      subject: "Booking End Reminder",
+      html: "<html>Reminder email</html>",
+    });
+    expect(whatsAppService.sendMessage).toHaveBeenCalledWith({
+      to: "+1234567890",
+      templateKey: expect.any(String),
+      variables: expect.objectContaining({
+        "1": "John Doe",
+        "2": "Car Name",
+      }),
+    });
+    expect(results).toHaveLength(2);
+    expect(results[0]?.channel).toBe(NotificationChannel.EMAIL);
+    expect(results[1]?.channel).toBe(NotificationChannel.WHATSAPP);
+    expect(results.every((r) => r.success)).toBe(true);
+  });
+
+  it("should return empty results when no recipients are provided", async () => {
+    const job = {
+      id: "job-4",
+      name: "send-notification",
+      data: {
+        id: "notification-4",
+        type: NotificationType.BOOKING_STATUS_CHANGE,
+        channels: [NotificationChannel.EMAIL],
+        bookingId: "booking-999",
+        recipients: {},
+        templateData: {
+          id: "booking-999",
+          bookingReference: "BR-999",
+          customerName: "John Doe",
+          ownerName: "Owner Name",
+          chauffeurName: "Chauffeur Name",
+          chauffeurPhoneNumber: "1234567890",
+          carName: "Car Name",
+          pickupLocation: "Pickup Location",
+          returnLocation: "Return Location",
+          startDate: "2024-01-01",
+          endDate: "2024-01-02",
+          totalAmount: "10000",
+          title: "Booking Title",
+          status: "ACTIVE",
+          cancellationReason: "",
+          subject: "Booking Status Update",
+          oldStatus: "CONFIRMED",
+          newStatus: "ACTIVE",
+        },
+      },
+    } as Job<NotificationJobData, NotificationResult[], string>;
+
+    const results = await processor.process(job);
+
+    expect(emailService.sendEmail).not.toHaveBeenCalled();
+    expect(results).toHaveLength(0);
+  });
+
+  it("should handle email service errors gracefully", async () => {
+    const job = {
+      id: "job-5",
+      name: "send-notification",
+      data: {
+        id: "notification-5",
+        type: NotificationType.BOOKING_STATUS_CHANGE,
+        channels: [NotificationChannel.EMAIL],
+        bookingId: "booking-111",
+        recipients: {
+          [CLIENT_RECIPIENT_TYPE]: {
+            email: "client@example.com",
+          },
+        },
+        templateData: {
+          id: "booking-111",
+          bookingReference: "BR-111",
+          customerName: "John Doe",
+          ownerName: "Owner Name",
+          chauffeurName: "Chauffeur Name",
+          chauffeurPhoneNumber: "1234567890",
+          carName: "Car Name",
+          pickupLocation: "Pickup Location",
+          returnLocation: "Return Location",
+          startDate: "2024-01-01",
+          endDate: "2024-01-02",
+          totalAmount: "10000",
+          title: "Booking Title",
+          status: "ACTIVE",
+          cancellationReason: "",
+          subject: "Booking Status Update",
+          oldStatus: "CONFIRMED",
+          newStatus: "ACTIVE",
+        },
+      },
+    } as Job<NotificationJobData, NotificationResult[], string>;
+
+    const emailError = new Error("Email service unavailable");
+    vi.mocked(emailService.sendEmail).mockRejectedValueOnce(emailError);
+
+    const results = await processor.process(job);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual({
+      channel: NotificationChannel.EMAIL,
+      success: false,
+      error: "Email service unavailable",
+    });
+  });
+
+  it("should handle whatsapp service errors gracefully", async () => {
+    const job = {
+      id: "job-6",
+      name: "send-notification",
+      data: {
+        id: "notification-6",
+        type: NotificationType.BOOKING_REMINDER_START,
+        channels: [NotificationChannel.WHATSAPP],
+        bookingId: "booking-222",
+        recipients: {
+          [CLIENT_RECIPIENT_TYPE]: {
+            phoneNumber: "+1234567890",
+          },
+        },
+        templateData: {
+          bookingLegId: "leg-1",
+          bookingId: "booking-222",
+          customerName: "John Doe",
+          chauffeurName: "Chauffeur Name",
+          customerPhone: "+1234567890",
+          legDate: "2024-01-01",
+          legStartTime: "10:00",
+          legEndTime: "18:00",
+          carName: "Car Name",
+          pickupLocation: "Pickup Location",
+          returnLocation: "Return Location",
+          subject: "Booking Reminder",
+          recipientType: CLIENT_RECIPIENT_TYPE,
+        },
+      },
+    } as Job<NotificationJobData, NotificationResult[], string>;
+
+    const whatsappError = new Error("WhatsApp service unavailable");
+    vi.mocked(whatsAppService.sendMessage).mockRejectedValueOnce(whatsappError);
+
+    const results = await processor.process(job);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual({
+      channel: NotificationChannel.WHATSAPP,
+      success: false,
+      error: "WhatsApp service unavailable",
+    });
+  });
+
+  it("should process multiple channels and handle partial failures", async () => {
+    const job = {
+      id: "job-7",
+      name: "send-notification",
+      data: {
+        id: "notification-7",
+        type: NotificationType.BOOKING_REMINDER_END,
+        channels: [NotificationChannel.EMAIL, NotificationChannel.WHATSAPP],
+        bookingId: "booking-333",
+        recipients: {
+          [CLIENT_RECIPIENT_TYPE]: {
+            email: "client@example.com",
+            phoneNumber: "+1234567890",
+          },
+        },
+        templateData: {
+          bookingLegId: "leg-1",
+          bookingId: "booking-333",
+          customerName: "John Doe",
+          chauffeurName: "Chauffeur Name",
+          customerPhone: "+1234567890",
+          legDate: "2024-01-01",
+          legStartTime: "10:00",
+          legEndTime: "18:00",
+          carName: "Car Name",
+          pickupLocation: "Pickup Location",
+          returnLocation: "Return Location",
+          subject: "Booking End Reminder",
+          recipientType: CLIENT_RECIPIENT_TYPE,
+        },
+      },
+    } as Job<NotificationJobData, NotificationResult[], string>;
+
+    vi.mocked(emailService.sendEmail).mockResolvedValueOnce(undefined);
+    const whatsappError = new Error("WhatsApp service unavailable");
+    vi.mocked(whatsAppService.sendMessage).mockRejectedValueOnce(whatsappError);
+
+    const results = await processor.process(job);
+
+    expect(emailService.sendEmail).toHaveBeenCalledWith({
+      to: "client@example.com",
+      subject: "Booking End Reminder",
+      html: "<html>Reminder email</html>",
+    });
+    expect(results).toHaveLength(2);
+    expect(results[0]).toEqual({
+      channel: NotificationChannel.EMAIL,
+      success: true,
+      messageId: "email-sent",
+    });
+    expect(results[1]).toEqual({
+      channel: NotificationChannel.WHATSAPP,
+      success: false,
+      error: "WhatsApp service unavailable",
+    });
+  });
+});

--- a/src/modules/payment/payment.processor.spec.ts
+++ b/src/modules/payment/payment.processor.spec.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { BookingStatus } from "@prisma/client";
+import { Job } from "bullmq";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createBooking } from "../../shared/helper.fixtures";
 import { DatabaseService } from "../database/database.service";
 import { PayoutJobData, PROCESS_PAYOUT_FOR_BOOKING } from "./payment.interface";
 import { PaymentProcessor } from "./payment.processor";
@@ -38,17 +40,15 @@ describe("PaymentProcessor", () => {
   });
 
   it("should process payout job and call initiatePayout when booking exists", async () => {
-    const job: any = {
+    const job = {
+      id: "job-1",
       name: PROCESS_PAYOUT_FOR_BOOKING,
-      data: { bookingId: "booking-1", timestamp: new Date().toISOString() } as PayoutJobData,
-    };
+      data: { bookingId: "booking-1", timestamp: new Date().toISOString() },
+    } as Job<PayoutJobData, any, string>;
 
-    (
-      databaseService.booking.findUnique as unknown as ReturnType<typeof vi.fn>
-    ).mockResolvedValueOnce({
-      id: "booking-1",
-      status: BookingStatus.COMPLETED,
-    });
+    vi.mocked(databaseService.booking.findUnique).mockResolvedValueOnce(
+      createBooking({ id: "booking-1", status: BookingStatus.COMPLETED }),
+    );
 
     const result = await processor.process(job);
 
@@ -63,14 +63,13 @@ describe("PaymentProcessor", () => {
   });
 
   it("should not call initiatePayout when booking is not found", async () => {
-    const job: any = {
+    const job = {
+      id: "job-2",
       name: PROCESS_PAYOUT_FOR_BOOKING,
-      data: { bookingId: "missing-booking", timestamp: new Date().toISOString() } as PayoutJobData,
-    };
+      data: { bookingId: "missing-booking", timestamp: new Date().toISOString() },
+    } as Job<PayoutJobData, any, string>;
 
-    (
-      databaseService.booking.findUnique as unknown as ReturnType<typeof vi.fn>
-    ).mockResolvedValueOnce(null);
+    vi.mocked(databaseService.booking.findUnique).mockResolvedValueOnce(null);
 
     const result = await processor.process(job);
 
@@ -79,13 +78,63 @@ describe("PaymentProcessor", () => {
   });
 
   it("should throw error for unknown job type", async () => {
-    const job: any = {
+    const job = {
+      id: "job-3",
       name: "unknown-job-type",
       data: { bookingId: "booking-1", timestamp: new Date().toISOString() },
-    };
+    } as Job<PayoutJobData, any, string>;
 
     await expect(processor.process(job)).rejects.toThrow(
       "Unknown payout job type: unknown-job-type",
     );
+  });
+
+  it("should not call initiatePayout when booking status is not COMPLETED", async () => {
+    const job = {
+      id: "job-4",
+      name: PROCESS_PAYOUT_FOR_BOOKING,
+      data: { bookingId: "booking-1", timestamp: new Date().toISOString() },
+    } as Job<PayoutJobData, any, string>;
+
+    vi.mocked(databaseService.booking.findUnique).mockResolvedValueOnce(
+      createBooking({ id: "booking-1", status: BookingStatus.ACTIVE }),
+    );
+
+    const result = await processor.process(job);
+
+    expect(paymentService.initiatePayout).not.toHaveBeenCalled();
+    expect(result).toEqual({ success: false, reason: "INVALID_BOOKING_STATUS" });
+  });
+
+  it("should throw error when database query fails", async () => {
+    const job = {
+      id: "job-5",
+      name: PROCESS_PAYOUT_FOR_BOOKING,
+      data: { bookingId: "booking-1", timestamp: new Date().toISOString() },
+    } as Job<PayoutJobData, any, string>;
+
+    const dbError = new Error("Database connection failed");
+    vi.mocked(databaseService.booking.findUnique).mockRejectedValueOnce(dbError);
+
+    await expect(processor.process(job)).rejects.toThrow("Database connection failed");
+    expect(paymentService.initiatePayout).not.toHaveBeenCalled();
+  });
+
+  it("should throw error when initiatePayout fails", async () => {
+    const job = {
+      id: "job-6",
+      name: PROCESS_PAYOUT_FOR_BOOKING,
+      data: { bookingId: "booking-1", timestamp: new Date().toISOString() },
+    } as Job<PayoutJobData, any, string>;
+
+    vi.mocked(databaseService.booking.findUnique).mockResolvedValueOnce(
+      createBooking({ id: "booking-1", status: BookingStatus.COMPLETED }),
+    );
+
+    const payoutError = new Error("Payout service unavailable");
+    vi.mocked(paymentService.initiatePayout).mockRejectedValueOnce(payoutError);
+
+    await expect(processor.process(job)).rejects.toThrow("Payout service unavailable");
+    expect(paymentService.initiatePayout).toHaveBeenCalled();
   });
 });

--- a/src/modules/reminder/reminder.processor.spec.ts
+++ b/src/modules/reminder/reminder.processor.spec.ts
@@ -1,0 +1,153 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { Job } from "bullmq";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  BOOKING_LEG_END_REMINDER,
+  BOOKING_LEG_START_REMINDER,
+  TRIP_END,
+  TRIP_START,
+} from "../../config/constants";
+import { ReminderJobData } from "./reminder.interface";
+import { ReminderProcessor } from "./reminder.processor";
+import { ReminderService } from "./reminder.service";
+
+describe("ReminderProcessor", () => {
+  let processor: ReminderProcessor;
+  let reminderService: ReminderService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReminderProcessor,
+        {
+          provide: ReminderService,
+          useValue: {
+            sendBookingStartReminderEmails: vi.fn(),
+            sendBookingEndReminderEmails: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    processor = module.get<ReminderProcessor>(ReminderProcessor);
+    reminderService = module.get<ReminderService>(ReminderService);
+  });
+
+  it("should process BOOKING_LEG_START_REMINDER job and call sendBookingStartReminderEmails", async () => {
+    const job = {
+      id: "job-1",
+      name: BOOKING_LEG_START_REMINDER,
+      data: { type: TRIP_START, timestamp: new Date().toISOString() },
+    } as Job<ReminderJobData, any, string>;
+
+    vi.mocked(reminderService.sendBookingStartReminderEmails).mockResolvedValueOnce(
+      "Queued 10 start reminder notifications.",
+    );
+
+    const result = await processor.process(job);
+
+    expect(reminderService.sendBookingStartReminderEmails).toHaveBeenCalledExactlyOnceWith();
+    expect(result).toEqual({
+      success: true,
+      result: "Queued 10 start reminder notifications.",
+    });
+  });
+
+  it("should process BOOKING_LEG_END_REMINDER job and call sendBookingEndReminderEmails", async () => {
+    const job = {
+      id: "job-2",
+      name: BOOKING_LEG_END_REMINDER,
+      data: { type: TRIP_END, timestamp: new Date().toISOString() },
+    } as Job<ReminderJobData, any, string>;
+
+    vi.mocked(reminderService.sendBookingEndReminderEmails).mockResolvedValueOnce(
+      "Queued 5 end reminder notifications.",
+    );
+
+    const result = await processor.process(job);
+
+    expect(reminderService.sendBookingEndReminderEmails).toHaveBeenCalledExactlyOnceWith();
+    expect(result).toEqual({
+      success: true,
+      result: "Queued 5 end reminder notifications.",
+    });
+  });
+
+  it("should handle empty result from sendBookingStartReminderEmails", async () => {
+    const job = {
+      id: "job-3",
+      name: BOOKING_LEG_START_REMINDER,
+      data: { type: TRIP_START, timestamp: new Date().toISOString() },
+    } as Job<ReminderJobData, any, string>;
+
+    vi.mocked(reminderService.sendBookingStartReminderEmails).mockResolvedValueOnce(
+      "No relevant booking legs today, so no start reminders to send.",
+    );
+
+    const result = await processor.process(job);
+
+    expect(result).toEqual({
+      success: true,
+      result: "No relevant booking legs today, so no start reminders to send.",
+    });
+  });
+
+  it("should handle empty result from sendBookingEndReminderEmails", async () => {
+    const job = {
+      id: "job-4",
+      name: BOOKING_LEG_END_REMINDER,
+      data: { type: TRIP_END, timestamp: new Date().toISOString() },
+    } as Job<ReminderJobData, any, string>;
+
+    vi.mocked(reminderService.sendBookingEndReminderEmails).mockResolvedValueOnce(
+      "No relevant booking legs today, so no end reminders to send.",
+    );
+
+    const result = await processor.process(job);
+
+    expect(result).toEqual({
+      success: true,
+      result: "No relevant booking legs today, so no end reminders to send.",
+    });
+  });
+
+  it("should throw error for unknown job type", async () => {
+    const job = {
+      id: "job-5",
+      name: "unknown-job-type",
+      data: { type: TRIP_START, timestamp: new Date().toISOString() },
+    } as Job<ReminderJobData, any, string>;
+
+    await expect(processor.process(job)).rejects.toThrow(
+      "Unknown reminder job type: unknown-job-type",
+    );
+  });
+
+  it("should throw error when sendBookingStartReminderEmails fails", async () => {
+    const job = {
+      id: "job-6",
+      name: BOOKING_LEG_START_REMINDER,
+      data: { type: TRIP_START, timestamp: new Date().toISOString() },
+    } as Job<ReminderJobData, any, string>;
+
+    const serviceError = new Error("Notification service unavailable");
+    vi.mocked(reminderService.sendBookingStartReminderEmails).mockRejectedValueOnce(serviceError);
+
+    await expect(processor.process(job)).rejects.toThrow("Notification service unavailable");
+    expect(reminderService.sendBookingStartReminderEmails).toHaveBeenCalled();
+  });
+
+  it("should throw error when sendBookingEndReminderEmails fails", async () => {
+    const job = {
+      id: "job-7",
+      name: BOOKING_LEG_END_REMINDER,
+      data: { type: TRIP_END, timestamp: new Date().toISOString() },
+    } as Job<ReminderJobData, any, string>;
+
+    const serviceError = new Error("Database connection failed");
+    vi.mocked(reminderService.sendBookingEndReminderEmails).mockRejectedValueOnce(serviceError);
+
+    await expect(processor.process(job)).rejects.toThrow("Database connection failed");
+    expect(reminderService.sendBookingEndReminderEmails).toHaveBeenCalled();
+  });
+});

--- a/src/modules/status-change/status-change.processor.spec.ts
+++ b/src/modules/status-change/status-change.processor.spec.ts
@@ -1,0 +1,156 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { Job } from "bullmq";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ACTIVE_TO_COMPLETED, CONFIRMED_TO_ACTIVE } from "../../config/constants";
+import { StatusUpdateJobData } from "./status-change.interface";
+import { StatusChangeProcessor } from "./status-change.processor";
+import { StatusChangeService } from "./status-change.service";
+
+describe("StatusChangeProcessor", () => {
+  let processor: StatusChangeProcessor;
+  let statusChangeService: StatusChangeService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StatusChangeProcessor,
+        {
+          provide: StatusChangeService,
+          useValue: {
+            updateBookingsFromConfirmedToActive: vi.fn(),
+            updateBookingsFromActiveToCompleted: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    processor = module.get<StatusChangeProcessor>(StatusChangeProcessor);
+    statusChangeService = module.get<StatusChangeService>(StatusChangeService);
+  });
+
+  it("should process CONFIRMED_TO_ACTIVE job and call updateBookingsFromConfirmedToActive", async () => {
+    const job = {
+      id: "job-1",
+      name: CONFIRMED_TO_ACTIVE,
+      data: { type: CONFIRMED_TO_ACTIVE, timestamp: new Date().toISOString() },
+    } as Job<StatusUpdateJobData, any, string>;
+
+    vi.mocked(statusChangeService.updateBookingsFromConfirmedToActive).mockResolvedValueOnce(
+      "Updated 5 bookings from confirmed to active",
+    );
+
+    const result = await processor.process(job);
+
+    expect(statusChangeService.updateBookingsFromConfirmedToActive).toHaveBeenCalledExactlyOnceWith(
+      job.data.timestamp,
+    );
+    expect(result).toEqual({
+      success: true,
+      result: "Updated 5 bookings from confirmed to active",
+    });
+  });
+
+  it("should process CONFIRMED_TO_ACTIVE job without timestamp", async () => {
+    const job = {
+      id: "job-2",
+      name: CONFIRMED_TO_ACTIVE,
+      data: { type: CONFIRMED_TO_ACTIVE },
+    } as Job<StatusUpdateJobData, any, string>;
+
+    vi.mocked(statusChangeService.updateBookingsFromConfirmedToActive).mockResolvedValueOnce(
+      "No bookings to update",
+    );
+
+    const result = await processor.process(job);
+
+    expect(statusChangeService.updateBookingsFromConfirmedToActive).toHaveBeenCalledExactlyOnceWith(
+      undefined,
+    );
+    expect(result).toEqual({ success: true, result: "No bookings to update" });
+  });
+
+  it("should process ACTIVE_TO_COMPLETED job and call updateBookingsFromActiveToCompleted", async () => {
+    const job = {
+      id: "job-3",
+      name: ACTIVE_TO_COMPLETED,
+      data: { type: ACTIVE_TO_COMPLETED, timestamp: new Date().toISOString() },
+    } as Job<StatusUpdateJobData, any, string>;
+
+    vi.mocked(statusChangeService.updateBookingsFromActiveToCompleted).mockResolvedValueOnce(
+      "Updated 3 bookings from active to completed",
+    );
+
+    const result = await processor.process(job);
+
+    expect(statusChangeService.updateBookingsFromActiveToCompleted).toHaveBeenCalledExactlyOnceWith(
+      job.data.timestamp,
+    );
+    expect(result).toEqual({
+      success: true,
+      result: "Updated 3 bookings from active to completed",
+    });
+  });
+
+  it("should process ACTIVE_TO_COMPLETED job without timestamp", async () => {
+    const job = {
+      id: "job-4",
+      name: ACTIVE_TO_COMPLETED,
+      data: { type: ACTIVE_TO_COMPLETED },
+    } as Job<StatusUpdateJobData, any, string>;
+
+    vi.mocked(statusChangeService.updateBookingsFromActiveToCompleted).mockResolvedValueOnce(
+      "No bookings to update",
+    );
+
+    const result = await processor.process(job);
+
+    expect(statusChangeService.updateBookingsFromActiveToCompleted).toHaveBeenCalledExactlyOnceWith(
+      undefined,
+    );
+    expect(result).toEqual({ success: true, result: "No bookings to update" });
+  });
+
+  it("should throw error for unknown job type", async () => {
+    const job = {
+      id: "job-5",
+      name: "unknown-job-type",
+      data: { type: CONFIRMED_TO_ACTIVE, timestamp: new Date().toISOString() },
+    } as Job<StatusUpdateJobData, any, string>;
+
+    await expect(processor.process(job)).rejects.toThrow(
+      "Unknown status update job type: unknown-job-type",
+    );
+  });
+
+  it("should throw error when updateBookingsFromConfirmedToActive fails", async () => {
+    const job = {
+      id: "job-6",
+      name: CONFIRMED_TO_ACTIVE,
+      data: { type: CONFIRMED_TO_ACTIVE, timestamp: new Date().toISOString() },
+    } as Job<StatusUpdateJobData, any, string>;
+
+    const serviceError = new Error("Database connection failed");
+    vi.mocked(statusChangeService.updateBookingsFromConfirmedToActive).mockRejectedValueOnce(
+      serviceError,
+    );
+
+    await expect(processor.process(job)).rejects.toThrow("Database connection failed");
+    expect(statusChangeService.updateBookingsFromConfirmedToActive).toHaveBeenCalled();
+  });
+
+  it("should throw error when updateBookingsFromActiveToCompleted fails", async () => {
+    const job = {
+      id: "job-7",
+      name: ACTIVE_TO_COMPLETED,
+      data: { type: ACTIVE_TO_COMPLETED, timestamp: new Date().toISOString() },
+    } as Job<StatusUpdateJobData, any, string>;
+
+    const serviceError = new Error("Service unavailable");
+    vi.mocked(statusChangeService.updateBookingsFromActiveToCompleted).mockRejectedValueOnce(
+      serviceError,
+    );
+
+    await expect(processor.process(job)).rejects.toThrow("Service unavailable");
+    expect(statusChangeService.updateBookingsFromActiveToCompleted).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
- Add comprehensive unit tests for ReminderProcessor
- Fix type casting issues in test mocks using proper Job type assertions
- Use correct constant values (TRIP_START, TRIP_END) in test data
- Cover success cases, error handling, and edge cases for all processor methods