### PR TITLE
feat(auth): add AuthModule with service and controller

### DIFF
--- a/src/config/env.config.ts
+++ b/src/config/env.config.ts
@@ -61,7 +61,12 @@ export const envSchema = z.object({
   // Auth configuration (optional - only required when AuthModule is used)
   SESSION_SECRET: z.string().min(32, "SESSION_SECRET must be at least 32 characters").optional(),
   AUTH_BASE_URL: z.url("AUTH_BASE_URL must be a valid URL").optional(),
-  TRUSTED_ORIGINS: z.string().min(1, "TRUSTED_ORIGINS is required").optional(),
+  TRUSTED_ORIGINS: z
+    .string()
+    .min(1, "TRUSTED_ORIGINS is required")
+    .transform((val) => val.split(",").map((origin) => origin.trim()).filter(Boolean))
+    .pipe(z.array(z.url("Each TRUSTED_ORIGIN must be a valid URL")).min(1, "At least one valid TRUSTED_ORIGIN is required"))
+    .optional(),
 });
 
 export type EnvConfig = z.infer<typeof envSchema>;

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,7 @@ async function bootstrap() {
     const trustedOrigins = configService.get("TRUSTED_ORIGINS", { infer: true });
     if (trustedOrigins) {
       app.enableCors({
-        origin: trustedOrigins.split(","),
+        origin: trustedOrigins,
         credentials: true,
         allowedHeaders: ["Content-Type", "Authorization", "Cookie"],
         exposedHeaders: ["Set-Cookie"],

--- a/src/modules/auth/auth.controller.spec.ts
+++ b/src/modules/auth/auth.controller.spec.ts
@@ -1,0 +1,86 @@
+import { ServiceUnavailableException, UnauthorizedException } from "@nestjs/common";
+import { Test, TestingModule } from "@nestjs/testing";
+import type { Request } from "express";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthController } from "./auth.controller";
+import { AuthService } from "./auth.service";
+
+describe("AuthController", () => {
+  let controller: AuthController;
+  let authService: AuthService;
+
+  const mockAuthService = {
+    isInitialized: true,
+    auth: {
+      api: {
+        getSession: vi.fn(),
+      },
+    },
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [
+        {
+          provide: AuthService,
+          useValue: mockAuthService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<AuthController>(AuthController);
+    authService = module.get<AuthService>(AuthService);
+  });
+
+  it("should be defined", () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe("getSession", () => {
+    const mockRequest = {
+      headers: {
+        cookie: "session=test-token",
+      },
+    } as unknown as Request;
+
+    it("should return session when authenticated", async () => {
+      const mockSession = {
+        user: { id: "user-123", email: "test@example.com" },
+        session: { id: "session-123", expiresAt: new Date() },
+      };
+
+      mockAuthService.auth.api.getSession.mockResolvedValueOnce(mockSession);
+
+      const result = await controller.getSession(mockRequest);
+
+      expect(result).toEqual(mockSession);
+      expect(mockAuthService.auth.api.getSession).toHaveBeenCalledWith({
+        headers: mockRequest.headers,
+      });
+    });
+
+    it("should throw UnauthorizedException when not authenticated", async () => {
+      mockAuthService.auth.api.getSession.mockResolvedValueOnce(null);
+
+      await expect(controller.getSession(mockRequest)).rejects.toThrow(UnauthorizedException);
+      await expect(controller.getSession(mockRequest)).rejects.toThrow("Not authenticated");
+    });
+
+    it("should throw ServiceUnavailableException when auth not initialized", async () => {
+      mockAuthService.isInitialized = false;
+
+      await expect(controller.getSession(mockRequest)).rejects.toThrow(
+        ServiceUnavailableException,
+      );
+      await expect(controller.getSession(mockRequest)).rejects.toThrow(
+        "Authentication service is not configured",
+      );
+
+      // Reset for other tests
+      mockAuthService.isInitialized = true;
+    });
+  });
+});

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,0 +1,62 @@
+import {
+  All,
+  Controller,
+  Get,
+  Req,
+  Res,
+  ServiceUnavailableException,
+  UnauthorizedException,
+} from "@nestjs/common";
+import { toNodeHandler } from "better-auth/node";
+import type { Request, Response } from "express";
+import { AuthService } from "./auth.service";
+
+@Controller("auth")
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  /**
+   * Catch-all handler for Better Auth endpoints.
+   * Routes all /auth/api/* requests to Better Auth.
+   *
+   * Note: We use @Res() here because Better Auth needs direct access
+   * to the response object to handle cookies and headers.
+   */
+  @All("api/*path")
+  async handleAuthRequest(@Req() req: Request, @Res() res: Response): Promise<void> {
+    this.ensureAuthInitialized();
+
+    const handler = toNodeHandler(this.authService.auth);
+    await handler(req, res);
+  }
+
+  /**
+   * Get current session information.
+   * Returns session data if authenticated, 401 if not.
+   */
+  @Get("session")
+  async getSession(@Req() req: Request): Promise<{ user: unknown; session: unknown }> {
+    this.ensureAuthInitialized();
+
+    const session = await this.authService.auth.api.getSession({
+      headers: req.headers as Record<string, string>,
+    });
+
+    if (!session) {
+      throw new UnauthorizedException("Not authenticated");
+    }
+
+    return session;
+  }
+
+  /**
+   * Throws ServiceUnavailableException if auth is not configured.
+   */
+  private ensureAuthInitialized(): void {
+    if (!this.authService.isInitialized) {
+      throw new ServiceUnavailableException(
+        "Authentication service is not configured. Contact support.",
+      );
+    }
+  }
+}

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,3 +1,4 @@
+import type { IncomingHttpHeaders } from "node:http";
 import {
   All,
   Controller,
@@ -10,6 +11,19 @@ import {
 import { toNodeHandler } from "better-auth/node";
 import type { Request, Response } from "express";
 import { AuthService } from "./auth.service";
+
+/**
+ * Converts Express IncomingHttpHeaders to a Headers object.
+ * Normalizes string[] values to comma-separated strings and skips undefined values.
+ */
+function toHeaders(incomingHeaders: IncomingHttpHeaders): Headers {
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(incomingHeaders)) {
+    if (value === undefined) continue;
+    headers.set(key, Array.isArray(value) ? value.join(", ") : value);
+  }
+  return headers;
+}
 
 @Controller("auth")
 export class AuthController {
@@ -39,7 +53,7 @@ export class AuthController {
     this.ensureAuthInitialized();
 
     const session = await this.authService.auth.api.getSession({
-      headers: req.headers as Record<string, string>,
+      headers: toHeaders(req.headers),
     });
 
     if (!session) {

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -1,0 +1,14 @@
+import { Module } from "@nestjs/common";
+import { DatabaseModule } from "../database/database.module";
+import { NotificationModule } from "../notification/notification.module";
+import { AuthController } from "./auth.controller";
+import { AuthEmailService } from "./auth-email.service";
+import { AuthService } from "./auth.service";
+
+@Module({
+  imports: [DatabaseModule, NotificationModule],
+  controllers: [AuthController],
+  providers: [AuthService, AuthEmailService],
+  exports: [AuthService],
+})
+export class AuthModule {}

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -1,0 +1,59 @@
+import { Injectable, Logger, OnModuleInit } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import type { EnvConfig } from "../../config/env.config";
+import { DatabaseService } from "../database/database.service";
+import { AuthEmailService } from "./auth-email.service";
+import { type Auth, createAuth } from "./auth.config";
+
+@Injectable()
+export class AuthService implements OnModuleInit {
+  private readonly logger = new Logger(AuthService.name);
+  private _auth: Auth | null = null;
+
+  constructor(
+    private readonly databaseService: DatabaseService,
+    private readonly configService: ConfigService<EnvConfig>,
+    private readonly authEmailService: AuthEmailService,
+  ) {}
+
+  onModuleInit() {
+    const sessionSecret = this.configService.get("SESSION_SECRET", { infer: true });
+    const authBaseUrl = this.configService.get("AUTH_BASE_URL", { infer: true });
+    const trustedOriginsStr = this.configService.get("TRUSTED_ORIGINS", { infer: true });
+    const nodeEnv = this.configService.get("NODE_ENV", { infer: true });
+
+    if (!sessionSecret || !authBaseUrl || !trustedOriginsStr) {
+      this.logger.warn(
+        "Auth configuration incomplete. AuthService will not be initialized. " +
+          "Set SESSION_SECRET, AUTH_BASE_URL, and TRUSTED_ORIGINS to enable auth.",
+      );
+      return;
+    }
+
+    const trustedOrigins = trustedOriginsStr.split(",").map((origin) => origin.trim());
+
+    this._auth = createAuth({
+      prisma: this.databaseService,
+      sessionSecret,
+      authBaseUrl,
+      trustedOrigins,
+      secureCookies: nodeEnv === "production",
+      sendOTPEmail: this.authEmailService.sendOTPEmail.bind(this.authEmailService),
+    });
+
+    this.logger.log("Auth service initialized successfully");
+  }
+
+  get auth(): Auth {
+    if (!this._auth) {
+      throw new Error(
+        "Auth service not initialized. Ensure SESSION_SECRET, AUTH_BASE_URL, and TRUSTED_ORIGINS are configured.",
+      );
+    }
+    return this._auth;
+  }
+
+  get isInitialized(): boolean {
+    return this._auth !== null;
+  }
+}

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -19,10 +19,10 @@ export class AuthService implements OnModuleInit {
   onModuleInit() {
     const sessionSecret = this.configService.get("SESSION_SECRET", { infer: true });
     const authBaseUrl = this.configService.get("AUTH_BASE_URL", { infer: true });
-    const trustedOriginsStr = this.configService.get("TRUSTED_ORIGINS", { infer: true });
+    const trustedOrigins = this.configService.get("TRUSTED_ORIGINS", { infer: true });
     const nodeEnv = this.configService.get("NODE_ENV", { infer: true });
 
-    if (!sessionSecret || !authBaseUrl || !trustedOriginsStr) {
+    if (!sessionSecret || !authBaseUrl || !trustedOrigins?.length) {
       this.logger.warn(
         "Auth configuration incomplete. AuthService will not be initialized. " +
           "Set SESSION_SECRET, AUTH_BASE_URL, and TRUSTED_ORIGINS to enable auth.",
@@ -30,14 +30,12 @@ export class AuthService implements OnModuleInit {
       return;
     }
 
-    const trustedOrigins = trustedOriginsStr.split(",").map((origin) => origin.trim());
-
     this._auth = createAuth({
       prisma: this.databaseService,
       sessionSecret,
       authBaseUrl,
       trustedOrigins,
-      secureCookies: nodeEnv === "production",
+      secureCookies: nodeEnv !== "development",
       sendOTPEmail: this.authEmailService.sendOTPEmail.bind(this.authEmailService),
     });
 


### PR DESCRIPTION
- Create AuthModule with DatabaseModule and NotificationModule imports
- Add AuthService wrapping Better Auth with lazy initialization
- Add AuthController with catch-all handler for /auth/api/* and session endpoint
- Use NestJS exceptions (ServiceUnavailable, Unauthorized) for proper error handling
- Add unit tests for AuthService and AuthController (10 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces Better Auth integration and refines environment/CORS handling.
> 
> - **New `AuthModule` with `AuthService` and `AuthController`**: Catch-all handler for `GET/POST /auth/api/*` via Better Auth and `GET /auth/session` that returns session or `401` when unauthenticated; throws `503` if auth not configured
> - **Lazy initialization in `AuthService`**: Initializes only when `SESSION_SECRET`, `AUTH_BASE_URL`, and `TRUSTED_ORIGINS` are set; configures `secureCookies` based on `NODE_ENV`
> - **Env schema change**: `TRUSTED_ORIGINS` now parsed from comma-separated string into validated URL array
> - **CORS setup**: `main.ts` now passes validated `TRUSTED_ORIGINS` array directly to `enableCors({ origin })`
> - **Tests**: Unit tests for `AuthService` and `AuthController` covering init behavior and session endpoint
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0115966f4cda9c6b1a571085aa0d8f76aec22c6. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->