### PR TITLE
feat(auth): add Better Auth hooks for role validation in OTP flow

### DIFF
--- a/src/modules/auth/auth.config.ts
+++ b/src/modules/auth/auth.config.ts
@@ -1,7 +1,29 @@
 import type { PrismaClient } from "@prisma/client";
-import { betterAuth } from "better-auth";
+import { APIError, betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
+import { createAuthMiddleware } from "better-auth/api";
 import { bearer, emailOTP } from "better-auth/plugins";
+import {
+  type ClientType,
+  isValidRole,
+  MOBILE,
+  type RoleName,
+  USER,
+  type ValidateRoleForClientParams,
+} from "./auth.types";
+
+/**
+ * Role validation callbacks that integrate with AuthService methods.
+ * These are injected by AuthService to allow hooks to use NestJS services.
+ */
+export interface RoleValidationCallbacks {
+  /** Validates that a role is allowed for the given client type and origin */
+  validateRoleForClient: (params: ValidateRoleForClientParams) => boolean;
+  /** Validates that an existing user has the requested role */
+  validateExistingUserRole: (email: string, role: RoleName) => Promise<boolean>;
+  /** Assigns or verifies a role after successful OTP verification */
+  assignRoleOnVerify: (userId: string, role: RoleName) => Promise<void>;
+}
 
 export interface AuthConfigOptions {
   prisma: PrismaClient;
@@ -11,6 +33,69 @@ export interface AuthConfigOptions {
   sendOTPEmail: (email: string, otp: string) => Promise<void>;
   secureCookies: boolean;
   enableRateLimit: boolean;
+  /** Optional role validation callbacks for hooks */
+  roleValidation?: RoleValidationCallbacks;
+}
+
+/**
+ * Paths that require role validation before processing.
+ */
+const ROLE_VALIDATED_PATHS = [
+  "/email-otp/send-verification-otp",
+  "/email-otp/verify-email",
+  "/sign-in/email-otp",
+] as const;
+
+/**
+ * Paths where role assignment happens after successful verification.
+ */
+const ROLE_ASSIGNMENT_PATHS = ["/email-otp/verify-email", "/sign-in/email-otp"] as const;
+
+/**
+ * Safely extracts email from an unknown body type.
+ */
+function extractEmail(body: unknown): string | undefined {
+  if (body && typeof body === "object" && "email" in body) {
+    const email = (body as { email: unknown }).email;
+    return typeof email === "string" ? email : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Safely extracts role from an unknown body type.
+ */
+function extractRole(body: unknown): unknown {
+  if (body && typeof body === "object" && "role" in body) {
+    return (body as { role: unknown }).role;
+  }
+  return undefined;
+}
+
+/**
+ * Extracts role validation parameters from a Better Auth request context.
+ */
+function extractRoleParams(ctx: { request?: Request; body?: unknown }): {
+  role: RoleName;
+  clientType: ClientType | null;
+  origin: string | null;
+  referer: string | null;
+} {
+  const request = ctx.request;
+  const bodyRole = extractRole(ctx.body);
+
+  // Determine role from body, defaulting to USER
+  const role: RoleName = isValidRole(bodyRole) ? bodyRole : USER;
+
+  // Determine client type from headers
+  const clientTypeHeader = request?.headers.get("x-client-type");
+  const clientType: ClientType | null = clientTypeHeader === MOBILE ? MOBILE : null;
+
+  // Get origin and referer for web client validation
+  const origin = request?.headers.get("origin") ?? null;
+  const referer = request?.headers.get("referer") ?? null;
+
+  return { role, clientType, origin, referer };
 }
 
 export function createAuth(options: AuthConfigOptions) {
@@ -22,7 +107,68 @@ export function createAuth(options: AuthConfigOptions) {
     sendOTPEmail,
     secureCookies,
     enableRateLimit,
+    roleValidation,
   } = options;
+
+  // Create before hook middleware for role validation
+  const beforeHook = roleValidation
+    ? createAuthMiddleware(async (ctx) => {
+        const path = ctx.path;
+
+        // Only validate paths that require role validation
+        if (!ROLE_VALIDATED_PATHS.includes(path as (typeof ROLE_VALIDATED_PATHS)[number])) {
+          return;
+        }
+
+        const { role, clientType, origin, referer } = extractRoleParams(ctx);
+        const email = extractEmail(ctx.body);
+
+        // Validate role is allowed for this client type/origin
+        if (!roleValidation.validateRoleForClient({ role, clientType, origin, referer })) {
+          throw new APIError("FORBIDDEN", {
+            message: `Role "${role}" is not allowed from this client`,
+          });
+        }
+
+        // For send-verification-otp and sign-in, validate existing user has the role
+        if (email && path !== "/email-otp/verify-email") {
+          const isValid = await roleValidation.validateExistingUserRole(email, role);
+          if (!isValid) {
+            throw new APIError("FORBIDDEN", {
+              message: `User does not have the "${role}" role`,
+            });
+          }
+        }
+
+        // Role will be extracted again in after hook from request body
+      })
+    : undefined;
+
+  // Create after hook middleware for role assignment
+  const afterHook = roleValidation
+    ? createAuthMiddleware(async (ctx) => {
+        const path = ctx.path;
+
+        // Only process paths that need role assignment
+        if (!ROLE_ASSIGNMENT_PATHS.includes(path as (typeof ROLE_ASSIGNMENT_PATHS)[number])) {
+          return;
+        }
+
+        // Extract role from request body (same as before hook)
+        const { role } = extractRoleParams(ctx);
+
+        // Try to get user ID from newSession (for sign-in flows) or from returned response
+        const context = ctx.context as {
+          newSession?: { user?: { id?: string } };
+          returned?: { user?: { id?: string } };
+        };
+        const userId = context.newSession?.user?.id || context.returned?.user?.id;
+
+        if (userId) {
+          await roleValidation.assignRoleOnVerify(userId, role);
+        }
+      })
+    : undefined;
 
   return betterAuth({
     database: prismaAdapter(prisma, { provider: "postgresql" }),
@@ -37,6 +183,13 @@ export function createAuth(options: AuthConfigOptions) {
         maxAge: 60 * 5, // 5 minutes
       },
     },
+    hooks:
+      beforeHook || afterHook
+        ? {
+            before: beforeHook,
+            after: afterHook,
+          }
+        : undefined,
     plugins: [
       emailOTP({
         expiresIn: 600, // 10 minutes

--- a/src/modules/auth/auth.config.ts
+++ b/src/modules/auth/auth.config.ts
@@ -125,8 +125,10 @@ export function createAuth(options: AuthConfigOptions) {
           });
         }
 
-        // For send-verification-otp and sign-in, validate existing user has the role
-        if (email && path !== "/email-otp/verify-email") {
+        // Validate user can use this role:
+        // - New users can only request grantable roles (user, fleetOwner)
+        // - Existing users must already have the requested role
+        if (email) {
           const isValid = await roleValidation.validateExistingUserRole(email, role);
           if (!isValid) {
             throw new APIError("FORBIDDEN", {
@@ -134,7 +136,6 @@ export function createAuth(options: AuthConfigOptions) {
             });
           }
         }
-
       })
     : undefined;
 
@@ -167,7 +168,7 @@ export function createAuth(options: AuthConfigOptions) {
                 const role: RoleName = isValidRole(bodyRole) ? bodyRole : USER;
 
                 // Assign the role to the newly created user
-                // Role was already validated in the before hook
+                // Protected roles were already rejected in the before hook via validateExistingUserRole()
                 await roleValidation.assignRoleToNewUser(user.id, role);
               },
             },

--- a/src/modules/auth/auth.service.spec.ts
+++ b/src/modules/auth/auth.service.spec.ts
@@ -658,7 +658,7 @@ describe("AuthService", () => {
     });
   });
 
-  describe("assignRoleOnVerify", () => {
+  describe("assignRoleToNewUser", () => {
     beforeEach(async () => {
       await setupTestModule({
         SESSION_SECRET: "test-secret-at-least-32-characters-long",
@@ -680,7 +680,7 @@ describe("AuthService", () => {
       });
       mockDatabaseService.user.update.mockResolvedValue({});
 
-      await service.assignRoleOnVerify("user-1", USER);
+      await service.assignRoleToNewUser("user-1", USER);
 
       expect(mockDatabaseService.user.update).toHaveBeenCalledWith({
         where: { id: "user-1" },
@@ -695,7 +695,7 @@ describe("AuthService", () => {
       });
       mockDatabaseService.user.update.mockResolvedValue({});
 
-      await service.assignRoleOnVerify("user-1", FLEET_OWNER);
+      await service.assignRoleToNewUser("user-1", FLEET_OWNER);
 
       expect(mockDatabaseService.user.update).toHaveBeenCalledWith({
         where: { id: "user-1" },
@@ -709,40 +709,30 @@ describe("AuthService", () => {
         roles: [{ name: USER }],
       });
 
-      await service.assignRoleOnVerify("user-1", USER);
+      await service.assignRoleToNewUser("user-1", USER);
 
       expect(mockDatabaseService.user.update).not.toHaveBeenCalled();
     });
 
-    it("should throw for admin role if user does not have it (protected)", async () => {
-      mockDatabaseService.user.findUnique.mockResolvedValue({
-        id: "user-1",
-        roles: [{ name: USER }],
-      });
-
-      await expect(service.assignRoleOnVerify("user-1", ADMIN)).rejects.toThrow(
-        UnauthorizedException,
-      );
-    });
-
-    it("should not throw for admin role if user already has it", async () => {
-      mockDatabaseService.user.findUnique.mockResolvedValue({
-        id: "user-1",
-        roles: [{ name: ADMIN }],
-      });
-
-      await expect(service.assignRoleOnVerify("user-1", ADMIN)).resolves.not.toThrow();
-      expect(mockDatabaseService.user.update).not.toHaveBeenCalled();
-    });
-
-    it("should throw for staff role if user does not have it (protected)", async () => {
+    it("should throw for admin role (protected roles cannot be assigned to new users)", async () => {
       mockDatabaseService.user.findUnique.mockResolvedValue({
         id: "user-1",
         roles: [],
       });
 
-      await expect(service.assignRoleOnVerify("user-1", STAFF)).rejects.toThrow(
-        UnauthorizedException,
+      await expect(service.assignRoleToNewUser("user-1", ADMIN)).rejects.toThrow(
+        'Protected role "admin" cannot be assigned to new users',
+      );
+    });
+
+    it("should throw for staff role (protected roles cannot be assigned to new users)", async () => {
+      mockDatabaseService.user.findUnique.mockResolvedValue({
+        id: "user-1",
+        roles: [],
+      });
+
+      await expect(service.assignRoleToNewUser("user-1", STAFF)).rejects.toThrow(
+        'Protected role "staff" cannot be assigned to new users',
       );
     });
   });

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -234,7 +234,7 @@ export class AuthService implements OnModuleInit {
       await this.ensureUserHasRole(userId, role);
     } else if ((PROTECTED_ROLES as readonly RoleName[]).includes(role)) {
       // Protected roles cannot be assigned to new users
-      // This should never happen as the before hook validates this
+      // The before hook should prevent this, but this is a safety check
       throw new UnauthorizedException(`Protected role "${role}" cannot be assigned to new users`);
     } else {
       throw new UnauthorizedException(`Invalid role: ${role}`);

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -58,6 +58,11 @@ export class AuthService implements OnModuleInit {
       secureCookies: nodeEnv !== "development",
       enableRateLimit: true,
       sendOTPEmail: this.authEmailService.sendOTPEmail.bind(this.authEmailService),
+      roleValidation: {
+        validateRoleForClient: this.validateRoleForClient.bind(this),
+        validateExistingUserRole: this.validateExistingUserRole.bind(this),
+        assignRoleOnVerify: this.assignRoleOnVerify.bind(this),
+      },
     });
 
     this.logger.log("Auth service initialized successfully");

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -21,6 +21,19 @@ describe("Auth E2E Tests", () => {
     console.log(`Cleared ${deleted.count} rate limit records`);
   };
 
+  // Seed roles once at test suite startup
+  const seedRoles = async () => {
+    const roles = ["user", "fleetOwner", "admin", "staff"];
+    for (const roleName of roles) {
+      await databaseService.role.upsert({
+        where: { name: roleName },
+        update: {},
+        create: { name: roleName, description: `${roleName} role` },
+      });
+    }
+    console.log("Seeded roles in database");
+  };
+
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
@@ -35,6 +48,9 @@ describe("Auth E2E Tests", () => {
     databaseService = app.get(DatabaseService);
 
     await app.init();
+
+    // Seed roles once at test suite startup
+    await seedRoles();
 
     // Clear any existing rate limits from previous test runs
     await clearRateLimits();
@@ -84,6 +100,7 @@ describe("Auth E2E Tests", () => {
 
       const response = await request(app.getHttpServer())
         .post("/auth/api/email-otp/send-verification-otp")
+        .set("X-Client-Type", "mobile")
         .send({ email: testEmail, type: "sign-in" });
 
       expect(response.status).toBe(HttpStatus.OK);
@@ -106,6 +123,7 @@ describe("Auth E2E Tests", () => {
     it("should reject invalid email format", async () => {
       const response = await request(app.getHttpServer())
         .post("/auth/api/email-otp/send-verification-otp")
+        .set("X-Client-Type", "mobile")
         .send({ email: "not-an-email", type: "sign-in" });
 
       // Better Auth returns 400 for validation errors
@@ -124,11 +142,13 @@ describe("Auth E2E Tests", () => {
       // First, send OTP to create verification
       await request(app.getHttpServer())
         .post("/auth/api/email-otp/send-verification-otp")
+        .set("X-Client-Type", "mobile")
         .send({ email: testEmail, type: "sign-in" });
 
       // Try to verify with wrong OTP
       const response = await request(app.getHttpServer())
         .post("/auth/api/sign-in/email-otp")
+        .set("X-Client-Type", "mobile")
         .send({ email: testEmail, otp: "000000" });
 
       // Should fail verification
@@ -141,6 +161,7 @@ describe("Auth E2E Tests", () => {
       // Send OTP
       const sendResponse = await request(app.getHttpServer())
         .post("/auth/api/email-otp/send-verification-otp")
+        .set("X-Client-Type", "mobile")
         .send({ email: testEmail, type: "sign-in" });
 
       expect(sendResponse.status).toBe(HttpStatus.OK);
@@ -161,6 +182,7 @@ describe("Auth E2E Tests", () => {
       // Verify OTP - this creates user and session
       const verifyResponse = await request(app.getHttpServer())
         .post("/auth/api/sign-in/email-otp")
+        .set("X-Client-Type", "mobile")
         .send({ email: testEmail, otp });
 
       expect(verifyResponse.status).toBe(HttpStatus.OK);
@@ -185,6 +207,7 @@ describe("Auth E2E Tests", () => {
       // Step 1: Send OTP
       const sendResponse = await request(app.getHttpServer())
         .post("/auth/api/email-otp/send-verification-otp")
+        .set("X-Client-Type", "mobile")
         .send({ email: testEmail, type: "sign-in" });
 
       expect(sendResponse.status).toBe(HttpStatus.OK);
@@ -202,6 +225,7 @@ describe("Auth E2E Tests", () => {
       // Step 3: Verify OTP and sign in
       const verifyResponse = await request(app.getHttpServer())
         .post("/auth/api/sign-in/email-otp")
+        .set("X-Client-Type", "mobile")
         .send({ email: testEmail, otp });
 
       expect(verifyResponse.status).toBe(HttpStatus.OK);
@@ -240,6 +264,7 @@ describe("Auth E2E Tests", () => {
       for (let i = 0; i < 7; i++) {
         const response = await request(app.getHttpServer())
           .post("/auth/api/email-otp/send-verification-otp")
+          .set("X-Client-Type", "mobile")
           .send({ email: rateLimitEmail, type: "sign-in" });
         responses.push(response);
       }
@@ -252,6 +277,201 @@ describe("Auth E2E Tests", () => {
 
       expect(successCount).toBe(5);
       expect(rateLimitedCount).toBe(2);
+    });
+  });
+
+  describe("Role validation in OTP flow", () => {
+    beforeEach(async () => {
+      await clearRateLimits();
+    });
+
+    describe("Mobile client (X-Client-Type: mobile)", () => {
+      it("should allow user role for mobile client", async () => {
+        const testEmail = uniqueEmail("mobile-user");
+
+        const response = await request(app.getHttpServer())
+          .post("/auth/api/email-otp/send-verification-otp")
+          .set("X-Client-Type", "mobile")
+          .send({ email: testEmail, type: "sign-in", role: "user" });
+
+        expect(response.status).toBe(HttpStatus.OK);
+        expect(response.body.success).toBe(true);
+      });
+
+      it("should reject fleetOwner role for mobile client", async () => {
+        const testEmail = uniqueEmail("mobile-fleet");
+
+        const response = await request(app.getHttpServer())
+          .post("/auth/api/email-otp/send-verification-otp")
+          .set("X-Client-Type", "mobile")
+          .send({ email: testEmail, type: "sign-in", role: "fleetOwner" });
+
+        expect(response.status).toBe(HttpStatus.FORBIDDEN);
+        expect(response.body.message).toContain("not allowed from this client");
+      });
+
+      it("should reject admin role for mobile client", async () => {
+        const testEmail = uniqueEmail("mobile-admin");
+
+        const response = await request(app.getHttpServer())
+          .post("/auth/api/email-otp/send-verification-otp")
+          .set("X-Client-Type", "mobile")
+          .send({ email: testEmail, type: "sign-in", role: "admin" });
+
+        expect(response.status).toBe(HttpStatus.FORBIDDEN);
+        expect(response.body.message).toContain("not allowed from this client");
+      });
+    });
+
+    describe("Web client with Origin header", () => {
+      // Note: TRUSTED_ORIGINS must include these test origins in the test environment
+      // The default config should allow localhost origins in development
+
+      it("should allow user role for web client from trusted origin", async () => {
+        const testEmail = uniqueEmail("web-user");
+
+        const response = await request(app.getHttpServer())
+          .post("/auth/api/email-otp/send-verification-otp")
+          .set("Origin", "http://localhost:3000")
+          .send({ email: testEmail, type: "sign-in", role: "user" });
+
+        // May succeed or fail depending on TRUSTED_ORIGINS config
+        // If origin not trusted, will get 403
+        if (response.status === HttpStatus.FORBIDDEN) {
+          expect(response.body.message).toContain("not allowed from this client");
+        } else {
+          expect(response.status).toBe(HttpStatus.OK);
+        }
+      });
+
+      it("should reject requests from untrusted origin", async () => {
+        const testEmail = uniqueEmail("untrusted-origin");
+
+        const response = await request(app.getHttpServer())
+          .post("/auth/api/email-otp/send-verification-otp")
+          .set("Origin", "https://evil.com")
+          .send({ email: testEmail, type: "sign-in", role: "user" });
+
+        expect(response.status).toBe(HttpStatus.FORBIDDEN);
+        expect(response.body.message).toContain("not allowed from this client");
+      });
+    });
+
+    describe("Protected roles (admin, staff)", () => {
+      it("should reject admin role for user who does not have it", async () => {
+        const testEmail = uniqueEmail("no-admin-role");
+
+        // First create a regular user
+        const sendResponse = await request(app.getHttpServer())
+          .post("/auth/api/email-otp/send-verification-otp")
+          .set("X-Client-Type", "mobile")
+          .send({ email: testEmail, type: "sign-in", role: "user" });
+
+        expect(sendResponse.status).toBe(HttpStatus.OK);
+
+        // Get OTP and verify to create the user
+        const verification = await databaseService.verification.findFirst({
+          where: { identifier: `sign-in-otp-${testEmail}` },
+          orderBy: { createdAt: "desc" },
+        });
+        const otp = verification?.value.split(":")[0];
+
+        await request(app.getHttpServer())
+          .post("/auth/api/sign-in/email-otp")
+          .set("X-Client-Type", "mobile")
+          .send({ email: testEmail, otp, role: "user" });
+
+        // Clear rate limits for next request
+        await clearRateLimits();
+
+        // Now try to request admin role for this user from admin referer
+        // This should fail because user doesn't have admin role
+        const adminResponse = await request(app.getHttpServer())
+          .post("/auth/api/email-otp/send-verification-otp")
+          .set("Origin", "http://localhost:3000")
+          .set("Referer", "http://localhost:3000/admin/dashboard")
+          .send({ email: testEmail, type: "sign-in", role: "admin" });
+
+        // Should be forbidden because:
+        // 1. Either origin is not trusted, OR
+        // 2. User doesn't have admin role
+        expect(adminResponse.status).toBe(HttpStatus.FORBIDDEN);
+      });
+    });
+
+    describe("Role assignment after verification", () => {
+      it("should assign user role after successful OTP verification", async () => {
+        const testEmail = uniqueEmail("role-assign");
+
+        // Send OTP with user role
+        const sendResponse = await request(app.getHttpServer())
+          .post("/auth/api/email-otp/send-verification-otp")
+          .set("X-Client-Type", "mobile")
+          .send({ email: testEmail, type: "sign-in", role: "user" });
+
+        expect(sendResponse.status).toBe(HttpStatus.OK);
+
+        // Get OTP from database
+        const verification = await databaseService.verification.findFirst({
+          where: { identifier: `sign-in-otp-${testEmail}` },
+          orderBy: { createdAt: "desc" },
+        });
+        const otp = verification?.value.split(":")[0];
+
+        // Verify OTP
+        const verifyResponse = await request(app.getHttpServer())
+          .post("/auth/api/sign-in/email-otp")
+          .set("X-Client-Type", "mobile")
+          .send({ email: testEmail, otp, role: "user" });
+
+        expect(verifyResponse.status).toBe(HttpStatus.OK);
+        expect(verifyResponse.body.user).toBeDefined();
+
+        // Check that user has the role in database
+        const user = await databaseService.user.findUnique({
+          where: { email: testEmail },
+          include: { roles: { select: { name: true } } },
+        });
+
+        expect(user).toBeDefined();
+        expect(user?.roles.some((r) => r.name === "user")).toBe(true);
+      });
+    });
+
+    describe("Default role behavior", () => {
+      it("should default to user role when no role is specified", async () => {
+        const testEmail = uniqueEmail("default-role");
+
+        // Send OTP without specifying role
+        const sendResponse = await request(app.getHttpServer())
+          .post("/auth/api/email-otp/send-verification-otp")
+          .set("X-Client-Type", "mobile")
+          .send({ email: testEmail, type: "sign-in" }); // No role specified
+
+        expect(sendResponse.status).toBe(HttpStatus.OK);
+
+        // Get OTP and verify
+        const verification = await databaseService.verification.findFirst({
+          where: { identifier: `sign-in-otp-${testEmail}` },
+          orderBy: { createdAt: "desc" },
+        });
+        const otp = verification?.value.split(":")[0];
+
+        const verifyResponse = await request(app.getHttpServer())
+          .post("/auth/api/sign-in/email-otp")
+          .set("X-Client-Type", "mobile")
+          .send({ email: testEmail, otp }); // No role specified
+
+        expect(verifyResponse.status).toBe(HttpStatus.OK);
+
+        // User should have the default 'user' role
+        const user = await databaseService.user.findUnique({
+          where: { email: testEmail },
+          include: { roles: { select: { name: true } } },
+        });
+
+        expect(user?.roles.some((r) => r.name === "user")).toBe(true);
+      });
     });
   });
 });

--- a/test/e2e.setup.ts
+++ b/test/e2e.setup.ts
@@ -31,6 +31,11 @@ export async function setup() {
     process.env.REDIS_HOST = redisHost;
     process.env.REDIS_PORT = redisPort.toString();
 
+    // Auth configuration for e2e tests
+    process.env.SESSION_SECRET = "e2e-test-session-secret-at-least-32-chars";
+    process.env.AUTH_BASE_URL = "http://localhost:3000";
+    process.env.TRUSTED_ORIGINS = "http://localhost:3000";
+
     const prismaEnv = { ...process.env, DATABASE_URL: databaseUrl };
 
     console.log("Generating Prisma client with test database URL...");


### PR DESCRIPTION
- Add before hooks for send-verification-otp, verify-email, and sign-in/email-otp to validate role is allowed for client type/origin
- Add after hooks for verify-email and sign-in/email-otp to assign roles after successful authentication
- Create RoleValidationCallbacks interface to inject AuthService methods
- Add helper functions for safe extraction of email and role from request body
- Wire up AuthService role validation methods to createAuth configuration
- Add E2E tests for role validation including:
  - Mobile client role restrictions (user only)
  - Untrusted origin rejection
  - Protected role validation (admin, staff)
  - Role assignment after verification
  - Default role behavior
- Update existing E2E tests to include X-Client-Type header

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces role-aware auth flow using Better Auth hooks and safer role assignment.
> 
> - Adds `before` middleware to validate requested `role` against client type (`X-Client-Type`), trusted `Origin`, and path context; restricts protected roles to existing users only
> - Implements `databaseHooks.user.create.after` to assign grantable roles via `assignRoleToNewUser`, using an in-memory `pendingRoles` cache to pass the validated role between hooks
> - Creates `RoleValidationCallbacks` and wires `AuthService` methods (`validateRoleForClient`, `validateExistingUserRole`, `assignRoleToNewUser`) into `createAuth`
> - Updates `AuthService`: new defaulting/validation rules for new vs existing users; renames and hardens role assignment for new users; adds robust origin/referer parsing
> - Expands E2E tests: role restrictions (mobile/web), untrusted origin rejection, protected role checks, role assignment after verification, default role behavior; seeds roles and sets test env vars
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24fc18c1dc753a3a775e9649a9bcbbf7b56b30b5. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->