### PR TITLE
feat(auth): add OTP email service and template

### DIFF
--- a/src/modules/auth/auth-email.service.spec.ts
+++ b/src/modules/auth/auth-email.service.spec.ts
@@ -1,0 +1,77 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EmailService } from "../notification/email.service";
+import { AuthEmailService } from "./auth-email.service";
+
+// Mock the email template renderer
+vi.mock("../../templates/emails", () => ({
+  renderAuthOTPEmail: vi.fn().mockResolvedValue("<html>OTP Email</html>"),
+}));
+
+describe("AuthEmailService", () => {
+  let service: AuthEmailService;
+  let emailService: EmailService;
+
+  const mockEmailService = {
+    sendEmail: vi.fn(),
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthEmailService,
+        {
+          provide: EmailService,
+          useValue: mockEmailService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<AuthEmailService>(AuthEmailService);
+    emailService = module.get<EmailService>(EmailService);
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+
+  it("should have email service injected", () => {
+    expect(emailService).toBeDefined();
+  });
+
+  describe("sendOTPEmail", () => {
+    const testEmail = "user@example.com";
+    const testOTP = "123456";
+
+    it("should send OTP email successfully", async () => {
+      mockEmailService.sendEmail.mockResolvedValueOnce({ data: { id: "email-123" } });
+
+      await service.sendOTPEmail(testEmail, testOTP);
+
+      expect(mockEmailService.sendEmail).toHaveBeenCalledTimes(1);
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith({
+        to: testEmail,
+        subject: "Your Verification Code",
+        html: "<html>OTP Email</html>",
+      });
+    });
+
+    it("should throw error when email service fails", async () => {
+      const error = new Error("Email sending failed");
+      mockEmailService.sendEmail.mockRejectedValueOnce(error);
+
+      await expect(service.sendOTPEmail(testEmail, testOTP)).rejects.toThrow(error);
+    });
+
+    it("should call renderAuthOTPEmail with correct OTP", async () => {
+      const { renderAuthOTPEmail } = await import("../../templates/emails");
+      mockEmailService.sendEmail.mockResolvedValueOnce({ data: { id: "email-123" } });
+
+      await service.sendOTPEmail(testEmail, testOTP);
+
+      expect(renderAuthOTPEmail).toHaveBeenCalledWith({ otp: testOTP });
+    });
+  });
+});

--- a/src/modules/auth/auth-email.service.ts
+++ b/src/modules/auth/auth-email.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from "@nestjs/common";
+import { maskEmail } from "../../shared/helper";
 import { renderAuthOTPEmail } from "../../templates/emails";
 import { EmailService } from "../notification/email.service";
 
@@ -9,7 +10,8 @@ export class AuthEmailService {
   constructor(private readonly emailService: EmailService) {}
 
   async sendOTPEmail(email: string, otp: string): Promise<void> {
-    this.logger.log(`Sending OTP email to ${email}`);
+    const maskedEmail = maskEmail(email);
+    this.logger.log(`Sending OTP email to ${maskedEmail}`);
 
     const html = await renderAuthOTPEmail({ otp });
 
@@ -19,6 +21,6 @@ export class AuthEmailService {
       html,
     });
 
-    this.logger.log(`OTP email sent successfully to ${email}`);
+    this.logger.log(`OTP email sent successfully to ${maskedEmail}`);
   }
 }

--- a/src/modules/auth/auth-email.service.ts
+++ b/src/modules/auth/auth-email.service.ts
@@ -1,0 +1,24 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { renderAuthOTPEmail } from "../../templates/emails";
+import { EmailService } from "../notification/email.service";
+
+@Injectable()
+export class AuthEmailService {
+  private readonly logger = new Logger(AuthEmailService.name);
+
+  constructor(private readonly emailService: EmailService) {}
+
+  async sendOTPEmail(email: string, otp: string): Promise<void> {
+    this.logger.log(`Sending OTP email to ${email}`);
+
+    const html = await renderAuthOTPEmail({ otp });
+
+    await this.emailService.sendEmail({
+      to: email,
+      subject: "Your Verification Code",
+      html,
+    });
+
+    this.logger.log(`OTP email sent successfully to ${email}`);
+  }
+}

--- a/src/shared/helper.spec.ts
+++ b/src/shared/helper.spec.ts
@@ -1,6 +1,6 @@
 import { BookingStatus } from "@prisma/client";
 import { describe, expect, it } from "vitest";
-import { formatCurrency, getCustomerDetails, getUserDisplayName } from "./helper";
+import { formatCurrency, getCustomerDetails, getUserDisplayName, maskEmail } from "./helper";
 import {
   createBooking,
   createBookingLeg,
@@ -11,6 +11,32 @@ import {
 } from "./helper.fixtures";
 
 describe("Helper Functions", () => {
+  describe("maskEmail", () => {
+    it("should mask email with single character local part", () => {
+      expect(maskEmail("a@example.com")).toBe("a***@example.com");
+    });
+
+    it("should mask email with multi-character local part", () => {
+      expect(maskEmail("user@example.com")).toBe("u***@example.com");
+    });
+
+    it("should mask email with long local part", () => {
+      expect(maskEmail("verylongemail@test.org")).toBe("v***@test.org");
+    });
+
+    it("should preserve domain", () => {
+      expect(maskEmail("john@subdomain.example.co.uk")).toBe("j***@subdomain.example.co.uk");
+    });
+
+    it("should return *** for invalid email without @", () => {
+      expect(maskEmail("invalidemail")).toBe("***");
+    });
+
+    it("should handle empty local part", () => {
+      expect(maskEmail("@example.com")).toBe("***@example.com");
+    });
+  });
+
   describe("formatCurrency", () => {
     it("should handle zero amount", () => {
       expect(formatCurrency(0)).toContain("₦0");

--- a/src/shared/helper.ts
+++ b/src/shared/helper.ts
@@ -8,6 +8,18 @@ import {
   NormalisedBookingLegDetails,
 } from "../types";
 
+/**
+ * Masks an email address for safe logging (PII protection).
+ * Example: "user@example.com" -> "u***@example.com"
+ * Example: "ab@test.org" -> "a***@test.org"
+ */
+export function maskEmail(email: string): string {
+  const [localPart, domain] = email.split("@");
+  if (!domain) return "***";
+  const maskedLocal = localPart.length > 0 ? `${localPart[0]}***` : "***";
+  return `${maskedLocal}@${domain}`;
+}
+
 // Helper to generate a user-friendly name or email
 export function getUserDisplayName(
   booking: Partial<Omit<BookingWithRelations, "legs">>,

--- a/src/templates/emails.tsx
+++ b/src/templates/emails.tsx
@@ -274,10 +274,8 @@ export interface AuthOTPEmailProps {
 }
 
 export async function renderAuthOTPEmail({ otp }: AuthOTPEmailProps) {
-  const previewText = `Your verification code is ${otp}`;
-
   return await render(
-    <EmailTemplate previewText={previewText} pageTitle="Verification Code">
+    <EmailTemplate previewText="Your verification code" pageTitle="Verification Code">
       <Heading as="h2" className="text-xl font-semibold mb-4 text-center">
         Your Verification Code
       </Heading>

--- a/src/templates/emails.tsx
+++ b/src/templates/emails.tsx
@@ -268,3 +268,36 @@ export async function renderBookingReminderEmail(
     </EmailTemplate>,
   );
 }
+
+export interface AuthOTPEmailProps {
+  readonly otp: string;
+}
+
+export async function renderAuthOTPEmail({ otp }: AuthOTPEmailProps) {
+  const previewText = `Your verification code is ${otp}`;
+
+  return await render(
+    <EmailTemplate previewText={previewText} pageTitle="Verification Code">
+      <Heading as="h2" className="text-xl font-semibold mb-4 text-center">
+        Your Verification Code
+      </Heading>
+
+      <Text className="mb-4 text-center text-gray-600">
+        Use the code below to complete your sign in. This code will expire in 10 minutes.
+      </Text>
+
+      <Section className="bg-gray-50 border border-gray-200 rounded-lg p-6 my-6 text-center">
+        <Text
+          className="text-4xl font-bold tracking-widest text-gray-900 m-0"
+          style={{ letterSpacing: "0.5em" }}
+        >
+          {otp}
+        </Text>
+      </Section>
+
+      <Text className="text-sm text-gray-500 text-center">
+        If you didn't request this code, you can safely ignore this email.
+      </Text>
+    </EmailTemplate>,
+  );
+}


### PR DESCRIPTION
- Add renderAuthOTPEmail template for verification codes
- Create AuthEmailService to send OTP emails directly via EmailService
- Add unit tests for AuthEmailService