### PR TITLE
feat(auth): add session roles & RBAC guards with sign-in enrichment

### DIFF
--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -4,12 +4,13 @@ import { NotificationModule } from "../notification/notification.module";
 import { AuthController } from "./auth.controller";
 import { AuthService } from "./auth.service";
 import { AuthEmailService } from "./auth-email.service";
+import { RoleGuard } from "./guards/role.guard";
 import { SessionGuard } from "./guards/session.guard";
 
 @Module({
   imports: [DatabaseModule, NotificationModule],
   controllers: [AuthController],
-  providers: [AuthService, AuthEmailService, SessionGuard],
-  exports: [AuthService, SessionGuard],
+  providers: [AuthService, AuthEmailService, SessionGuard, RoleGuard],
+  exports: [AuthService, SessionGuard, RoleGuard],
 })
 export class AuthModule {}

--- a/src/modules/auth/auth.service.spec.ts
+++ b/src/modules/auth/auth.service.spec.ts
@@ -889,4 +889,49 @@ describe("AuthService", () => {
       );
     });
   });
+
+  describe("getUserRoles", () => {
+    beforeEach(async () => {
+      await setupTestModule({
+        SESSION_SECRET: "test-secret-at-least-32-characters-long",
+        AUTH_BASE_URL: "https://api.example.com",
+        TRUSTED_ORIGINS: ["https://example.com"],
+        NODE_ENV: "production",
+      });
+
+      mockDatabaseService.user = {
+        findUnique: vi.fn(),
+      };
+    });
+
+    it("should return empty array if user not found", async () => {
+      mockDatabaseService.user.findUnique.mockResolvedValue(null);
+
+      const roles = await service.getUserRoles("nonexistent");
+
+      expect(roles).toEqual([]);
+    });
+
+    it("should return user roles", async () => {
+      mockDatabaseService.user.findUnique.mockResolvedValue({
+        id: "user-1",
+        roles: [{ name: USER }, { name: ADMIN }],
+      });
+
+      const roles = await service.getUserRoles("user-1");
+
+      expect(roles).toEqual([USER, ADMIN]);
+    });
+
+    it("should return empty array if user has no roles", async () => {
+      mockDatabaseService.user.findUnique.mockResolvedValue({
+        id: "user-1",
+        roles: [],
+      });
+
+      const roles = await service.getUserRoles("user-1");
+
+      expect(roles).toEqual([]);
+    });
+  });
 });

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -62,6 +62,7 @@ export class AuthService implements OnModuleInit {
         validateRoleForClient: this.validateRoleForClient.bind(this),
         validateExistingUserRole: this.validateExistingUserRole.bind(this),
         assignRoleToNewUser: this.assignRoleToNewUser.bind(this),
+        getUserRoles: this.getUserRoles.bind(this),
       },
     });
 
@@ -290,5 +291,24 @@ export class AuthService implements OnModuleInit {
       this.logger.warn(`User ${userId} does not have required role: ${role}`);
       throw new UnauthorizedException(`User does not have required role: ${role}`);
     }
+  }
+
+  /**
+   * Gets all roles for a user.
+   *
+   * @param userId - User's ID
+   * @returns Array of role names, empty array if user not found
+   */
+  async getUserRoles(userId: string): Promise<RoleName[]> {
+    const user = await this.databaseService.user.findUnique({
+      where: { id: userId },
+      include: { roles: { select: { name: true } } },
+    });
+
+    if (!user) {
+      return [];
+    }
+
+    return user.roles.map((r) => r.name as RoleName);
   }
 }

--- a/src/modules/auth/decorators/current-user.decorator.spec.ts
+++ b/src/modules/auth/decorators/current-user.decorator.spec.ts
@@ -6,7 +6,7 @@ import { AUTH_SESSION_KEY, AuthSession } from "../guards/session.guard";
 import { CurrentUser } from "./current-user.decorator";
 
 describe("CurrentUser Decorator", () => {
-  const mockUser: User = {
+  const mockUser: AuthSession["user"] = {
     id: "user-123",
     email: "test@example.com",
     name: "Test User",
@@ -14,6 +14,7 @@ describe("CurrentUser Decorator", () => {
     image: null,
     createdAt: new Date(),
     updatedAt: new Date(),
+    roles: ["user"],
   };
 
   const mockSessionData: Session = {

--- a/src/modules/auth/decorators/roles.decorator.ts
+++ b/src/modules/auth/decorators/roles.decorator.ts
@@ -1,0 +1,24 @@
+import { SetMetadata } from "@nestjs/common";
+import type { RoleName } from "../auth.types";
+
+export const ROLES_KEY = "roles";
+
+/**
+ * Decorator to specify which roles are allowed to access a route.
+ *
+ * Must be used with RoleGuard to enforce the role requirement.
+ * RoleGuard must be used AFTER SessionGuard to ensure the session is validated first.
+ *
+ * Usage:
+ * ```typescript
+ * @UseGuards(SessionGuard, RoleGuard)
+ * @Roles('admin', 'staff')
+ * @Get('admin/dashboard')
+ * getAdminDashboard() {
+ *   return { message: 'Admin dashboard' };
+ * }
+ * ```
+ *
+ * @param roles - One or more role names that are allowed to access the route
+ */
+export const Roles = (...roles: RoleName[]) => SetMetadata(ROLES_KEY, roles);

--- a/src/modules/auth/guards/role.guard.spec.ts
+++ b/src/modules/auth/guards/role.guard.spec.ts
@@ -1,0 +1,171 @@
+import { ExecutionContext, ForbiddenException } from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { Test, TestingModule } from "@nestjs/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RoleName } from "../auth.types";
+import { RoleGuard } from "./role.guard";
+import { AUTH_SESSION_KEY, type AuthSession } from "./session.guard";
+
+describe("RoleGuard", () => {
+  let guard: RoleGuard;
+  let reflector: Reflector;
+
+  const createMockSession = (roles: RoleName[]): AuthSession => ({
+    user: {
+      id: "user-123",
+      email: "test@example.com",
+      name: "Test User",
+      emailVerified: true,
+      image: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      roles,
+    },
+    session: {
+      id: "session-123",
+      userId: "user-123",
+      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      token: "token-123",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ipAddress: "127.0.0.1",
+      userAgent: "test-agent",
+    },
+  });
+
+  const createMockExecutionContext = (session?: AuthSession) => {
+    const mockRequest = { [AUTH_SESSION_KEY]: session };
+    return {
+      switchToHttp: () => ({
+        getRequest: () => mockRequest,
+      }),
+      getHandler: () => ({}),
+      getClass: () => ({}),
+    } as unknown as ExecutionContext;
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [RoleGuard, Reflector],
+    }).compile();
+
+    guard = module.get<RoleGuard>(RoleGuard);
+    reflector = module.get<Reflector>(Reflector);
+  });
+
+  it("should be defined", () => {
+    expect(guard).toBeDefined();
+  });
+
+  describe("when no roles are required", () => {
+    it("should allow access when @Roles decorator is not present", () => {
+      vi.spyOn(reflector, "getAllAndOverride").mockReturnValue(undefined);
+      const context = createMockExecutionContext(createMockSession(["user"]));
+
+      const result = guard.canActivate(context);
+
+      expect(result).toBe(true);
+    });
+
+    it("should allow access when @Roles decorator has empty array", () => {
+      vi.spyOn(reflector, "getAllAndOverride").mockReturnValue([]);
+      const context = createMockExecutionContext(createMockSession(["user"]));
+
+      const result = guard.canActivate(context);
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("when roles are required", () => {
+    it("should allow access when user has one of the required roles", () => {
+      vi.spyOn(reflector, "getAllAndOverride").mockReturnValue(["admin", "staff"]);
+      const context = createMockExecutionContext(createMockSession(["admin"]));
+
+      const result = guard.canActivate(context);
+
+      expect(result).toBe(true);
+    });
+
+    it("should allow access when user has multiple roles including required one", () => {
+      vi.spyOn(reflector, "getAllAndOverride").mockReturnValue(["admin"]);
+      const context = createMockExecutionContext(createMockSession(["user", "admin"]));
+
+      const result = guard.canActivate(context);
+
+      expect(result).toBe(true);
+    });
+
+    it("should deny access when user does not have any required role", () => {
+      vi.spyOn(reflector, "getAllAndOverride").mockReturnValue(["admin", "staff"]);
+      const context = createMockExecutionContext(createMockSession(["user"]));
+
+      expect(() => guard.canActivate(context)).toThrow(ForbiddenException);
+      expect(() => guard.canActivate(context)).toThrow(
+        "Access denied. Required roles: admin, staff",
+      );
+    });
+
+    it("should deny access when user has no roles", () => {
+      vi.spyOn(reflector, "getAllAndOverride").mockReturnValue(["admin"]);
+      const context = createMockExecutionContext(createMockSession([]));
+
+      expect(() => guard.canActivate(context)).toThrow(ForbiddenException);
+    });
+  });
+
+  describe("when session is missing", () => {
+    it("should throw ForbiddenException when session is not attached", () => {
+      vi.spyOn(reflector, "getAllAndOverride").mockReturnValue(["admin"]);
+      const context = createMockExecutionContext(undefined);
+
+      expect(() => guard.canActivate(context)).toThrow(ForbiddenException);
+      expect(() => guard.canActivate(context)).toThrow(
+        "Session not found. Ensure SessionGuard is used before RoleGuard.",
+      );
+    });
+  });
+
+  describe("role combinations", () => {
+    it("should allow fleetOwner to access fleet-owner routes", () => {
+      vi.spyOn(reflector, "getAllAndOverride").mockReturnValue(["fleetOwner"]);
+      const context = createMockExecutionContext(createMockSession(["fleetOwner"]));
+
+      const result = guard.canActivate(context);
+
+      expect(result).toBe(true);
+    });
+
+    it("should allow staff to access staff routes", () => {
+      vi.spyOn(reflector, "getAllAndOverride").mockReturnValue(["staff"]);
+      const context = createMockExecutionContext(createMockSession(["staff"]));
+
+      const result = guard.canActivate(context);
+
+      expect(result).toBe(true);
+    });
+
+    it("should allow admin to access admin-only routes", () => {
+      vi.spyOn(reflector, "getAllAndOverride").mockReturnValue(["admin"]);
+      const context = createMockExecutionContext(createMockSession(["admin"]));
+
+      const result = guard.canActivate(context);
+
+      expect(result).toBe(true);
+    });
+
+    it("should deny regular user access to admin routes", () => {
+      vi.spyOn(reflector, "getAllAndOverride").mockReturnValue(["admin"]);
+      const context = createMockExecutionContext(createMockSession(["user"]));
+
+      expect(() => guard.canActivate(context)).toThrow(ForbiddenException);
+    });
+
+    it("should deny fleetOwner access to admin routes", () => {
+      vi.spyOn(reflector, "getAllAndOverride").mockReturnValue(["admin"]);
+      const context = createMockExecutionContext(createMockSession(["fleetOwner"]));
+
+      expect(() => guard.canActivate(context)).toThrow(ForbiddenException);
+    });
+  });
+});

--- a/src/modules/auth/guards/role.guard.ts
+++ b/src/modules/auth/guards/role.guard.ts
@@ -1,0 +1,67 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import type { Request } from "express";
+import type { RoleName } from "../auth.types";
+import { ROLES_KEY } from "../decorators/roles.decorator";
+import { AUTH_SESSION_KEY, type AuthSession } from "./session.guard";
+
+/**
+ * Guard that enforces role-based access control (RBAC).
+ *
+ * IMPORTANT: This guard MUST be used AFTER SessionGuard, as it relies on
+ * the session being attached to the request by SessionGuard.
+ *
+ * Usage:
+ * ```typescript
+ * @UseGuards(SessionGuard, RoleGuard)
+ * @Roles('admin', 'staff')
+ * @Get('admin/dashboard')
+ * getAdminDashboard() {
+ *   return { message: 'Admin dashboard' };
+ * }
+ * ```
+ *
+ * If no @Roles() decorator is present, the guard allows access (authentication-only).
+ * If @Roles() is present, the user must have at least one of the specified roles.
+ */
+@Injectable()
+export class RoleGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    // Get required roles from the @Roles() decorator
+    const requiredRoles = this.reflector.getAllAndOverride<RoleName[] | undefined>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    // If no roles are required, allow access (authentication-only route)
+    if (!requiredRoles || requiredRoles.length === 0) {
+      return true;
+    }
+
+    // Get the session attached by SessionGuard
+    const request = context
+      .switchToHttp()
+      .getRequest<Request & { [AUTH_SESSION_KEY]?: AuthSession }>();
+    const authSession = request[AUTH_SESSION_KEY];
+
+    if (!authSession) {
+      // This should not happen if SessionGuard is used first
+      throw new ForbiddenException(
+        "Session not found. Ensure SessionGuard is used before RoleGuard.",
+      );
+    }
+
+    const userRoles = authSession.user.roles;
+
+    // Check if user has at least one of the required roles
+    const hasRole = requiredRoles.some((role) => userRoles.includes(role));
+
+    if (!hasRole) {
+      throw new ForbiddenException(`Access denied. Required roles: ${requiredRoles.join(", ")}`);
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION
- Add RoleGuard for role-based access control (RBAC)
- Add @Roles() decorator for protecting routes by role
- Update SessionGuard to include user roles in AuthSession
- Update /auth/session endpoint to return user with roles array
- Add an after hook plugin to enrich the sign-in response with roles
  - Eliminates the need for an extra /auth/session call after login
  - Sign-in response now includes user.roles directly
- Add getUserRoles() method to AuthService
- Add comprehensive unit tests for RoleGuard
- Add E2E tests for roles in sign-in response

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds role awareness across auth flows and introduces RBAC enforcement.
> 
> - New `getUserRoles` in `AuthService` and injected into `auth.config` hooks
> - After-hook plugin enriches `POST /auth/api/sign-in/email-otp` response with `user.roles`
> - `SessionGuard` now fetches roles and attaches them to `AuthSession.user`; `@CurrentUser` tests updated
> - `/auth/session` now returns `user` with `roles`
> - Introduces `RoleGuard` and `@Roles` decorator; `AuthModule` exports/registration updated
> - Extensive unit and E2E tests for role enrichment, guards, and session responses
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 874192ffb877802e0909f3bd67a420caa6c1737f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->