### PR TITLE
feat(auth): add AuthModule with service and controller

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,6 +15,7 @@ import { PaymentModule } from "./modules/payment/payment.module";
 import { ReferralModule } from "./modules/referral/referral.module";
 import { ReminderModule } from "./modules/reminder/reminder.module";
 import { StatusChangeModule } from "./modules/status-change/status-change.module";
+import { AuthModule } from "./modules/auth/auth.module";
 
 @Module({
   imports: [
@@ -74,6 +75,7 @@ import { StatusChangeModule } from "./modules/status-change/status-change.module
     HealthModule,
     JobModule,
     ReferralModule,
+    AuthModule,
   ],
 })
 export class AppModule {}

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -4,11 +4,12 @@ import { NotificationModule } from "../notification/notification.module";
 import { AuthController } from "./auth.controller";
 import { AuthEmailService } from "./auth-email.service";
 import { AuthService } from "./auth.service";
+import { SessionGuard } from "./guards/session.guard";
 
 @Module({
   imports: [DatabaseModule, NotificationModule],
   controllers: [AuthController],
-  providers: [AuthService, AuthEmailService],
-  exports: [AuthService],
+  providers: [AuthService, AuthEmailService, SessionGuard],
+  exports: [AuthService, SessionGuard],
 })
 export class AuthModule {}

--- a/src/modules/auth/decorators/current-user.decorator.spec.ts
+++ b/src/modules/auth/decorators/current-user.decorator.spec.ts
@@ -1,0 +1,101 @@
+import { ExecutionContext } from "@nestjs/common";
+import { ROUTE_ARGS_METADATA } from "@nestjs/common/constants";
+import type { Session, User } from "better-auth";
+import { describe, expect, it } from "vitest";
+import { AUTH_SESSION_KEY, AuthSession } from "../guards/session.guard";
+import { CurrentUser } from "./current-user.decorator";
+
+describe("CurrentUser Decorator", () => {
+  const mockUser: User = {
+    id: "user-123",
+    email: "test@example.com",
+    name: "Test User",
+    emailVerified: true,
+    image: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  const mockSessionData: Session = {
+    id: "session-123",
+    userId: "user-123",
+    expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    token: "token-123",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ipAddress: "127.0.0.1",
+    userAgent: "test-agent",
+  };
+
+  const mockSession: AuthSession = {
+    user: mockUser,
+    session: mockSessionData,
+  };
+
+  const getParamDecoratorFactory = () => {
+    class TestClass {
+      testMethod(@CurrentUser() _user: User) {}
+    }
+
+    const metadata = Reflect.getMetadata(ROUTE_ARGS_METADATA, TestClass, "testMethod");
+    const key = Object.keys(metadata)[0];
+    return metadata[key].factory;
+  };
+
+  const createMockExecutionContext = (session?: AuthSession) => {
+    const mockRequest = { [AUTH_SESSION_KEY]: session };
+    return {
+      switchToHttp: () => ({
+        getRequest: () => mockRequest,
+      }),
+    } as unknown as ExecutionContext;
+  };
+
+  it("should return user by default when session exists", () => {
+    const factory = getParamDecoratorFactory();
+    const context = createMockExecutionContext(mockSession);
+
+    const result = factory(undefined, context);
+
+    expect(result).toEqual(mockSession.user);
+  });
+
+  it("should return full session when data is 'session'", () => {
+    class TestClass {
+      testMethod(@CurrentUser("session") _session: AuthSession) {}
+    }
+
+    const metadata = Reflect.getMetadata(ROUTE_ARGS_METADATA, TestClass, "testMethod");
+    const key = Object.keys(metadata)[0];
+    const factory = metadata[key].factory;
+    const context = createMockExecutionContext(mockSession);
+
+    const result = factory("session", context);
+
+    expect(result).toEqual(mockSession);
+  });
+
+  it("should return null when no session exists", () => {
+    const factory = getParamDecoratorFactory();
+    const context = createMockExecutionContext(undefined);
+
+    const result = factory(undefined, context);
+
+    expect(result).toBeNull();
+  });
+
+  it("should return user when data is 'user'", () => {
+    class TestClass {
+      testMethod(@CurrentUser("user") _user: User) {}
+    }
+
+    const metadata = Reflect.getMetadata(ROUTE_ARGS_METADATA, TestClass, "testMethod");
+    const key = Object.keys(metadata)[0];
+    const factory = metadata[key].factory;
+    const context = createMockExecutionContext(mockSession);
+
+    const result = factory("user", context);
+
+    expect(result).toEqual(mockSession.user);
+  });
+});

--- a/src/modules/auth/decorators/current-user.decorator.ts
+++ b/src/modules/auth/decorators/current-user.decorator.ts
@@ -1,0 +1,41 @@
+import { createParamDecorator, ExecutionContext } from "@nestjs/common";
+import type { Request } from "express";
+import { AUTH_SESSION_KEY, AuthSession } from "../guards/session.guard";
+
+/**
+ * Parameter decorator to extract the current user from the request.
+ *
+ * Must be used with SessionGuard to ensure the session is validated first.
+ *
+ * Usage:
+ * ```typescript
+ * @UseGuards(SessionGuard)
+ * @Get('profile')
+ * getProfile(@CurrentUser() user: AuthSession['user']) {
+ *   return user;
+ * }
+ *
+ * // Or get the full session
+ * @Get('session')
+ * getSession(@CurrentUser('session') session: AuthSession) {
+ *   return session;
+ * }
+ * ```
+ */
+export const CurrentUser = createParamDecorator(
+  (data: "user" | "session" | undefined, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest<Request & { [AUTH_SESSION_KEY]?: AuthSession }>();
+    const authSession = request[AUTH_SESSION_KEY];
+
+    if (!authSession) {
+      return null;
+    }
+
+    if (data === "session") {
+      return authSession;
+    }
+
+    // Default: return user
+    return authSession.user;
+  },
+);

--- a/src/modules/auth/guards/session.guard.spec.ts
+++ b/src/modules/auth/guards/session.guard.spec.ts
@@ -1,0 +1,122 @@
+import { ExecutionContext, UnauthorizedException } from "@nestjs/common";
+import { Test, TestingModule } from "@nestjs/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthService } from "../auth.service";
+import { AUTH_SESSION_KEY, SessionGuard } from "./session.guard";
+
+describe("SessionGuard", () => {
+  let guard: SessionGuard;
+  let mockGetSession: ReturnType<typeof vi.fn>;
+
+  const mockSession = {
+    user: {
+      id: "user-123",
+      email: "test@example.com",
+      name: "Test User",
+      emailVerified: true,
+      image: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    session: {
+      id: "session-123",
+      userId: "user-123",
+      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      token: "token-123",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ipAddress: "127.0.0.1",
+      userAgent: "test-agent",
+    },
+  };
+
+  const createMockAuthService = (isInitialized: boolean) => {
+    mockGetSession = vi.fn();
+    return {
+      isInitialized,
+      auth: {
+        api: {
+          getSession: mockGetSession,
+        },
+      },
+    };
+  };
+
+  const createMockExecutionContext = (headers: Record<string, string> = {}) => {
+    const mockRequest = { headers, [AUTH_SESSION_KEY]: undefined };
+    return {
+      switchToHttp: () => ({
+        getRequest: () => mockRequest,
+      }),
+      getRequest: () => mockRequest,
+    } as unknown as ExecutionContext & { getRequest: () => typeof mockRequest };
+  };
+
+  const setupTestModule = async (isInitialized: boolean) => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SessionGuard,
+        { provide: AuthService, useValue: createMockAuthService(isInitialized) },
+      ],
+    }).compile();
+
+    guard = module.get<SessionGuard>(SessionGuard);
+  };
+
+  describe("when auth is initialized", () => {
+    beforeEach(async () => {
+      await setupTestModule(true);
+    });
+
+    it("should be defined", () => {
+      expect(guard).toBeDefined();
+    });
+
+    it("should return true and attach session when valid session exists", async () => {
+      mockGetSession.mockResolvedValueOnce(mockSession);
+      const context = createMockExecutionContext({ cookie: "session=token-123" });
+
+      const result = await guard.canActivate(context);
+
+      expect(result).toBe(true);
+      expect(context.getRequest()[AUTH_SESSION_KEY]).toEqual(mockSession);
+    });
+
+    it("should throw UnauthorizedException when no session found", async () => {
+      mockGetSession.mockResolvedValueOnce(null);
+      const context = createMockExecutionContext({ cookie: "session=invalid" });
+
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        new UnauthorizedException("Invalid or expired session"),
+      );
+    });
+
+    it("should pass headers to getSession", async () => {
+      mockGetSession.mockResolvedValueOnce(mockSession);
+      const context = createMockExecutionContext({
+        cookie: "session=token-123",
+        authorization: "Bearer some-token",
+      });
+
+      await guard.canActivate(context);
+
+      expect(mockGetSession).toHaveBeenCalledWith({
+        headers: expect.any(Headers),
+      });
+    });
+  });
+
+  describe("when auth is not initialized", () => {
+    beforeEach(async () => {
+      await setupTestModule(false);
+    });
+
+    it("should throw UnauthorizedException", async () => {
+      const context = createMockExecutionContext();
+
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        new UnauthorizedException("Authentication service is not available"),
+      );
+    });
+  });
+});

--- a/src/modules/auth/guards/session.guard.spec.ts
+++ b/src/modules/auth/guards/session.guard.spec.ts
@@ -1,4 +1,8 @@
-import { ExecutionContext, UnauthorizedException } from "@nestjs/common";
+import {
+  ExecutionContext,
+  ServiceUnavailableException,
+  UnauthorizedException,
+} from "@nestjs/common";
 import { Test, TestingModule } from "@nestjs/testing";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AuthService } from "../auth.service";
@@ -111,11 +115,13 @@ describe("SessionGuard", () => {
       await setupTestModule(false);
     });
 
-    it("should throw UnauthorizedException", async () => {
+    it("should throw ServiceUnavailableException", async () => {
       const context = createMockExecutionContext();
 
       await expect(guard.canActivate(context)).rejects.toThrow(
-        new UnauthorizedException("Authentication service is not available"),
+        new ServiceUnavailableException(
+          "Authentication service is not configured. Contact support.",
+        ),
       );
     });
   });

--- a/src/modules/auth/guards/session.guard.ts
+++ b/src/modules/auth/guards/session.guard.ts
@@ -1,0 +1,64 @@
+import type { IncomingHttpHeaders } from "node:http";
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from "@nestjs/common";
+import type { Session, User } from "better-auth";
+import type { Request } from "express";
+import { AuthService } from "../auth.service";
+
+/**
+ * Converts Express IncomingHttpHeaders to a Headers object.
+ */
+function toHeaders(incomingHeaders: IncomingHttpHeaders): Headers {
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(incomingHeaders)) {
+    if (value === undefined) continue;
+    headers.set(key, Array.isArray(value) ? value.join(", ") : value);
+  }
+  return headers;
+}
+
+export const AUTH_SESSION_KEY = "authSession";
+
+export interface AuthSession {
+  user: User;
+  session: Session;
+}
+
+/**
+ * Guard that validates user session via Better Auth.
+ *
+ * Supports both cookie-based (web) and bearer token (mobile) authentication.
+ * Attaches the session to the request object for use by the @CurrentUser decorator.
+ *
+ * Usage:
+ * ```typescript
+ * @UseGuards(SessionGuard)
+ * @Get('profile')
+ * getProfile(@CurrentUser() user: AuthSession['user']) {
+ *   return user;
+ * }
+ * ```
+ */
+@Injectable()
+export class SessionGuard implements CanActivate {
+  constructor(private readonly authService: AuthService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    if (!this.authService.isInitialized) {
+      throw new UnauthorizedException("Authentication service is not available");
+    }
+
+    const request = context.switchToHttp().getRequest<Request>();
+    const session = await this.authService.auth.api.getSession({
+      headers: toHeaders(request.headers),
+    });
+
+    if (!session) {
+      throw new UnauthorizedException("Invalid or expired session");
+    }
+
+    // Attach session to request for use by @CurrentUser decorator
+    (request as Request & { [AUTH_SESSION_KEY]: AuthSession })[AUTH_SESSION_KEY] = session;
+
+    return true;
+  }
+}

--- a/src/modules/auth/guards/session.guard.ts
+++ b/src/modules/auth/guards/session.guard.ts
@@ -1,5 +1,11 @@
 import type { IncomingHttpHeaders } from "node:http";
-import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from "@nestjs/common";
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  ServiceUnavailableException,
+  UnauthorizedException,
+} from "@nestjs/common";
 import type { Session, User } from "better-auth";
 import type { Request } from "express";
 import { AuthService } from "../auth.service";
@@ -44,7 +50,9 @@ export class SessionGuard implements CanActivate {
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     if (!this.authService.isInitialized) {
-      throw new UnauthorizedException("Authentication service is not available");
+      throw new ServiceUnavailableException(
+        "Authentication service is not configured. Contact support.",
+      );
     }
 
     const request = context.switchToHttp().getRequest<Request>();


### PR DESCRIPTION
- Create AuthModule with DatabaseModule and NotificationModule imports
- Add AuthService wrapping Better Auth with lazy initialization
- Add AuthController with catch-all handler for /auth/api/* and session endpoint
- Use NestJS exceptions (ServiceUnavailable, Unauthorized) for proper error handling
- Add unit tests for AuthService and AuthController (10 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces session-based auth utilities and wires `AuthModule` into the app.
> 
> - Adds `SessionGuard` to validate sessions via Better Auth, convert request headers, and attach `authSession` to the request
> - Adds `@CurrentUser` param decorator to access the current `user` or full `session` from requests
> - Registers and exports `SessionGuard` from `AuthModule`; updates `AppModule` to import `AuthModule`
> - Adds unit tests for `SessionGuard` and `CurrentUser` decorator
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06d194f497da02426da3bf02835eabc974e6fb9d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->