### PR TITLE
feat(auth): add e2e tests for Better Auth OTP flow

### DIFF
--- a/.env.e2e
+++ b/.env.e2e
@@ -18,3 +18,8 @@ FLUTTERWAVE_WEBHOOK_SECRET=test-webhook-secret
 FLUTTERWAVE_WEBHOOK_URL=https://test.example.com/flutterwave-webhook
 
 ENABLE_MANUAL_TRIGGERS=true
+
+# Auth configuration for e2e tests
+SESSION_SECRET=e2e-test-secret-at-least-32-characters-long
+AUTH_BASE_URL=http://localhost:3001
+TRUSTED_ORIGINS=http://localhost:3001,http://localhost:3000

--- a/src/modules/auth/auth.config.ts
+++ b/src/modules/auth/auth.config.ts
@@ -10,16 +10,25 @@ export interface AuthConfigOptions {
   trustedOrigins: string[];
   sendOTPEmail: (email: string, otp: string) => Promise<void>;
   secureCookies: boolean;
+  enableRateLimit: boolean;
 }
 
 export function createAuth(options: AuthConfigOptions) {
-  const { prisma, sessionSecret, authBaseUrl, trustedOrigins, sendOTPEmail, secureCookies } =
-    options;
+  const {
+    prisma,
+    sessionSecret,
+    authBaseUrl,
+    trustedOrigins,
+    sendOTPEmail,
+    secureCookies,
+    enableRateLimit,
+  } = options;
 
   return betterAuth({
     database: prismaAdapter(prisma, { provider: "postgresql" }),
     secret: sessionSecret,
     baseURL: authBaseUrl,
+    basePath: "/auth/api",
     trustedOrigins,
     session: {
       expiresIn: 60 * 60 * 24 * 7, // 7 days
@@ -39,7 +48,7 @@ export function createAuth(options: AuthConfigOptions) {
       bearer(),
     ],
     rateLimit: {
-      enabled: true,
+      enabled: enableRateLimit,
       window: 60,
       max: 100,
       storage: "database",

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -36,6 +36,7 @@ export class AuthService implements OnModuleInit {
       authBaseUrl,
       trustedOrigins,
       secureCookies: nodeEnv !== "development",
+      enableRateLimit: true,
       sendOTPEmail: this.authEmailService.sendOTPEmail.bind(this.authEmailService),
     });
 

--- a/src/modules/job/job.controller.spec.ts
+++ b/src/modules/job/job.controller.spec.ts
@@ -1,9 +1,12 @@
 import { ConfigService } from "@nestjs/config";
+import { Reflector } from "@nestjs/core";
 import { Test, TestingModule } from "@nestjs/testing";
+import { ThrottlerStorage } from "@nestjs/throttler";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { JobException } from "./errors";
 import { JobController } from "./job.controller";
 import { JobService } from "./job.service";
+import { JobThrottlerGuard } from "./job-throttler.guard";
 
 describe("JobController", () => {
   let controller: JobController;
@@ -32,6 +35,17 @@ describe("JobController", () => {
             get: mockConfigGet,
           },
         },
+        // Mock throttler dependencies for the guard
+        {
+          provide: "THROTTLER:MODULE_OPTIONS",
+          useValue: [{ name: "manual-triggers", ttl: 3600, limit: 1 }],
+        },
+        {
+          provide: ThrottlerStorage,
+          useValue: { increment: vi.fn(), get: vi.fn() },
+        },
+        Reflector,
+        JobThrottlerGuard,
       ],
     }).compile();
 
@@ -68,6 +82,17 @@ describe("JobController", () => {
             get: configGet,
           },
         },
+        // Mock throttler dependencies for the guard
+        {
+          provide: "THROTTLER:MODULE_OPTIONS",
+          useValue: [{ name: "manual-triggers", ttl: 3600, limit: 1 }],
+        },
+        {
+          provide: ThrottlerStorage,
+          useValue: { increment: vi.fn(), get: vi.fn() },
+        },
+        Reflector,
+        JobThrottlerGuard,
       ],
     }).compile();
     return module.get<JobController>(JobController);

--- a/src/modules/job/job.controller.ts
+++ b/src/modules/job/job.controller.ts
@@ -3,11 +3,12 @@ import { ConfigService } from "@nestjs/config";
 import { ApiKeyGuard } from "./api-key.guard";
 import { JobException } from "./errors";
 import { ValidateJobTypePipe } from "./job.dto";
+import { JobThrottlerGuard } from "./job-throttler.guard";
 import { JobType, JobTypeNames } from "./job.schema";
 import { JobService } from "./job.service";
 
 @Controller("job")
-@UseGuards(ApiKeyGuard)
+@UseGuards(ApiKeyGuard, JobThrottlerGuard)
 export class JobController {
   private readonly manualTriggersEnabled: boolean;
 

--- a/src/modules/job/job.module.ts
+++ b/src/modules/job/job.module.ts
@@ -1,5 +1,4 @@
 import { Module } from "@nestjs/common";
-import { APP_GUARD } from "@nestjs/core";
 import { ThrottlerModule } from "@nestjs/throttler";
 import { ReminderModule } from "../reminder/reminder.module";
 import { StatusChangeModule } from "../status-change/status-change.module";
@@ -20,12 +19,6 @@ import { JobThrottlerGuard } from "./job-throttler.guard";
     StatusChangeModule,
   ],
   controllers: [JobController],
-  providers: [
-    JobService,
-    {
-      provide: APP_GUARD,
-      useClass: JobThrottlerGuard,
-    },
-  ],
+  providers: [JobService, JobThrottlerGuard],
 })
 export class JobModule {}

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -1,0 +1,257 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+import { HttpAdapterHost } from "@nestjs/core";
+import { Test, TestingModule } from "@nestjs/testing";
+import request from "supertest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { AppModule } from "../src/app.module";
+import { GlobalExceptionFilter } from "../src/common/filters/global-exception.filter";
+import { DatabaseService } from "../src/modules/database/database.service";
+
+describe("Auth E2E Tests", () => {
+  let app: INestApplication;
+  let databaseService: DatabaseService;
+  let testId: number;
+
+  // Generate unique email for each test to avoid conflicts
+  const uniqueEmail = (prefix: string) => `${prefix}-${testId}-${Date.now()}@example.com`;
+
+  // Helper to clear rate limits before a test
+  const clearRateLimits = async () => {
+    const deleted = await databaseService.rateLimit.deleteMany({});
+    console.log(`Cleared ${deleted.count} rate limit records`);
+  };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+
+    // Register global exception filter (same as in main.ts)
+    const httpAdapterHost = app.get(HttpAdapterHost);
+    app.useGlobalFilters(new GlobalExceptionFilter(httpAdapterHost));
+
+    databaseService = app.get(DatabaseService);
+
+    await app.init();
+
+    // Clear any existing rate limits from previous test runs
+    await clearRateLimits();
+  });
+
+  beforeEach(() => {
+    testId = Math.floor(Math.random() * 100000);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe("GET /auth/session", () => {
+    it("should return 401 when not authenticated", async () => {
+      const response = await request(app.getHttpServer()).get("/auth/session");
+
+      expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+      expect(response.body.message).toBe("Not authenticated");
+    });
+
+    it("should return 401 with invalid cookie", async () => {
+      const response = await request(app.getHttpServer())
+        .get("/auth/session")
+        .set("Cookie", "better-auth.session_token=invalid-token");
+
+      // Log rate limit records after request
+      const rateLimitCount = await databaseService.rateLimit.count();
+      console.log(`Rate limit records in DB: ${rateLimitCount}`);
+      if (response.status === 429) {
+        console.log("Rate limit response body:", response.body);
+      }
+
+      expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+      expect(response.body.message).toBe("Not authenticated");
+    });
+  });
+
+  describe("POST /auth/api/email-otp/send-verification-otp", () => {
+    beforeEach(async () => {
+      // Clear rate limits before each OTP test to ensure clean state
+      await clearRateLimits();
+    });
+
+    it("should send OTP to email and create verification record", async () => {
+      const testEmail = uniqueEmail("otp-test");
+
+      const response = await request(app.getHttpServer())
+        .post("/auth/api/email-otp/send-verification-otp")
+        .send({ email: testEmail, type: "sign-in" });
+
+      expect(response.status).toBe(HttpStatus.OK);
+      expect(response.body.success).toBe(true);
+
+      // Check verification exists in database
+      // Better Auth stores with identifier format: sign-in-otp-{email}
+      const verification = await databaseService.verification.findFirst({
+        where: { identifier: `sign-in-otp-${testEmail}` },
+        orderBy: { createdAt: "desc" },
+      });
+
+      expect(verification).toBeDefined();
+      expect(verification?.identifier).toBe(`sign-in-otp-${testEmail}`);
+      expect(verification?.value).toBeDefined();
+      // OTP is stored as "otp:attempts" format (e.g., "123456:0")
+      expect(verification?.value.split(":")[0].length).toBe(6);
+    });
+
+    it("should reject invalid email format", async () => {
+      const response = await request(app.getHttpServer())
+        .post("/auth/api/email-otp/send-verification-otp")
+        .send({ email: "not-an-email", type: "sign-in" });
+
+      // Better Auth returns 400 for validation errors
+      expect(response.status).toBeGreaterThanOrEqual(400);
+    });
+  });
+
+  describe("POST /auth/api/sign-in/email-otp (verify)", () => {
+    beforeEach(async () => {
+      await clearRateLimits();
+    });
+
+    it("should reject invalid OTP", async () => {
+      const testEmail = uniqueEmail("invalid-otp");
+
+      // First, send OTP to create verification
+      await request(app.getHttpServer())
+        .post("/auth/api/email-otp/send-verification-otp")
+        .send({ email: testEmail, type: "sign-in" });
+
+      // Try to verify with wrong OTP
+      const response = await request(app.getHttpServer())
+        .post("/auth/api/sign-in/email-otp")
+        .send({ email: testEmail, otp: "000000" });
+
+      // Should fail verification
+      expect(response.status).toBeGreaterThanOrEqual(400);
+    });
+
+    it("should verify correct OTP and return session with cookies", async () => {
+      const testEmail = uniqueEmail("verify-otp");
+
+      // Send OTP
+      const sendResponse = await request(app.getHttpServer())
+        .post("/auth/api/email-otp/send-verification-otp")
+        .send({ email: testEmail, type: "sign-in" });
+
+      expect(sendResponse.status).toBe(HttpStatus.OK);
+      expect(sendResponse.body.success).toBe(true);
+
+      // Get OTP from database - Better Auth stores as "sign-in-otp-{email}"
+      const verification = await databaseService.verification.findFirst({
+        where: { identifier: `sign-in-otp-${testEmail}` },
+        orderBy: { createdAt: "desc" },
+      });
+
+      expect(verification).toBeDefined();
+      expect(verification?.value).toBeDefined();
+
+      // Extract OTP from "otp:attempts" format
+      const otp = verification?.value.split(":")[0];
+
+      // Verify OTP - this creates user and session
+      const verifyResponse = await request(app.getHttpServer())
+        .post("/auth/api/sign-in/email-otp")
+        .send({ email: testEmail, otp });
+
+      expect(verifyResponse.status).toBe(HttpStatus.OK);
+      expect(verifyResponse.body.user).toBeDefined();
+      expect(verifyResponse.body.user.email).toBe(testEmail);
+      expect(verifyResponse.body.token).toBeDefined();
+
+      // Should set session cookie
+      const cookies = verifyResponse.headers["set-cookie"];
+      expect(cookies).toBeDefined();
+    });
+  });
+
+  describe("Authenticated session flow", () => {
+    beforeEach(async () => {
+      await clearRateLimits();
+    });
+
+    it("should complete full auth flow and access protected session endpoint", async () => {
+      const testEmail = uniqueEmail("auth-flow");
+
+      // Step 1: Send OTP
+      const sendResponse = await request(app.getHttpServer())
+        .post("/auth/api/email-otp/send-verification-otp")
+        .send({ email: testEmail, type: "sign-in" });
+
+      expect(sendResponse.status).toBe(HttpStatus.OK);
+      expect(sendResponse.body.success).toBe(true);
+
+      // Step 2: Get OTP from database
+      const verification = await databaseService.verification.findFirst({
+        where: { identifier: `sign-in-otp-${testEmail}` },
+        orderBy: { createdAt: "desc" },
+      });
+
+      expect(verification?.value).toBeDefined();
+      const otp = verification?.value.split(":")[0];
+
+      // Step 3: Verify OTP and sign in
+      const verifyResponse = await request(app.getHttpServer())
+        .post("/auth/api/sign-in/email-otp")
+        .send({ email: testEmail, otp });
+
+      expect(verifyResponse.status).toBe(HttpStatus.OK);
+      expect(verifyResponse.body.token).toBeDefined();
+
+      // Extract session cookie
+      const cookies = verifyResponse.headers["set-cookie"];
+      expect(cookies).toBeDefined();
+      const sessionCookie = Array.isArray(cookies) ? cookies.join("; ") : cookies;
+
+      // Step 4: Access session endpoint with cookie
+      const sessionResponse = await request(app.getHttpServer())
+        .get("/auth/session")
+        .set("Cookie", sessionCookie);
+
+      expect(sessionResponse.status).toBe(HttpStatus.OK);
+      expect(sessionResponse.body.user).toBeDefined();
+      expect(sessionResponse.body.user.email).toBe(testEmail);
+      expect(sessionResponse.body.session).toBeDefined();
+      expect(sessionResponse.body.session.userId).toBe(sessionResponse.body.user.id);
+    });
+  });
+
+  describe("Rate limiting", () => {
+    beforeEach(async () => {
+      // Clear rate limits to start fresh for rate limit tests
+      await clearRateLimits();
+    });
+
+    it("should enforce rate limiting on OTP send endpoint", async () => {
+      const rateLimitEmail = uniqueEmail("rate-limit");
+
+      // Send multiple requests sequentially to same email
+      // Rate limit is 5 requests per 60 seconds for this endpoint
+      const responses: request.Response[] = [];
+      for (let i = 0; i < 7; i++) {
+        const response = await request(app.getHttpServer())
+          .post("/auth/api/email-otp/send-verification-otp")
+          .send({ email: rateLimitEmail, type: "sign-in" });
+        responses.push(response);
+      }
+
+      // First 5 should succeed, the rest should be rate limited
+      const successCount = responses.filter((r) => r.status === HttpStatus.OK).length;
+      const rateLimitedCount = responses.filter(
+        (r) => r.status === HttpStatus.TOO_MANY_REQUESTS,
+      ).length;
+
+      expect(successCount).toBe(5);
+      expect(rateLimitedCount).toBe(2);
+    });
+  });
+});

--- a/test/e2e.setup.ts
+++ b/test/e2e.setup.ts
@@ -46,16 +46,18 @@ export async function setup() {
       throw error;
     }
 
-    console.log("Running Prisma migrations on test database...");
+    console.log("Pushing Prisma schema to test database...");
 
     try {
-      execSync("npx prisma migrate deploy", {
+      // Use db push for e2e tests since it syncs the full schema without requiring migrations
+      // This ensures all tables (including auth tables) are created regardless of migration state
+      execSync("npx prisma db push --skip-generate", {
         env: prismaEnv,
         stdio: "inherit",
       });
-      console.log("Prisma migrations completed successfully");
+      console.log("Prisma schema push completed successfully");
     } catch (error) {
-      console.error("Prisma migration failed:", error);
+      console.error("Prisma schema push failed:", error);
       throw error;
     }
 


### PR DESCRIPTION
- Add auth e2e tests covering session, OTP send/verify, and rate limiting
- Fix Better Auth basePath to match NestJS controller routing (/auth/api)
- Enable rate limiting in auth config
- Fix global throttler issue: move JobThrottlerGuard from APP_GUARD to controller-level
- Update e2e setup to use prisma db push for full schema sync
- Add auth env vars to .env.e2e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Adds comprehensive auth E2E coverage and aligns auth routes/config**
> 
> - New tests for `GET /auth/session`, OTP send/verify flows, and rate limiting; uses Testcontainers and validates DB records
> - Auth config: set `basePath` to `/auth/api`, introduce `enableRateLimit` flag (used in service), and keep DB-backed rate limits
> - Job throttling: apply `JobThrottlerGuard` at controller level (remove global APP_GUARD); update unit tests to mock throttler deps
> - E2E setup: switch Prisma migrations to `npx prisma db push` for full schema sync; add auth env vars to `.env.e2e`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95354ac03832e543ad7be055f0877bbea85a803b. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->