### PR TITLE
feat: add API key and Bull Board authentication

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@swc/core": "^1.13.5",
     "@testcontainers/postgresql": "^11.8.0",
     "@testcontainers/redis": "^11.8.0",
+    "@types/express": "^5.0.6",
     "@types/node": "^20.19.13",
     "@types/react": "^18.3.24",
     "@types/react-dom": "^18.3.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       '@testcontainers/redis':
         specifier: ^11.8.0
         version: 11.8.0
+      '@types/express':
+        specifier: ^5.0.6
+        version: 5.0.6
       '@types/node':
         specifier: ^20.19.13
         version: 20.19.24
@@ -1239,8 +1242,14 @@ packages:
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/cookiejar@2.1.5':
     resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
@@ -1263,6 +1272,15 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/express-serve-static-core@5.1.0':
+    resolution: {integrity: sha512-jnHMsrd0Mwa9Cf4IdOzbz543y4XJepXrbia2T4b6+spXC2We3t1y6K44D3mR8XMFSXMCf3/l7rCgddfx7UNVBA==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -1284,6 +1302,12 @@ packages:
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
+  '@types/qs@6.14.0':
+    resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
   '@types/react-dom@18.3.7':
     resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
     peerDependencies:
@@ -1291,6 +1315,12 @@ packages:
 
   '@types/react@18.3.26':
     resolution: {integrity: sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
   '@types/ssh2-streams@0.1.13':
     resolution: {integrity: sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA==}
@@ -4548,10 +4578,19 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 20.19.24
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 20.19.24
 
   '@types/cookiejar@2.1.5': {}
 
@@ -4580,6 +4619,21 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/express-serve-static-core@5.1.0':
+    dependencies:
+      '@types/node': 20.19.24
+      '@types/qs': 6.14.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.0
+      '@types/serve-static': 2.2.0
+
+  '@types/http-errors@2.0.5': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/luxon@3.7.1': {}
@@ -4600,6 +4654,10 @@ snapshots:
 
   '@types/prop-types@15.7.15': {}
 
+  '@types/qs@6.14.0': {}
+
+  '@types/range-parser@1.2.7': {}
+
   '@types/react-dom@18.3.7(@types/react@18.3.26)':
     dependencies:
       '@types/react': 18.3.26
@@ -4608,6 +4666,15 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.1.3
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 20.19.24
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 20.19.24
 
   '@types/ssh2-streams@0.1.13':
     dependencies:

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,8 +1,9 @@
 import { ExpressAdapter } from "@bull-board/express";
 import { BullBoardModule } from "@bull-board/nestjs";
 import { BullModule } from "@nestjs/bullmq";
-import { Module } from "@nestjs/common";
+import { type MiddlewareConsumer, Module, type NestModule } from "@nestjs/common";
 import { ConfigModule, ConfigService } from "@nestjs/config";
+import { BasicAuthMiddleware } from "./middleware/basic-auth.middleware";
 import { ScheduleModule } from "@nestjs/schedule";
 import { validateEnvironment } from "./config/env.config";
 import { DatabaseModule } from "./modules/database/database.module";
@@ -60,4 +61,8 @@ import { StatusChangeModule } from "./modules/status-change/status-change.module
     ReferralModule,
   ],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(BasicAuthMiddleware).forRoutes("/queues");
+  }
+}

--- a/src/config/env.config.ts
+++ b/src/config/env.config.ts
@@ -47,6 +47,14 @@ export const envSchema = z.object({
       return val.toLowerCase() === "true";
     })
     .default(false),
+
+  API_KEY: z.string().min(8, "API_KEY must be at least 32 characters").optional(),
+
+  BULL_BOARD_USERNAME: z.string().min(1).optional(),
+  BULL_BOARD_PASSWORD: z
+    .string()
+    .min(8, "BULL_BOARD_PASSWORD must be at least 8 characters")
+    .optional(),
 });
 
 export type EnvConfig = z.infer<typeof envSchema>;

--- a/src/middleware/basic-auth.middleware.ts
+++ b/src/middleware/basic-auth.middleware.ts
@@ -1,0 +1,74 @@
+import { Injectable, NestMiddleware } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { NextFunction, Request, Response } from "express";
+import { timingSafeEqual } from "node:crypto";
+
+/**
+ * Basic Auth middleware for protecting routes like Bull Board.
+ *
+ * Prompts browser for username/password via HTTP Basic Authentication.
+ * Uses timing-safe comparison to prevent timing attacks.
+ *
+ * If credentials are not configured, middleware is bypassed (disabled).
+ */
+@Injectable()
+export class BasicAuthMiddleware implements NestMiddleware {
+  private readonly username: string | undefined;
+  private readonly password: string | undefined;
+
+  constructor(private readonly configService: ConfigService) {
+    this.username = this.configService.get<string>("BULL_BOARD_USERNAME");
+    this.password = this.configService.get<string>("BULL_BOARD_PASSWORD");
+  }
+
+  use(req: Request, res: Response, next: NextFunction): void {
+    // If credentials not configured, bypass auth
+    if (!this.username || !this.password) {
+      next();
+      return;
+    }
+
+    const authHeader = req.get("authorization");
+
+    if (!authHeader?.startsWith("Basic ")) {
+      this.sendUnauthorizedResponse(res);
+      return;
+    }
+
+    const encodedCreds = authHeader.split(" ")[1];
+    const decodedCreds = Buffer.from(encodedCreds, "base64").toString("utf-8");
+    const [username, password] = decodedCreds.split(":");
+
+    if (!this.isValidCredentials(username, password)) {
+      this.sendUnauthorizedResponse(res);
+      return;
+    }
+
+    next();
+  }
+
+  private isValidCredentials(username: string, password: string): boolean {
+    const validUsername = this.safeCompare(username, this.username);
+    const validPassword = this.safeCompare(password, this.password);
+    return validUsername && validPassword;
+  }
+
+  /**
+   * Timing-safe string comparison to prevent timing attacks
+   */
+  private safeCompare(provided: string, expected: string): boolean {
+    if (provided.length !== expected.length) {
+      return false;
+    }
+
+    const providedBuffer = Buffer.from(provided);
+    const expectedBuffer = Buffer.from(expected);
+
+    return timingSafeEqual(providedBuffer, expectedBuffer);
+  }
+
+  private sendUnauthorizedResponse(res: Response): void {
+    res.setHeader("WWW-Authenticate", 'Basic realm="Bull Board", charset="UTF-8"');
+    res.sendStatus(401);
+  }
+}

--- a/src/modules/job/api-key.guard.ts
+++ b/src/modules/job/api-key.guard.ts
@@ -1,0 +1,55 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { Request } from "express";
+import { timingSafeEqual } from "node:crypto";
+
+/**
+ * Guard that validates API key from request headers.
+ *
+ * Expects the API key in the `x-api-key` header.
+ * Uses timing-safe comparison to prevent timing attacks.
+ *
+ * If API_KEY is not configured, the guard allows all requests (disabled).
+ */
+@Injectable()
+export class ApiKeyGuard implements CanActivate {
+  private readonly apiKey: string | undefined;
+
+  constructor(private readonly configService: ConfigService) {
+    this.apiKey = this.configService.get<string>("API_KEY");
+  }
+
+  canActivate(context: ExecutionContext): boolean {
+    // If no API key configured, allow all requests
+    if (!this.apiKey) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest<Request>();
+    const providedKey = request.headers["x-api-key"];
+
+    if (!providedKey || typeof providedKey !== "string") {
+      throw new UnauthorizedException("Missing API key");
+    }
+
+    if (!this.isValidApiKey(providedKey)) {
+      throw new UnauthorizedException("Invalid API key");
+    }
+
+    return true;
+  }
+
+  /**
+   * Timing-safe comparison to prevent timing attacks
+   */
+  private isValidApiKey(providedKey: string): boolean {
+    if (providedKey.length !== this.apiKey.length) {
+      return false;
+    }
+
+    const providedBuffer = Buffer.from(providedKey);
+    const expectedBuffer = Buffer.from(this.apiKey);
+
+    return timingSafeEqual(providedBuffer, expectedBuffer);
+  }
+}

--- a/src/modules/job/job.controller.ts
+++ b/src/modules/job/job.controller.ts
@@ -1,11 +1,13 @@
-import { Controller, HttpCode, HttpStatus, Param, Post } from "@nestjs/common";
+import { Controller, HttpCode, HttpStatus, Param, Post, UseGuards } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
+import { ApiKeyGuard } from "./api-key.guard";
 import { JobException } from "./errors";
 import { ValidateJobTypePipe } from "./job.dto";
 import { JobType, JobTypeNames } from "./job.schema";
 import { JobService } from "./job.service";
 
 @Controller("job")
+@UseGuards(ApiKeyGuard)
 export class JobController {
   private readonly manualTriggersEnabled: boolean;
 


### PR DESCRIPTION
- Add ApiKeyGuard to protect job endpoints with x-api-key header
- Add BasicAuthMiddleware to protect Bull Board routes (/queues)
- Add environment variables: API_KEY, BULL_BOARD_USERNAME, BULL_BOARD_PASSWORD
- Both authentication mechanisms use timing-safe comparison to prevent timing attacks
- Both are optional and bypass if credentials are not configured
- Add @types/express dependency for TypeScript support