### PR TITLE
fix(migrations): add missing Booking columns for e2e schema sync

### DIFF
--- a/prisma/migrations/20260113131349_make_fuel_upgrade_rate_optional_and_explicit_booking_review_relation/migration.sql
+++ b/prisma/migrations/20260113131349_make_fuel_upgrade_rate_optional_and_explicit_booking_review_relation/migration.sql
@@ -1,9 +1,15 @@
 -- AlterTable
 ALTER TABLE "Car" ALTER COLUMN "fuelUpgradeRate" DROP NOT NULL;
 
+-- Add Booking columns that exist in the schema but were missing from migrations
+ALTER TABLE "Booking" ADD COLUMN "deletedAt" TIMESTAMP(3);
+ALTER TABLE "Booking" ADD COLUMN "flightNumber" TEXT;
+ALTER TABLE "Booking" ADD COLUMN "estimatedDuration" INTEGER;
+ALTER TABLE "Booking" ADD COLUMN "flightId" TEXT;
+
 -- AddTable
 ALTER TABLE "Car" ADD COLUMN "pricingIncludesFuel" BOOLEAN NOT NULL DEFAULT false;
 
 -- The Booking-Review relation name is already explicit in the schema
--- This migration documents the schema change where fuelUpgradeRate was made optional
--- and adds the pricingIncludesFuel column
+-- This migration documents the schema change where fuelUpgradeRate was made optional,
+-- adds the pricingIncludesFuel column, and includes Booking.deletedAt for soft deletes.


### PR DESCRIPTION
- Add deletedAt, flightNumber, estimatedDuration, and flightId to Booking table
- Keep migration aligned with Prisma schema to avoid e2e failures