### PR TITLE
feat(flutterwave): add refund initiation method

### DIFF
--- a/src/modules/flutterwave/flutterwave.interface.ts
+++ b/src/modules/flutterwave/flutterwave.interface.ts
@@ -91,6 +91,34 @@ export interface FlutterwavePaymentLinkData {
   link: string;
 }
 
+// Refund Types
+export interface RefundOptions {
+  transactionId: string;
+  amount: number;
+  callbackUrl?: string;
+}
+
+export interface RefundResponse {
+  success: boolean;
+  refundId?: number;
+  amountRefunded?: number;
+  status?: string;
+  error?: string;
+}
+
+export interface FlutterwaveRefundData {
+  id: number;
+  account_id: number;
+  tx_id: number;
+  flw_ref: string;
+  wallet_id: number;
+  amount_refunded: number;
+  status: string;
+  destination: string;
+  meta: Record<string, unknown>;
+  created_at: string;
+}
+
 export class FlutterwaveError extends Error {
   constructor(
     message: string,


### PR DESCRIPTION
Add initiateRefund() to FlutterwaveService for processing payment refunds via Flutterwave API. Returns structured response with refund ID, amount refunded, and status.

Changes:
- Add RefundOptions, RefundResponse, FlutterwaveRefundData interfaces
- Implement initiateRefund() with optional callback URL support
- Handle success/failure responses and error cases gracefully
- Add 7 unit tests covering all scenarios

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds refund capability to the Flutterwave module with strict typing and robust handling.
> 
> - Implements `initiateRefund(options)` calling `POST /v3/transactions/{transactionId}/refund` with `amount` and optional `callback_url`, returning structured `RefundResponse`
> - Introduces `RefundOptions`, `RefundResponse`, and `FlutterwaveRefundData` interfaces
> - Integrates logging and error mapping (`FlutterwaveError`) for success/non-success and network/unknown failures
> - Adds unit tests covering success, callback URL inclusion, non-success/no-data responses, and error scenarios
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 038fccfcf188511a2dc0bdb67056f9219ff3afc5. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->