### PR TITLE
feat: make fuelUpgradeRate optional and update schema relations

### DIFF
--- a/prisma/migrations/20260113131349_make_fuel_upgrade_rate_optional_and_explicit_booking_review_relation/migration.sql
+++ b/prisma/migrations/20260113131349_make_fuel_upgrade_rate_optional_and_explicit_booking_review_relation/migration.sql
@@ -1,5 +1,9 @@
 -- AlterTable
 ALTER TABLE "Car" ALTER COLUMN "fuelUpgradeRate" DROP NOT NULL;
 
+-- AddTable
+ALTER TABLE "Car" ADD COLUMN "pricingIncludesFuel" BOOLEAN NOT NULL DEFAULT false;
+
 -- The Booking-Review relation name is already explicit in the schema
 -- This migration documents the schema change where fuelUpgradeRate was made optional
+-- and adds the pricingIncludesFuel column

--- a/prisma/migrations/20260113131349_make_fuel_upgrade_rate_optional_and_explicit_booking_review_relation/migration.sql
+++ b/prisma/migrations/20260113131349_make_fuel_upgrade_rate_optional_and_explicit_booking_review_relation/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Car" ALTER COLUMN "fuelUpgradeRate" DROP NOT NULL;
+
+-- The Booking-Review relation name is already explicit in the schema
+-- This migration documents the schema change where fuelUpgradeRate was made optional

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,9 +25,10 @@ model Car {
   hourlyRate         Int
   dayRate            Int
   nightRate          Int
-  fuelUpgradeRate    Int
+  fuelUpgradeRate    Int?
   fullDayRate        Int
   airportPickupRate  Int
+  pricingIncludesFuel Boolean           @default(false)
   // Vehicle categorization
   vehicleType        VehicleType        @default(SEDAN)
   serviceTier        ServiceTier        @default(STANDARD)
@@ -270,7 +271,7 @@ model Booking {
   customerPayments   Payment[]           @relation("BookingCustomerPayments")
   payoutTransactions PayoutTransaction[] @relation("BookingPayouts")
   referralRewards    ReferralReward[]
-  review             Review?
+  review             Review?             @relation("BookingReview")
 
   @@index([bookingReference])
   @@index([carId])
@@ -468,7 +469,7 @@ model Review {
   updatedAt DateTime @updatedAt
 
   // Relations
-  booking   Booking @relation(fields: [bookingId], references: [id], onDelete: Restrict) // Restrict prevents accidental deletion - reviews must persist for analytics/reputation
+  booking   Booking @relation("BookingReview", fields: [bookingId], references: [id], onDelete: Restrict) // Restrict prevents accidental deletion - reviews must persist for analytics/reputation
   user      User    @relation("CustomerReviews", fields: [userId], references: [id], onDelete: Cascade) // Cascade: when user is deleted, their reviews are deleted too
   moderator User?   @relation("ReviewModerator", fields: [moderatedBy], references: [id])
 

--- a/src/common/middlewares/bull-board-auth.middleware.ts
+++ b/src/common/middlewares/bull-board-auth.middleware.ts
@@ -1,4 +1,4 @@
-import type { Request, Response, NextFunction } from "express";
+import type { NextFunction, Request, Response } from "express";
 import { timingSafeEqual } from "node:crypto";
 
 /**

--- a/src/modules/status-change/status-change.service.ts
+++ b/src/modules/status-change/status-change.service.ts
@@ -114,7 +114,7 @@ export class StatusChangeService {
 
   async updateBookingsFromActiveToCompleted(timestamp?: string) {
     try {
-      const endDate = timestamp ? { lt: new Date(timestamp) } : this.getCurrentUtcHourWindow();
+      const endDate = timestamp ? { lte: new Date(timestamp) } : this.getCurrentUtcHourWindow();
       // Find all active bookings where end date falls within the current UTC hour window
       // Query for BOOKED cars only - cars with ACTIVE bookings should always be BOOKED
       const bookingsToUpdate = await this.databaseService.booking.findMany({

--- a/src/shared/helper.fixtures.ts
+++ b/src/shared/helper.fixtures.ts
@@ -129,6 +129,7 @@ export function createCar(
     approvalStatus: CarApprovalStatus.APPROVED,
     approvalNotes: null,
     ownerId: "owner-123",
+    pricingIncludesFuel: false,
     createdAt: new Date("2024-01-01T00:00:00Z"),
     updatedAt: new Date("2024-01-01T00:00:00Z"),
     ...overrides,

--- a/src/templates/emails.tsx
+++ b/src/templates/emails.tsx
@@ -25,7 +25,7 @@ export interface EmailTemplateProps {
 
 const COMPANY_NAME = process.env.APP_NAME || "Tripdly";
 const COMPANY_ADDRESS = process.env.COMPANY_ADDRESS || "Lagos, Nigeria";
-const WEBSITE_URL = process.env.WEBSITE_URL || process.env.DOMAIN || "https://dcodesmith.com";
+const WEBSITE_URL = process.env.DOMAIN;
 const SUPPORT_EMAIL = process.env.SUPPORT_EMAIL || "support@dcodesmith.com";
 const CURRENT_YEAR = new Date().getFullYear();
 


### PR DESCRIPTION
- Make Car.fuelUpgradeRate nullable in schema and add migration
- Add explicit "BookingReview" relation name between Booking and Review models
- Add pricingIncludesFuel field to Car model with default false
- Update status change service to use lte instead of lt for timestamp comparison
- Update email template to use DOMAIN env var for website URL
- Add pricingIncludesFuel to car fixtures
- Fix import order in bull-board-auth middleware