### PR TITLE
feat(payment): add Payment API endpoints with E2E tests

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -369,6 +369,7 @@ model Payment {
   lastVerifiedAt           DateTime?
   webhookPayload           Json?
   verificationResponse     Json?
+  refundIdempotencyKey     String?              @unique // Idempotency key for refund requests to prevent duplicate refunds
   booking                  Booking?             @relation("BookingCustomerPayments", fields: [bookingId], references: [id])
   extension                Extension?           @relation("ExtensionCustomerPayments", fields: [extensionId], references: [id])
 
@@ -582,6 +583,7 @@ enum PaymentAttemptStatus {
   REFUNDED
   REFUND_PROCESSING
   REFUND_FAILED
+  REFUND_ERROR // Network/unknown error during refund - needs reconciliation
   PARTIALLY_REFUNDED
 }
 

--- a/src/modules/flutterwave/flutterwave.interface.ts
+++ b/src/modules/flutterwave/flutterwave.interface.ts
@@ -96,6 +96,8 @@ export interface RefundOptions {
   transactionId: string;
   amount: number;
   callbackUrl?: string;
+  /** Idempotency key to prevent duplicate refunds on retry */
+  idempotencyKey: string;
 }
 
 export interface RefundResponse {

--- a/src/modules/flutterwave/flutterwave.service.spec.ts
+++ b/src/modules/flutterwave/flutterwave.service.spec.ts
@@ -36,7 +36,9 @@ describe("FlutterwaveService", () => {
       },
     };
 
-    vi.mocked(axios.create).mockReturnValue(mockAxiosInstance as unknown as ReturnType<typeof axios.create>);
+    vi.mocked(axios.create).mockReturnValue(
+      mockAxiosInstance as unknown as ReturnType<typeof axios.create>,
+    );
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -219,7 +221,9 @@ describe("FlutterwaveService", () => {
       await expect(service.createPaymentIntent(validOptions)).rejects.toThrow(FlutterwaveError);
 
       mockAxiosInstance.post.mockResolvedValue(mockResponse);
-      await expect(service.createPaymentIntent(validOptions)).rejects.toThrow("Invalid customer email");
+      await expect(service.createPaymentIntent(validOptions)).rejects.toThrow(
+        "Invalid customer email",
+      );
     });
 
     it("should throw FlutterwaveError when API returns success but no link", async () => {

--- a/src/modules/flutterwave/flutterwave.service.spec.ts
+++ b/src/modules/flutterwave/flutterwave.service.spec.ts
@@ -407,6 +407,7 @@ describe("FlutterwaveService", () => {
     const validRefundOptions: RefundOptions = {
       transactionId: "12345",
       amount: 5000,
+      idempotencyKey: "refund_payment-123_test-uuid",
     };
 
     it("should initiate refund successfully", async () => {
@@ -443,7 +444,11 @@ describe("FlutterwaveService", () => {
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         "/v3/transactions/12345/refund",
         { amount: 5000 },
-        undefined,
+        {
+          headers: {
+            "X-Idempotency-Key": "refund_payment-123_test-uuid",
+          },
+        },
       );
     });
 
@@ -482,7 +487,11 @@ describe("FlutterwaveService", () => {
           amount: 5000,
           callback_url: "https://example.com/refund-callback",
         },
-        undefined,
+        {
+          headers: {
+            "X-Idempotency-Key": "refund_payment-123_test-uuid",
+          },
+        },
       );
     });
 
@@ -536,25 +545,30 @@ describe("FlutterwaveService", () => {
       expect(result.error).toContain("Invalid transaction ID");
     });
 
-    it("should handle network errors", async () => {
-      // Network errors get wrapped by handleError with "Unexpected error:" prefix
-      const networkError = new Error("Network Error");
+    it("should throw network errors for caller to handle as uncertain state", async () => {
+      // Network errors should be thrown so caller can distinguish uncertain states
+      // from explicit rejections and handle appropriately (e.g., REFUND_ERROR vs REFUND_FAILED)
+      const networkError = new FlutterwaveError(
+        "Network error: Unable to reach Flutterwave servers",
+        "NETWORK_ERROR",
+      );
       mockAxiosInstance.post.mockRejectedValueOnce(networkError);
 
-      const result = await service.initiateRefund(validRefundOptions);
-
-      expect(result.success).toBe(false);
-      expect(result.error).toContain("Network Error");
+      await expect(service.initiateRefund(validRefundOptions)).rejects.toMatchObject({
+        message: "Network error: Unable to reach Flutterwave servers",
+        code: "NETWORK_ERROR",
+      });
     });
 
-    it("should handle unknown errors", async () => {
-      // Unknown errors get wrapped by handleError
-      mockAxiosInstance.post.mockRejectedValueOnce("Unknown error string");
+    it("should throw unknown errors for caller to handle as uncertain state", async () => {
+      // Unknown errors should be thrown wrapped as FlutterwaveError with UNEXPECTED_ERROR code
+      const unknownError = new Error("Something unexpected happened");
+      mockAxiosInstance.post.mockRejectedValueOnce(unknownError);
 
-      const result = await service.initiateRefund(validRefundOptions);
-
-      expect(result.success).toBe(false);
-      expect(result.error).toBeDefined();
+      await expect(service.initiateRefund(validRefundOptions)).rejects.toMatchObject({
+        message: expect.stringContaining("Something unexpected happened"),
+        code: "UNEXPECTED_ERROR",
+      });
     });
   });
 

--- a/src/modules/payment/dto/initialize-payment.dto.ts
+++ b/src/modules/payment/dto/initialize-payment.dto.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+// CUID pattern: starts with 'c', followed by 24 alphanumeric characters
+const cuidPattern = /^c[a-z0-9]{24}$/;
+
+export const initializePaymentSchema = z.object({
+  type: z.enum(["booking", "extension"]),
+  entityId: z.string().regex(cuidPattern, "Invalid entity ID format"),
+  amount: z.number().min(100, "Minimum amount is 100 NGN"),
+  callbackUrl: z.string().url("Invalid callback URL"),
+});
+
+export type InitializePaymentDto = z.infer<typeof initializePaymentSchema>;

--- a/src/modules/payment/dto/initialize-payment.dto.ts
+++ b/src/modules/payment/dto/initialize-payment.dto.ts
@@ -7,7 +7,7 @@ export const initializePaymentSchema = z.object({
   type: z.enum(["booking", "extension"]),
   entityId: z.string().regex(cuidPattern, "Invalid entity ID format"),
   amount: z.number().min(100, "Minimum amount is 100 NGN"),
-  callbackUrl: z.string().url("Invalid callback URL"),
+  callbackUrl: z.url("Invalid callback URL"),
 });
 
 export type InitializePaymentDto = z.infer<typeof initializePaymentSchema>;

--- a/src/modules/payment/dto/refund-payment.dto.ts
+++ b/src/modules/payment/dto/refund-payment.dto.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const refundPaymentSchema = z.object({
+  amount: z.number().min(100, "Minimum refund amount is 100 NGN"),
+  reason: z.string().optional(),
+});
+
+export type RefundPaymentDto = z.infer<typeof refundPaymentSchema>;

--- a/src/modules/payment/dto/zod-validation.pipe.ts
+++ b/src/modules/payment/dto/zod-validation.pipe.ts
@@ -1,0 +1,24 @@
+import { BadRequestException, PipeTransform } from "@nestjs/common";
+import type { ZodSchema } from "zod";
+
+export class ZodValidationPipe<T> implements PipeTransform<unknown, T> {
+  constructor(private readonly schema: ZodSchema<T>) {}
+
+  transform(value: unknown): T {
+    const result = this.schema.safeParse(value);
+
+    if (!result.success) {
+      // Zod v4 uses result.error.issues instead of result.error.errors
+      const errors = result.error.issues.map((issue) => ({
+        field: issue.path.join("."),
+        message: issue.message,
+      }));
+      throw new BadRequestException({
+        message: "Validation failed",
+        errors,
+      });
+    }
+
+    return result.data;
+  }
+}

--- a/src/modules/payment/dto/zod-validation.pipe.ts
+++ b/src/modules/payment/dto/zod-validation.pipe.ts
@@ -1,8 +1,8 @@
 import { BadRequestException, PipeTransform } from "@nestjs/common";
-import type { ZodSchema } from "zod";
+import type { z } from "zod";
 
 export class ZodValidationPipe<T> implements PipeTransform<unknown, T> {
-  constructor(private readonly schema: ZodSchema<T>) {}
+  constructor(private readonly schema: z.ZodType<T>) {}
 
   transform(value: unknown): T {
     const result = this.schema.safeParse(value);

--- a/src/modules/payment/payment-api.service.spec.ts
+++ b/src/modules/payment/payment-api.service.spec.ts
@@ -269,9 +269,9 @@ describe("PaymentApiService", () => {
     it("should throw NotFoundException when payment not found", async () => {
       vi.mocked(databaseService.payment.findFirst).mockResolvedValueOnce(null);
 
-      await expect(service.initiateRefund("invalid-ref", refundDto, mockUserInfo.id)).rejects.toThrow(
-        NotFoundException,
-      );
+      await expect(
+        service.initiateRefund("invalid-ref", refundDto, mockUserInfo.id),
+      ).rejects.toThrow(NotFoundException);
     });
 
     it("should throw BadRequestException when user does not own payment", async () => {
@@ -282,9 +282,9 @@ describe("PaymentApiService", () => {
 
       vi.mocked(databaseService.payment.findFirst).mockResolvedValueOnce(payment);
 
-      await expect(service.initiateRefund("tx-ref-123", refundDto, mockUserInfo.id)).rejects.toThrow(
-        BadRequestException,
-      );
+      await expect(
+        service.initiateRefund("tx-ref-123", refundDto, mockUserInfo.id),
+      ).rejects.toThrow(BadRequestException);
     });
 
     it("should throw BadRequestException when payment is not successful", async () => {
@@ -295,9 +295,9 @@ describe("PaymentApiService", () => {
 
       vi.mocked(databaseService.payment.findFirst).mockResolvedValueOnce(payment);
 
-      await expect(service.initiateRefund("tx-ref-123", refundDto, mockUserInfo.id)).rejects.toThrow(
-        BadRequestException,
-      );
+      await expect(
+        service.initiateRefund("tx-ref-123", refundDto, mockUserInfo.id),
+      ).rejects.toThrow(BadRequestException);
     });
 
     it("should throw BadRequestException when refund amount exceeds payment", async () => {
@@ -309,9 +309,9 @@ describe("PaymentApiService", () => {
 
       vi.mocked(databaseService.payment.findFirst).mockResolvedValueOnce(payment);
 
-      await expect(service.initiateRefund("tx-ref-123", refundDto, mockUserInfo.id)).rejects.toThrow(
-        BadRequestException,
-      );
+      await expect(
+        service.initiateRefund("tx-ref-123", refundDto, mockUserInfo.id),
+      ).rejects.toThrow(BadRequestException);
     });
 
     it("should throw BadRequestException when payment has no provider reference", async () => {
@@ -323,9 +323,9 @@ describe("PaymentApiService", () => {
 
       vi.mocked(databaseService.payment.findFirst).mockResolvedValueOnce(payment);
 
-      await expect(service.initiateRefund("tx-ref-123", refundDto, mockUserInfo.id)).rejects.toThrow(
-        BadRequestException,
-      );
+      await expect(
+        service.initiateRefund("tx-ref-123", refundDto, mockUserInfo.id),
+      ).rejects.toThrow(BadRequestException);
     });
 
     it("should not update payment status when refund fails", async () => {

--- a/src/modules/payment/payment-api.service.spec.ts
+++ b/src/modules/payment/payment-api.service.spec.ts
@@ -1,0 +1,350 @@
+import { BadRequestException, NotFoundException } from "@nestjs/common";
+import { Test, TestingModule } from "@nestjs/testing";
+import { PaymentStatus } from "@prisma/client";
+import { Decimal } from "@prisma/client/runtime/library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createBooking, createExtension, createPayment } from "../../shared/helper.fixtures";
+import { DatabaseService } from "../database/database.service";
+import { FlutterwaveService } from "../flutterwave/flutterwave.service";
+import { PaymentApiService } from "./payment-api.service";
+
+describe("PaymentApiService", () => {
+  let service: PaymentApiService;
+  let databaseService: DatabaseService;
+  let flutterwaveService: FlutterwaveService;
+
+  const mockUserInfo = {
+    id: "user-123",
+    email: "test@example.com",
+    name: "Test User",
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PaymentApiService,
+        {
+          provide: DatabaseService,
+          useValue: {
+            booking: {
+              findUnique: vi.fn(),
+            },
+            extension: {
+              findUnique: vi.fn(),
+            },
+            payment: {
+              findFirst: vi.fn(),
+              update: vi.fn(),
+            },
+          },
+        },
+        {
+          provide: FlutterwaveService,
+          useValue: {
+            createPaymentIntent: vi.fn(),
+            initiateRefund: vi.fn(),
+            getWebhookUrl: vi.fn().mockReturnValue("https://example.com/webhook"),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<PaymentApiService>(PaymentApiService);
+    databaseService = module.get<DatabaseService>(DatabaseService);
+    flutterwaveService = module.get<FlutterwaveService>(FlutterwaveService);
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+
+  describe("initializePayment", () => {
+    const validBookingDto = {
+      type: "booking" as const,
+      entityId: "booking-123",
+      amount: 10000,
+      callbackUrl: "https://example.com/callback",
+    };
+
+    it("should initialize payment for booking successfully", async () => {
+      const booking = createBooking({
+        id: "booking-123",
+        userId: mockUserInfo.id,
+        paymentStatus: PaymentStatus.UNPAID,
+      });
+
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValueOnce(booking);
+
+      vi.mocked(flutterwaveService.createPaymentIntent).mockResolvedValueOnce({
+        paymentIntentId: "pi-123",
+        checkoutUrl: "https://checkout.flutterwave.com/pay/abc123",
+      });
+
+      const result = await service.initializePayment(validBookingDto, mockUserInfo);
+
+      expect(result).toEqual({
+        paymentIntentId: "pi-123",
+        checkoutUrl: "https://checkout.flutterwave.com/pay/abc123",
+      });
+
+      expect(flutterwaveService.createPaymentIntent).toHaveBeenCalledWith({
+        amount: 10000,
+        customer: { email: mockUserInfo.email, name: mockUserInfo.name },
+        callbackUrl: "https://example.com/callback",
+        transactionType: "booking_creation",
+        idempotencyKey: "booking_booking-123",
+        metadata: {
+          type: "booking",
+          entityId: "booking-123",
+          userId: mockUserInfo.id,
+        },
+      });
+    });
+
+    it("should initialize payment for extension successfully", async () => {
+      const extensionDto = {
+        type: "extension" as const,
+        entityId: "extension-123",
+        amount: 5000,
+        callbackUrl: "https://example.com/callback",
+      };
+
+      const extension = createExtension({
+        id: "extension-123",
+        paymentStatus: PaymentStatus.UNPAID,
+        bookingLeg: { booking: { userId: mockUserInfo.id } },
+      });
+
+      vi.mocked(databaseService.extension.findUnique).mockResolvedValueOnce(extension);
+
+      vi.mocked(flutterwaveService.createPaymentIntent).mockResolvedValueOnce({
+        paymentIntentId: "pi-456",
+        checkoutUrl: "https://checkout.flutterwave.com/pay/def456",
+      });
+
+      const result = await service.initializePayment(extensionDto, mockUserInfo);
+
+      expect(result.paymentIntentId).toBe("pi-456");
+      expect(flutterwaveService.createPaymentIntent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          transactionType: "booking_extension",
+          idempotencyKey: "extension_extension-123",
+        }),
+      );
+    });
+
+    it("should throw NotFoundException when booking not found", async () => {
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValueOnce(null);
+
+      await expect(service.initializePayment(validBookingDto, mockUserInfo)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it("should throw BadRequestException when booking belongs to different user", async () => {
+      const booking = createBooking({
+        id: "booking-123",
+        userId: "different-user",
+        paymentStatus: PaymentStatus.UNPAID,
+      });
+
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValueOnce(booking);
+
+      await expect(service.initializePayment(validBookingDto, mockUserInfo)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it("should throw BadRequestException when booking already paid", async () => {
+      const booking = createBooking({
+        id: "booking-123",
+        userId: mockUserInfo.id,
+        paymentStatus: PaymentStatus.PAID,
+      });
+
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValueOnce(booking);
+
+      await expect(service.initializePayment(validBookingDto, mockUserInfo)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it("should throw NotFoundException when extension not found", async () => {
+      const extensionDto = {
+        type: "extension" as const,
+        entityId: "extension-123",
+        amount: 5000,
+        callbackUrl: "https://example.com/callback",
+      };
+
+      vi.mocked(databaseService.extension.findUnique).mockResolvedValueOnce(null);
+
+      await expect(service.initializePayment(extensionDto, mockUserInfo)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe("getPaymentStatus", () => {
+    it("should return payment status successfully", async () => {
+      const booking = createBooking({ id: "booking-123", userId: mockUserInfo.id });
+      const payment = createPayment({
+        status: "SUCCESSFUL",
+        amountCharged: new Decimal(10000),
+        confirmedAt: new Date("2024-01-15T10:00:00Z"),
+        booking: { id: booking.id, status: booking.status, userId: booking.userId },
+      });
+
+      vi.mocked(databaseService.payment.findFirst).mockResolvedValueOnce(payment);
+
+      const result = await service.getPaymentStatus("tx-ref-123", mockUserInfo.id);
+
+      expect(result).toEqual({
+        txRef: "tx-ref-123",
+        status: "SUCCESSFUL",
+        amountExpected: 10000,
+        amountCharged: 10000,
+        confirmedAt: new Date("2024-01-15T10:00:00Z"),
+        booking: { id: booking.id, status: booking.status },
+        extension: undefined,
+      });
+    });
+
+    it("should throw NotFoundException when payment not found", async () => {
+      vi.mocked(databaseService.payment.findFirst).mockResolvedValueOnce(null);
+
+      await expect(service.getPaymentStatus("invalid-ref", mockUserInfo.id)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it("should throw BadRequestException when user does not own payment", async () => {
+      const payment = createPayment({
+        status: "SUCCESSFUL",
+        booking: { id: "booking-123", status: "CONFIRMED", userId: "different-user" },
+      });
+
+      vi.mocked(databaseService.payment.findFirst).mockResolvedValueOnce(payment);
+
+      await expect(service.getPaymentStatus("tx-ref-123", mockUserInfo.id)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe("initiateRefund", () => {
+    const refundDto = { amount: 5000, reason: "Customer request" };
+
+    it("should initiate refund successfully for booking owner", async () => {
+      const payment = createPayment({
+        status: "SUCCESSFUL",
+        booking: { id: "booking-123", status: "CONFIRMED", userId: mockUserInfo.id },
+      });
+
+      vi.mocked(databaseService.payment.findFirst).mockResolvedValueOnce(payment);
+
+      vi.mocked(flutterwaveService.initiateRefund).mockResolvedValueOnce({
+        success: true,
+        refundId: 67890,
+        amountRefunded: 5000,
+        status: "completed",
+      });
+
+      vi.mocked(databaseService.payment.update).mockResolvedValueOnce({
+        ...payment,
+        status: "REFUND_PROCESSING",
+      });
+
+      const result = await service.initiateRefund("tx-ref-123", refundDto, mockUserInfo.id);
+
+      expect(result.success).toBe(true);
+      expect(result.refundId).toBe(67890);
+
+      expect(databaseService.payment.update).toHaveBeenCalledWith({
+        where: { id: "payment-123" },
+        data: { status: "REFUND_PROCESSING" },
+      });
+    });
+
+    it("should throw NotFoundException when payment not found", async () => {
+      vi.mocked(databaseService.payment.findFirst).mockResolvedValueOnce(null);
+
+      await expect(service.initiateRefund("invalid-ref", refundDto, mockUserInfo.id)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it("should throw BadRequestException when user does not own payment", async () => {
+      const payment = createPayment({
+        status: "SUCCESSFUL",
+        booking: { id: "booking-123", status: "CONFIRMED", userId: "different-user" },
+      });
+
+      vi.mocked(databaseService.payment.findFirst).mockResolvedValueOnce(payment);
+
+      await expect(service.initiateRefund("tx-ref-123", refundDto, mockUserInfo.id)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it("should throw BadRequestException when payment is not successful", async () => {
+      const payment = createPayment({
+        status: "PENDING",
+        booking: { id: "booking-123", status: "CONFIRMED", userId: mockUserInfo.id },
+      });
+
+      vi.mocked(databaseService.payment.findFirst).mockResolvedValueOnce(payment);
+
+      await expect(service.initiateRefund("tx-ref-123", refundDto, mockUserInfo.id)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it("should throw BadRequestException when refund amount exceeds payment", async () => {
+      const payment = createPayment({
+        status: "SUCCESSFUL",
+        amountExpected: new Decimal(1000),
+        booking: { id: "booking-123", status: "CONFIRMED", userId: mockUserInfo.id },
+      });
+
+      vi.mocked(databaseService.payment.findFirst).mockResolvedValueOnce(payment);
+
+      await expect(service.initiateRefund("tx-ref-123", refundDto, mockUserInfo.id)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it("should throw BadRequestException when payment has no provider reference", async () => {
+      const payment = createPayment({
+        status: "SUCCESSFUL",
+        flutterwaveTransactionId: null,
+        booking: { id: "booking-123", status: "CONFIRMED", userId: mockUserInfo.id },
+      });
+
+      vi.mocked(databaseService.payment.findFirst).mockResolvedValueOnce(payment);
+
+      await expect(service.initiateRefund("tx-ref-123", refundDto, mockUserInfo.id)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it("should not update payment status when refund fails", async () => {
+      const payment = createPayment({
+        status: "SUCCESSFUL",
+        booking: { id: "booking-123", status: "CONFIRMED", userId: mockUserInfo.id },
+      });
+
+      vi.mocked(databaseService.payment.findFirst).mockResolvedValueOnce(payment);
+
+      vi.mocked(flutterwaveService.initiateRefund).mockResolvedValueOnce({
+        success: false,
+        error: "Insufficient funds",
+      });
+
+      const result = await service.initiateRefund("tx-ref-123", refundDto, mockUserInfo.id);
+
+      expect(result.success).toBe(false);
+      expect(databaseService.payment.update).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/modules/payment/payment-api.service.ts
+++ b/src/modules/payment/payment-api.service.ts
@@ -1,0 +1,237 @@
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from "@nestjs/common";
+import { DatabaseService } from "../database/database.service";
+import { FlutterwaveService } from "../flutterwave/flutterwave.service";
+import type { PaymentIntentResponse, RefundResponse } from "../flutterwave/flutterwave.interface";
+import type { InitializePaymentDto } from "./dto/initialize-payment.dto";
+import type { RefundPaymentDto } from "./dto/refund-payment.dto";
+
+export interface PaymentStatusResponse {
+  txRef: string;
+  status: string;
+  amountExpected: number;
+  amountCharged: number | null;
+  confirmedAt: Date | null;
+  booking?: {
+    id: string;
+    status: string;
+  };
+  extension?: {
+    id: string;
+    status: string;
+  };
+}
+
+export interface UserInfo {
+  id: string;
+  email: string;
+  name: string | null;
+}
+
+@Injectable()
+export class PaymentApiService {
+  private readonly logger = new Logger(PaymentApiService.name);
+
+  constructor(
+    private readonly flutterwaveService: FlutterwaveService,
+    private readonly databaseService: DatabaseService,
+  ) {}
+
+  /**
+   * Initialize a payment for a booking or extension.
+   */
+  async initializePayment(
+    dto: InitializePaymentDto,
+    user: UserInfo,
+  ): Promise<PaymentIntentResponse> {
+    this.logger.log("Initializing payment", {
+      type: dto.type,
+      entityId: dto.entityId,
+      userId: user.id,
+    });
+
+    // Validate entity belongs to user and is not already paid
+    await this.validateEntityForPayment(dto.type, dto.entityId, user.id);
+
+    // Create payment intent with Flutterwave
+    const paymentIntent = await this.flutterwaveService.createPaymentIntent({
+      amount: dto.amount,
+      customer: {
+        email: user.email,
+        name: user.name || undefined,
+      },
+      callbackUrl: dto.callbackUrl,
+      transactionType: dto.type === "booking" ? "booking_creation" : "booking_extension",
+      idempotencyKey: `${dto.type}_${dto.entityId}`,
+      metadata: {
+        type: dto.type,
+        entityId: dto.entityId,
+        userId: user.id,
+      },
+    });
+
+    this.logger.log("Payment intent created", {
+      paymentIntentId: paymentIntent.paymentIntentId,
+      type: dto.type,
+      entityId: dto.entityId,
+    });
+
+    return paymentIntent;
+  }
+
+  /**
+   * Get payment status by transaction reference.
+   */
+  async getPaymentStatus(txRef: string, userId: string): Promise<PaymentStatusResponse> {
+    const payment = await this.databaseService.payment.findFirst({
+      where: { txRef },
+      include: {
+        booking: { select: { id: true, status: true, userId: true } },
+        extension: {
+          select: {
+            id: true,
+            status: true,
+            bookingLeg: { select: { booking: { select: { userId: true } } } },
+          },
+        },
+      },
+    });
+
+    if (!payment) {
+      throw new NotFoundException("Payment not found");
+    }
+
+    // Verify user owns this payment
+    const ownerId = payment.booking?.userId || payment.extension?.bookingLeg.booking.userId;
+    if (ownerId !== userId) {
+      throw new BadRequestException("You do not have permission to view this payment");
+    }
+
+    return {
+      txRef: payment.txRef,
+      status: payment.status,
+      amountExpected: payment.amountExpected.toNumber(),
+      amountCharged: payment.amountCharged?.toNumber() ?? null,
+      confirmedAt: payment.confirmedAt,
+      booking: payment.booking
+        ? { id: payment.booking.id, status: payment.booking.status }
+        : undefined,
+      extension: payment.extension
+        ? { id: payment.extension.id, status: payment.extension.status }
+        : undefined,
+    };
+  }
+
+  /**
+   * Initiate a refund for a payment.
+   * Only the booking/extension owner can request a refund.
+   */
+  async initiateRefund(txRef: string, dto: RefundPaymentDto, userId: string): Promise<RefundResponse> {
+    this.logger.log("Initiating refund", { txRef, amount: dto.amount, reason: dto.reason, userId });
+
+    const payment = await this.databaseService.payment.findFirst({
+      where: { txRef },
+      include: {
+        booking: { select: { userId: true } },
+        extension: {
+          select: {
+            bookingLeg: { select: { booking: { select: { userId: true } } } },
+          },
+        },
+      },
+    });
+
+    if (!payment) {
+      throw new NotFoundException("Payment not found");
+    }
+
+    // Verify user owns this payment
+    const ownerId = payment.booking?.userId || payment.extension?.bookingLeg.booking.userId;
+    if (ownerId !== userId) {
+      throw new BadRequestException("You do not have permission to refund this payment");
+    }
+
+    if (payment.status !== "SUCCESSFUL") {
+      throw new BadRequestException("Cannot refund a payment that is not successful");
+    }
+
+    if (dto.amount > payment.amountExpected.toNumber()) {
+      throw new BadRequestException("Refund amount cannot exceed payment amount");
+    }
+
+    if (!payment.flutterwaveTransactionId) {
+      throw new BadRequestException("Payment does not have a provider reference");
+    }
+
+    const refundResult = await this.flutterwaveService.initiateRefund({
+      transactionId: payment.flutterwaveTransactionId,
+      amount: dto.amount,
+      callbackUrl: this.flutterwaveService.getWebhookUrl("/api/payments/webhook/flutterwave"),
+    });
+
+    if (refundResult.success) {
+      await this.databaseService.payment.update({
+        where: { id: payment.id },
+        data: {
+          status: "REFUND_PROCESSING",
+        },
+      });
+
+      this.logger.log("Refund initiated successfully", {
+        txRef,
+        refundId: refundResult.refundId,
+      });
+    }
+
+    return refundResult;
+  }
+
+  /**
+   * Validates that an entity exists, belongs to the user, and is not already paid.
+   */
+  private async validateEntityForPayment(
+    type: "booking" | "extension",
+    entityId: string,
+    userId: string,
+  ): Promise<void> {
+    if (type === "booking") {
+      const booking = await this.databaseService.booking.findUnique({
+        where: { id: entityId },
+        select: { id: true, userId: true, paymentStatus: true },
+      });
+
+      if (!booking) {
+        throw new NotFoundException("Booking not found");
+      }
+
+      if (booking.userId !== userId) {
+        throw new BadRequestException("You do not have permission to pay for this booking");
+      }
+
+      if (booking.paymentStatus === "PAID") {
+        throw new BadRequestException("This booking has already been paid");
+      }
+    } else {
+      const extension = await this.databaseService.extension.findUnique({
+        where: { id: entityId },
+        include: { bookingLeg: { select: { booking: { select: { userId: true } } } } },
+      });
+
+      if (!extension) {
+        throw new NotFoundException("Extension not found");
+      }
+
+      if (extension.bookingLeg.booking.userId !== userId) {
+        throw new BadRequestException("You do not have permission to pay for this extension");
+      }
+
+      if (extension.paymentStatus === "PAID") {
+        throw new BadRequestException("This extension has already been paid");
+      }
+    }
+  }
+}

--- a/src/modules/payment/payment-api.service.ts
+++ b/src/modules/payment/payment-api.service.ts
@@ -1,12 +1,7 @@
-import {
-  BadRequestException,
-  Injectable,
-  Logger,
-  NotFoundException,
-} from "@nestjs/common";
+import { BadRequestException, Injectable, Logger, NotFoundException } from "@nestjs/common";
 import { DatabaseService } from "../database/database.service";
-import { FlutterwaveService } from "../flutterwave/flutterwave.service";
 import type { PaymentIntentResponse, RefundResponse } from "../flutterwave/flutterwave.interface";
+import { FlutterwaveService } from "../flutterwave/flutterwave.service";
 import type { InitializePaymentDto } from "./dto/initialize-payment.dto";
 import type { RefundPaymentDto } from "./dto/refund-payment.dto";
 
@@ -130,7 +125,11 @@ export class PaymentApiService {
    * Initiate a refund for a payment.
    * Only the booking/extension owner can request a refund.
    */
-  async initiateRefund(txRef: string, dto: RefundPaymentDto, userId: string): Promise<RefundResponse> {
+  async initiateRefund(
+    txRef: string,
+    dto: RefundPaymentDto,
+    userId: string,
+  ): Promise<RefundResponse> {
     this.logger.log("Initiating refund", { txRef, amount: dto.amount, reason: dto.reason, userId });
 
     const payment = await this.databaseService.payment.findFirst({

--- a/src/modules/payment/payment.controller.ts
+++ b/src/modules/payment/payment.controller.ts
@@ -1,0 +1,56 @@
+import { Body, Controller, Get, Param, Post, UseGuards } from "@nestjs/common";
+import { CurrentUser } from "../auth/decorators/current-user.decorator";
+import { SessionGuard, type AuthSession } from "../auth/guards/session.guard";
+import type { PaymentIntentResponse, RefundResponse } from "../flutterwave/flutterwave.interface";
+import { initializePaymentSchema, type InitializePaymentDto } from "./dto/initialize-payment.dto";
+import { refundPaymentSchema, type RefundPaymentDto } from "./dto/refund-payment.dto";
+import { ZodValidationPipe } from "./dto/zod-validation.pipe";
+import { PaymentApiService, type PaymentStatusResponse } from "./payment-api.service";
+
+@Controller("api/payments")
+export class PaymentController {
+  constructor(private readonly paymentApiService: PaymentApiService) {}
+
+  /**
+   * Initialize a payment for a booking or extension.
+   * Returns a checkout URL that the client should redirect to.
+   */
+  @Post("initialize")
+  @UseGuards(SessionGuard)
+  async initializePayment(
+    @Body(new ZodValidationPipe(initializePaymentSchema)) dto: InitializePaymentDto,
+    @CurrentUser() user: AuthSession["user"],
+  ): Promise<PaymentIntentResponse> {
+    return this.paymentApiService.initializePayment(dto, {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+    });
+  }
+
+  /**
+   * Get payment status by transaction reference.
+   */
+  @Get("status/:txRef")
+  @UseGuards(SessionGuard)
+  async getPaymentStatus(
+    @Param("txRef") txRef: string,
+    @CurrentUser() user: AuthSession["user"],
+  ): Promise<PaymentStatusResponse> {
+    return this.paymentApiService.getPaymentStatus(txRef, user.id);
+  }
+
+  /**
+   * Initiate a refund for a payment.
+   * Only the booking owner can request a refund (typically when cancelling).
+   */
+  @Post(":txRef/refund")
+  @UseGuards(SessionGuard)
+  async initiateRefund(
+    @Param("txRef") txRef: string,
+    @Body(new ZodValidationPipe(refundPaymentSchema)) dto: RefundPaymentDto,
+    @CurrentUser() user: AuthSession["user"],
+  ): Promise<RefundResponse> {
+    return this.paymentApiService.initiateRefund(txRef, dto, user.id);
+  }
+}

--- a/src/modules/payment/payment.controller.ts
+++ b/src/modules/payment/payment.controller.ts
@@ -1,9 +1,9 @@
 import { Body, Controller, Get, Param, Post, UseGuards } from "@nestjs/common";
 import { CurrentUser } from "../auth/decorators/current-user.decorator";
-import { SessionGuard, type AuthSession } from "../auth/guards/session.guard";
+import { type AuthSession, SessionGuard } from "../auth/guards/session.guard";
 import type { PaymentIntentResponse, RefundResponse } from "../flutterwave/flutterwave.interface";
-import { initializePaymentSchema, type InitializePaymentDto } from "./dto/initialize-payment.dto";
-import { refundPaymentSchema, type RefundPaymentDto } from "./dto/refund-payment.dto";
+import { type InitializePaymentDto, initializePaymentSchema } from "./dto/initialize-payment.dto";
+import { type RefundPaymentDto, refundPaymentSchema } from "./dto/refund-payment.dto";
 import { ZodValidationPipe } from "./dto/zod-validation.pipe";
 import { PaymentApiService, type PaymentStatusResponse } from "./payment-api.service";
 

--- a/src/modules/payment/payment.controller.ts
+++ b/src/modules/payment/payment.controller.ts
@@ -5,7 +5,8 @@ import type { PaymentIntentResponse, RefundResponse } from "../flutterwave/flutt
 import { type InitializePaymentDto, initializePaymentSchema } from "./dto/initialize-payment.dto";
 import { type RefundPaymentDto, refundPaymentSchema } from "./dto/refund-payment.dto";
 import { ZodValidationPipe } from "./dto/zod-validation.pipe";
-import { PaymentApiService, type PaymentStatusResponse } from "./payment-api.service";
+import { PaymentApiService } from "./payment-api.service";
+import { type PaymentStatusResponse } from "./payment.interface";
 
 @Controller("api/payments")
 export class PaymentController {

--- a/src/modules/payment/payment.interface.ts
+++ b/src/modules/payment/payment.interface.ts
@@ -4,3 +4,25 @@ export interface PayoutJobData {
   bookingId: string;
   timestamp: string;
 }
+
+export interface PaymentStatusResponse {
+  txRef: string;
+  status: string;
+  amountExpected: number;
+  amountCharged: number | null;
+  confirmedAt: Date | null;
+  booking?: {
+    id: string;
+    status: string;
+  };
+  extension?: {
+    id: string;
+    status: string;
+  };
+}
+
+export interface UserInfo {
+  id: string;
+  email: string;
+  name: string | null;
+}

--- a/src/modules/payment/payment.module.ts
+++ b/src/modules/payment/payment.module.ts
@@ -6,10 +6,10 @@ import { PAYOUTS_QUEUE } from "../../config/constants";
 import { AuthModule } from "../auth/auth.module";
 import { DatabaseModule } from "../database/database.module";
 import { FlutterwaveModule } from "../flutterwave/flutterwave.module";
-import { PaymentApiService } from "./payment-api.service";
 import { PaymentController } from "./payment.controller";
 import { PaymentProcessor } from "./payment.processor";
 import { PaymentService } from "./payment.service";
+import { PaymentApiService } from "./payment-api.service";
 
 @Module({
   imports: [

--- a/src/modules/payment/payment.module.ts
+++ b/src/modules/payment/payment.module.ts
@@ -3,8 +3,11 @@ import { BullBoardModule } from "@bull-board/nestjs";
 import { BullModule } from "@nestjs/bullmq";
 import { Module } from "@nestjs/common";
 import { PAYOUTS_QUEUE } from "../../config/constants";
+import { AuthModule } from "../auth/auth.module";
 import { DatabaseModule } from "../database/database.module";
 import { FlutterwaveModule } from "../flutterwave/flutterwave.module";
+import { PaymentApiService } from "./payment-api.service";
+import { PaymentController } from "./payment.controller";
 import { PaymentProcessor } from "./payment.processor";
 import { PaymentService } from "./payment.service";
 
@@ -12,6 +15,7 @@ import { PaymentService } from "./payment.service";
   imports: [
     FlutterwaveModule,
     DatabaseModule,
+    AuthModule,
     BullModule.registerQueue({
       name: PAYOUTS_QUEUE,
       defaultJobOptions: {
@@ -29,7 +33,8 @@ import { PaymentService } from "./payment.service";
       adapter: BullMQAdapter,
     }),
   ],
-  providers: [PaymentService, PaymentProcessor],
-  exports: [PaymentService],
+  controllers: [PaymentController],
+  providers: [PaymentService, PaymentApiService, PaymentProcessor],
+  exports: [PaymentService, PaymentApiService],
 })
 export class PaymentModule {}

--- a/src/shared/helper.fixtures.ts
+++ b/src/shared/helper.fixtures.ts
@@ -253,9 +253,7 @@ export function createExtension(
  * Create a mock Payment for testing.
  * Includes nested booking/extension for ownership checks.
  */
-export function createPayment(
-  overrides: Partial<PaymentWithRelations> = {},
-): PaymentWithRelations {
+export function createPayment(overrides: Partial<PaymentWithRelations> = {}): PaymentWithRelations {
   return {
     id: "payment-123",
     bookingId: "booking-123",

--- a/src/shared/helper.fixtures.ts
+++ b/src/shared/helper.fixtures.ts
@@ -244,7 +244,7 @@ export function createExtension(
     subtotalBeforeVat: null,
     vatAmount: null,
     vatRatePercent: null,
-    bookingLeg: { booking: { userId: "user-123" } },
+    bookingLeg: { booking: { userId: "user-123", status: BookingStatus.CONFIRMED } },
     ...overrides,
   };
 }

--- a/src/shared/helper.fixtures.ts
+++ b/src/shared/helper.fixtures.ts
@@ -273,7 +273,7 @@ export function createPayment(overrides: Partial<PaymentWithRelations> = {}): Pa
     lastVerifiedAt: null,
     webhookPayload: null,
     verificationResponse: null,
-    booking: { id: "booking-123", status: "CONFIRMED", userId: "user-123" },
+    booking: { id: "booking-123", status: BookingStatus.CONFIRMED, userId: "user-123" },
     extension: null,
     ...overrides,
   };

--- a/src/shared/helper.fixtures.ts
+++ b/src/shared/helper.fixtures.ts
@@ -4,14 +4,16 @@ import {
   BookingType,
   CarApprovalStatus,
   ChauffeurApprovalStatus,
+  ExtensionEventType,
   FleetOwnerStatus,
+  PaymentAttemptStatus,
   PaymentStatus,
   ServiceTier,
   Status,
   VehicleType,
 } from "@prisma/client";
 import { Decimal } from "@prisma/client/runtime/library";
-import { BookingWithRelations } from "../types";
+import { BookingWithRelations, ExtensionWithBookingLeg, PaymentWithRelations } from "../types";
 
 /**
  * Mock objects for testing purposes
@@ -207,6 +209,74 @@ export function createBooking(overrides: Partial<BookingWithRelations> = {}): Bo
     user: null,
     car: null,
     legs: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Create a mock Extension for testing.
+ * Includes nested bookingLeg with booking for ownership checks.
+ */
+export function createExtension(
+  overrides: Partial<ExtensionWithBookingLeg> = {},
+): ExtensionWithBookingLeg {
+  return {
+    id: "extension-123",
+    createdAt: new Date("2024-01-01T00:00:00Z"),
+    updatedAt: new Date("2024-01-01T00:00:00Z"),
+    totalAmount: new Decimal(5000),
+    paymentStatus: PaymentStatus.UNPAID,
+    paymentId: null,
+    paymentIntent: null,
+    status: "PENDING",
+    bookingLegId: "leg-123",
+    eventType: ExtensionEventType.HOURLY_ADDITION,
+    extendedDurationHours: 2,
+    extensionStartTime: new Date("2024-01-01T18:00:00Z"),
+    extensionEndTime: new Date("2024-01-01T20:00:00Z"),
+    fleetOwnerPayoutAmountNet: null,
+    netTotal: null,
+    overallPayoutStatus: null,
+    platformCustomerServiceFeeAmount: null,
+    platformCustomerServiceFeeRatePercent: null,
+    platformFleetOwnerCommissionAmount: null,
+    platformFleetOwnerCommissionRatePercent: null,
+    subtotalBeforeVat: null,
+    vatAmount: null,
+    vatRatePercent: null,
+    bookingLeg: { booking: { userId: "user-123" } },
+    ...overrides,
+  };
+}
+
+/**
+ * Create a mock Payment for testing.
+ * Includes nested booking/extension for ownership checks.
+ */
+export function createPayment(
+  overrides: Partial<PaymentWithRelations> = {},
+): PaymentWithRelations {
+  return {
+    id: "payment-123",
+    bookingId: "booking-123",
+    extensionId: null,
+    txRef: "tx-ref-123",
+    flutterwaveTransactionId: "flw-tx-123",
+    flutterwaveReference: null,
+    amountExpected: new Decimal(10000),
+    amountCharged: new Decimal(10000),
+    currency: "NGN",
+    feeChargedByProvider: null,
+    status: PaymentAttemptStatus.SUCCESSFUL,
+    paymentProviderStatus: null,
+    paymentMethod: null,
+    initiatedAt: new Date("2024-01-01T00:00:00Z"),
+    confirmedAt: new Date("2024-01-01T00:00:00Z"),
+    lastVerifiedAt: null,
+    webhookPayload: null,
+    verificationResponse: null,
+    booking: { id: "booking-123", status: "CONFIRMED", userId: "user-123" },
+    extension: null,
     ...overrides,
   };
 }

--- a/src/shared/helper.fixtures.ts
+++ b/src/shared/helper.fixtures.ts
@@ -273,6 +273,7 @@ export function createPayment(overrides: Partial<PaymentWithRelations> = {}): Pa
     lastVerifiedAt: null,
     webhookPayload: null,
     verificationResponse: null,
+    refundIdempotencyKey: null,
     booking: { id: "booking-123", status: BookingStatus.CONFIRMED, userId: "user-123" },
     extension: null,
     ...overrides,

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,7 +71,7 @@ export type BookingLegWithRelations = Prisma.BookingLegGetPayload<{
 }>;
 
 export type ExtensionWithBookingLeg = Prisma.ExtensionGetPayload<{
-  include: { bookingLeg: { select: { booking: { select: { userId: true } } } } };
+  include: { bookingLeg: { select: { booking: { select: { userId: true; status: true } } } } };
 }>;
 
 export type PaymentWithRelations = Prisma.PaymentGetPayload<{
@@ -81,7 +81,7 @@ export type PaymentWithRelations = Prisma.PaymentGetPayload<{
       select: {
         id: true;
         status: true;
-        bookingLeg: { select: { booking: { select: { userId: true } } } };
+        bookingLeg: { select: { booking: { select: { userId: true; status: true } } } };
       };
     };
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,3 +69,20 @@ export type BookingLegWithRelations = Prisma.BookingLegGetPayload<{
     };
   };
 }>;
+
+export type ExtensionWithBookingLeg = Prisma.ExtensionGetPayload<{
+  include: { bookingLeg: { select: { booking: { select: { userId: true } } } } };
+}>;
+
+export type PaymentWithRelations = Prisma.PaymentGetPayload<{
+  include: {
+    booking: { select: { id: true; status: true; userId: true } };
+    extension: {
+      select: {
+        id: true;
+        status: true;
+        bookingLeg: { select: { booking: { select: { userId: true } } } };
+      };
+    };
+  };
+}>;

--- a/test/e2e.setup.ts
+++ b/test/e2e.setup.ts
@@ -1,4 +1,3 @@
-import { PrismaClient } from "@prisma/client";
 import { PostgreSqlContainer, StartedPostgreSqlContainer } from "@testcontainers/postgresql";
 import { RedisContainer, StartedRedisContainer } from "@testcontainers/redis";
 import { execSync } from "node:child_process";
@@ -68,7 +67,9 @@ export async function setup() {
     }
 
     // Seed roles for authentication tests
+    // Dynamic import to avoid loading before prisma generate runs
     console.log("Seeding roles...");
+    const { PrismaClient } = await import("@prisma/client");
     const prisma = new PrismaClient({ datasourceUrl: databaseUrl });
     try {
       const roles = ["user", "fleetOwner", "admin", "staff"];

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -110,6 +110,11 @@ export class TestDataFactory {
       .send({ email, otp, role });
 
     const cookies = verifyResponse.headers["set-cookie"];
+
+    if (!cookies) {
+      throw new Error(`No session cookie set for ${email}. Status: ${verifyResponse.status}`);
+    }
+
     return Array.isArray(cookies) ? cookies.join("; ") : cookies;
   }
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,0 +1,332 @@
+import type { INestApplication } from "@nestjs/common";
+import type { Prisma, PrismaClient } from "@prisma/client";
+import request from "supertest";
+
+// ============================================================================
+// Test Data Factory Types (using Prisma UncheckedCreateInput for direct FK usage)
+// ============================================================================
+
+export type CreateUserOptions = Partial<Prisma.UserUncheckedCreateInput> & {
+  roles?: string[];
+};
+
+export type CreateCarOptions = Partial<Prisma.CarUncheckedCreateInput>;
+
+export type CreateBookingOptions = Partial<Prisma.BookingUncheckedCreateInput>;
+
+export type CreatePaymentOptions = Partial<Prisma.PaymentUncheckedCreateInput>;
+
+export type AuthRole = "user" | "fleetOwner" | "admin";
+
+// ============================================================================
+// Test Data Factory
+// ============================================================================
+
+/**
+ * Factory class for creating test data in E2E tests.
+ * Instantiate once with the database service and use throughout the test suite.
+ *
+ * @example Basic usage (data creation only)
+ * ```typescript
+ * let factory: TestDataFactory;
+ *
+ * beforeAll(async () => {
+ *   databaseService = app.get(DatabaseService);
+ *   factory = new TestDataFactory(databaseService);
+ *
+ *   const fleetOwner = await factory.createFleetOwner();
+ *   const car = await factory.createCar(fleetOwner.id);
+ *   const booking = await factory.createBooking(userId, car.id);
+ * });
+ * ```
+ *
+ * @example With authentication support
+ * ```typescript
+ * let factory: TestDataFactory;
+ *
+ * beforeAll(async () => {
+ *   databaseService = app.get(DatabaseService);
+ *   factory = new TestDataFactory(databaseService, app);
+ *
+ *   const { cookie, user } = await factory.authenticateAndGetUser(email, "user");
+ *   const adminResult = await factory.createAuthenticatedAdmin(adminEmail);
+ * });
+ * ```
+ */
+export class TestDataFactory {
+  constructor(
+    private readonly prisma: PrismaClient,
+    private readonly app?: INestApplication,
+  ) {}
+
+  /**
+   * Assign a role to an existing user.
+   * Use this when you need to add roles to users created through the auth flow.
+   */
+  async assignRole(userId: string, roleName: string): Promise<void> {
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { roles: { connect: { name: roleName } } },
+    });
+  }
+
+  /**
+   * Authenticate a user via OTP flow and return the session cookie.
+   * Automatically clears rate limits before authentication.
+   * Requires the factory to be initialized with an app instance.
+   *
+   * @throws Error if app instance was not provided to the factory
+   */
+  async authenticateAndGetCookie(email: string, role: AuthRole = "user"): Promise<string> {
+    if (!this.app) {
+      throw new Error("TestDataFactory requires app instance for authentication methods");
+    }
+
+    // Clear rate limits before auth to avoid test interference
+    await this.clearRateLimits();
+
+    // Send OTP
+    await request(this.app.getHttpServer())
+      .post("/auth/api/email-otp/send-verification-otp")
+      .set("X-Client-Type", "mobile")
+      .send({ email, type: "sign-in", role });
+
+    // Get OTP from database
+    const verification = await this.prisma.verification.findFirst({
+      where: { identifier: `sign-in-otp-${email}` },
+      orderBy: { createdAt: "desc" },
+    });
+
+    const otp = verification?.value.split(":")[0];
+
+    // Verify OTP
+    const verifyResponse = await request(this.app.getHttpServer())
+      .post("/auth/api/sign-in/email-otp")
+      .set("X-Client-Type", "mobile")
+      .send({ email, otp, role });
+
+    const cookies = verifyResponse.headers["set-cookie"];
+    return Array.isArray(cookies) ? cookies.join("; ") : cookies;
+  }
+
+  /**
+   * Get user by email.
+   */
+  async getUserByEmail(email: string): Promise<{ id: string; email: string; name: string | null } | null> {
+    return this.prisma.user.findUnique({
+      where: { email },
+      select: { id: true, email: true, name: true },
+    });
+  }
+
+  /**
+   * Convenience method to authenticate a user and get both cookie and user info.
+   * Useful when you need the user ID after authentication.
+   */
+  async authenticateAndGetUser(
+    email: string,
+    role: AuthRole = "user",
+  ): Promise<{ cookie: string; user: { id: string; email: string; name: string | null } }> {
+    const cookie = await this.authenticateAndGetCookie(email, role);
+    const user = await this.getUserByEmail(email);
+    if (!user) {
+      throw new Error(`User not found after authentication: ${email}`);
+    }
+    return { cookie, user };
+  }
+
+  /**
+   * Convenience method to create an authenticated admin user.
+   * Authenticates the user first, then assigns the admin role.
+   * Returns both the cookie and user info.
+   */
+  async createAuthenticatedAdmin(email: string): Promise<{
+    cookie: string;
+    user: { id: string; email: string; name: string | null };
+  }> {
+    const { cookie, user } = await this.authenticateAndGetUser(email, "user");
+    await this.assignRole(user.id, "admin");
+    return { cookie, user };
+  }
+
+  /**
+   * Clear all rate limits from the database.
+   * Call this in beforeEach of E2E tests that involve rate-limited endpoints.
+   */
+  async clearRateLimits(): Promise<void> {
+    await this.prisma.rateLimit.deleteMany();
+  }
+
+  /**
+   * Create a test user directly in the database (bypasses auth flow).
+   * Use this when you need a user without going through OTP authentication.
+   */
+  async createUser(options: CreateUserOptions = {}): Promise<{ id: string; email: string; name: string | null }> {
+    const email = options.email ?? uniqueEmail("test-user");
+    const user = await this.prisma.user.create({
+      data: {
+        email,
+        name: options.name ?? "Test User",
+        emailVerified: options.emailVerified ?? true,
+        roles: options.roles?.length ? { connect: options.roles.map((name) => ({ name })) } : undefined,
+      },
+      select: { id: true, email: true, name: true },
+    });
+    return user;
+  }
+
+  /**
+   * Create a fleet owner user directly in the database.
+   * Automatically assigns the fleetOwner role.
+   */
+  async createFleetOwner(options: Omit<CreateUserOptions, "roles"> = {}): Promise<{
+    id: string;
+    email: string;
+    name: string | null;
+  }> {
+    return this.createUser({
+      ...options,
+      email: options.email ?? uniqueEmail("fleet-owner"),
+      name: options.name ?? "Test Fleet Owner",
+      roles: ["fleetOwner"],
+    });
+  }
+
+  /**
+   * Create a test car in the database.
+   */
+  async createCar(ownerId: string, options: CreateCarOptions = {}): Promise<{ id: string }> {
+    const car = await this.prisma.car.create({
+      data: {
+        make: options.make ?? "Toyota",
+        model: options.model ?? "Camry",
+        year: options.year ?? 2022,
+        color: options.color ?? "Black",
+        ownerId,
+        registrationNumber:
+          options.registrationNumber ?? `TEST-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        status: options.status ?? "AVAILABLE",
+        hourlyRate: options.hourlyRate ?? 5000,
+        dayRate: options.dayRate ?? 50000,
+        nightRate: options.nightRate ?? 60000,
+        fullDayRate: options.fullDayRate ?? 100000,
+        airportPickupRate: options.airportPickupRate ?? 30000,
+      },
+      select: { id: true },
+    });
+    return car;
+  }
+
+  /**
+   * Create a test booking in the database.
+   */
+  async createBooking(
+    userId: string,
+    carId: string,
+    options: CreateBookingOptions = {},
+  ): Promise<{ id: string; bookingReference: string }> {
+    const booking = await this.prisma.booking.create({
+      data: {
+        userId,
+        carId,
+        startDate: options.startDate ?? new Date(),
+        endDate: options.endDate ?? new Date(Date.now() + 86400000), // +1 day
+        totalAmount: options.totalAmount ?? 50000,
+        pickupLocation: options.pickupLocation ?? "Lagos Airport",
+        returnLocation: options.returnLocation ?? "Victoria Island",
+        status: options.status ?? "PENDING",
+        paymentStatus: options.paymentStatus ?? "UNPAID",
+        bookingReference: options.bookingReference ?? `BOOK-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      },
+      select: { id: true, bookingReference: true },
+    });
+    return booking;
+  }
+
+  /**
+   * Create a test payment in the database.
+   */
+  async createPayment(bookingId: string, options: CreatePaymentOptions = {}): Promise<{ id: string; txRef: string }> {
+    const payment = await this.prisma.payment.create({
+      data: {
+        txRef: options.txRef ?? `tx-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        bookingId,
+        amountExpected: options.amountExpected ?? 50000,
+        amountCharged: options.amountCharged,
+        currency: options.currency ?? "NGN",
+        status: options.status ?? "PENDING",
+        flutterwaveTransactionId: options.flutterwaveTransactionId,
+        confirmedAt: options.confirmedAt,
+      },
+      select: { id: true, txRef: true },
+    });
+    return payment;
+  }
+
+  /**
+   * Convenience method to create a booking with all its dependencies (fleet owner, car).
+   * Use this when you just need a booking for testing and don't need fine-grained control
+   * over the intermediate entities.
+   *
+   * @example
+   * ```typescript
+   * const booking = await factory.createBookingWithDependencies(userId);
+   * ```
+   */
+  async createBookingWithDependencies(
+    userId: string,
+    options: {
+      fleetOwner?: Omit<CreateUserOptions, "roles">;
+      car?: CreateCarOptions;
+      booking?: CreateBookingOptions;
+    } = {},
+  ): Promise<{ id: string; bookingReference: string }> {
+    const fleetOwner = await this.createFleetOwner(options.fleetOwner);
+    const car = await this.createCar(fleetOwner.id, options.car);
+    return this.createBooking(userId, car.id, options.booking);
+  }
+}
+
+/**
+ * Authenticate a user and return the session cookie.
+ * Creates the user if they don't exist.
+ *
+ * @deprecated Use TestDataFactory.authenticateAndGetCookie() instead for consistency
+ */
+export async function authenticateUser(
+  app: INestApplication,
+  prisma: PrismaClient,
+  email: string,
+  role: AuthRole = "user",
+): Promise<string> {
+  // Send OTP
+  await request(app.getHttpServer())
+    .post("/auth/api/email-otp/send-verification-otp")
+    .set("X-Client-Type", "mobile")
+    .send({ email, type: "sign-in", role });
+
+  // Get OTP from database
+  const verification = await prisma.verification.findFirst({
+    where: { identifier: `sign-in-otp-${email}` },
+    orderBy: { createdAt: "desc" },
+  });
+
+  const otp = verification?.value.split(":")[0];
+
+  // Verify OTP
+  const verifyResponse = await request(app.getHttpServer())
+    .post("/auth/api/sign-in/email-otp")
+    .set("X-Client-Type", "mobile")
+    .send({ email, otp, role });
+
+  const cookies = verifyResponse.headers["set-cookie"];
+  return Array.isArray(cookies) ? cookies.join("; ") : cookies;
+}
+
+/**
+ * Generate a unique email for testing to avoid conflicts.
+ */
+export function uniqueEmail(prefix: string): string {
+  const randomId = Math.floor(Math.random() * 100000);
+  return `${prefix}-${randomId}-${Date.now()}@example.com`;
+}

--- a/test/payments.e2e-spec.ts
+++ b/test/payments.e2e-spec.ts
@@ -1,0 +1,302 @@
+import { HttpStatus, type INestApplication } from "@nestjs/common";
+import { HttpAdapterHost } from "@nestjs/core";
+import { Test, type TestingModule } from "@nestjs/testing";
+import request from "supertest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppModule } from "../src/app.module";
+import { GlobalExceptionFilter } from "../src/common/filters/global-exception.filter";
+import { AuthEmailService } from "../src/modules/auth/auth-email.service";
+import { DatabaseService } from "../src/modules/database/database.service";
+import { FlutterwaveService } from "../src/modules/flutterwave/flutterwave.service";
+import { TestDataFactory, uniqueEmail } from "./helpers";
+
+describe("Payments E2E Tests", () => {
+  let app: INestApplication;
+  let databaseService: DatabaseService;
+  let flutterwaveService: FlutterwaveService;
+  let factory: TestDataFactory;
+
+  // Test data
+  let testUserId: string;
+  let testUserCookie: string;
+  let otherUserCookie: string;
+  let testBookingId: string;
+
+  beforeAll(async () => {
+    const mockSendOTPEmail = vi.fn().mockResolvedValue(undefined);
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(AuthEmailService)
+      .useValue({ sendOTPEmail: mockSendOTPEmail })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+
+    const httpAdapterHost = app.get(HttpAdapterHost);
+    app.useGlobalFilters(new GlobalExceptionFilter(httpAdapterHost));
+
+    databaseService = app.get(DatabaseService);
+    flutterwaveService = app.get(FlutterwaveService);
+    factory = new TestDataFactory(databaseService, app);
+
+    await app.init();
+
+    // Create test user
+    const testEmail = uniqueEmail("payment-test-user");
+    const testResult = await factory.authenticateAndGetUser(testEmail, "user");
+    testUserCookie = testResult.cookie;
+    testUserId = testResult.user.id;
+
+    // Create another user (for ownership tests)
+    const otherEmail = uniqueEmail("payment-other-user");
+    otherUserCookie = await factory.authenticateAndGetCookie(otherEmail, "user");
+
+    // Create a booking with all dependencies (fleet owner, car)
+    const booking = await factory.createBookingWithDependencies(testUserId);
+    testBookingId = booking.id;
+  });
+
+  beforeEach(async () => {
+    await factory.clearRateLimits();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe("POST /api/payments/initialize", () => {
+    it("should return 401 when not authenticated", async () => {
+      const response = await request(app.getHttpServer()).post("/api/payments/initialize").send({
+        type: "booking",
+        entityId: testBookingId,
+        amount: 50000,
+        callbackUrl: "https://example.com/callback",
+      });
+
+      expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+    });
+
+    it("should initialize payment for a booking", async () => {
+      const mockPaymentIntent = {
+        success: true,
+        checkoutUrl: "https://checkout.flutterwave.com/v3/hosted/pay/abc123",
+        paymentIntentId: "FLW-MOCK-123",
+        txRef: `booking_${testBookingId}`,
+      };
+      vi.spyOn(flutterwaveService, "createPaymentIntent").mockResolvedValueOnce(mockPaymentIntent);
+
+      const response = await request(app.getHttpServer())
+        .post("/api/payments/initialize")
+        .set("Cookie", testUserCookie)
+        .send({
+          type: "booking",
+          entityId: testBookingId,
+          amount: 50000,
+          callbackUrl: "https://example.com/callback",
+        });
+
+      expect(response.status).toBe(HttpStatus.CREATED);
+      expect(response.body.success).toBe(true);
+      expect(response.body.checkoutUrl).toBeDefined();
+      expect(response.body.txRef).toBeDefined();
+    });
+
+    it("should reject payment for non-existent booking", async () => {
+      const response = await request(app.getHttpServer())
+        .post("/api/payments/initialize")
+        .set("Cookie", testUserCookie)
+        .send({
+          type: "booking",
+          entityId: "non-existent-id",
+          amount: 50000,
+          callbackUrl: "https://example.com/callback",
+        });
+
+      expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+    });
+
+    it("should reject payment for booking owned by another user", async () => {
+      const otherEmail = uniqueEmail("other-user");
+      const otherCookie = await factory.authenticateAndGetCookie(otherEmail, "user");
+
+      const response = await request(app.getHttpServer())
+        .post("/api/payments/initialize")
+        .set("Cookie", otherCookie)
+        .send({
+          type: "booking",
+          entityId: testBookingId,
+          amount: 50000,
+          callbackUrl: "https://example.com/callback",
+        });
+
+      expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+      expect(response.body.message).toContain("permission");
+    });
+
+    it("should validate request body with Zod schema", async () => {
+      const response = await request(app.getHttpServer())
+        .post("/api/payments/initialize")
+        .set("Cookie", testUserCookie)
+        .send({
+          type: "invalid-type",
+          entityId: "not-a-uuid",
+          amount: 50, // Below minimum
+          callbackUrl: "not-a-url",
+        });
+
+      expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+      expect(response.body.message).toBe("Validation failed");
+      expect(response.body.errors).toBeDefined();
+      expect(Array.isArray(response.body.errors)).toBe(true);
+    });
+  });
+
+  describe("GET /api/payments/status/:txRef", () => {
+    let testPaymentTxRef: string;
+
+    beforeAll(async () => {
+      const payment = await factory.createPayment(testBookingId);
+      testPaymentTxRef = payment.txRef;
+    });
+
+    it("should return 401 when not authenticated", async () => {
+      const response = await request(app.getHttpServer()).get(
+        `/api/payments/status/${testPaymentTxRef}`,
+      );
+
+      expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+    });
+
+    it("should return payment status for authenticated user", async () => {
+      const response = await request(app.getHttpServer())
+        .get(`/api/payments/status/${testPaymentTxRef}`)
+        .set("Cookie", testUserCookie);
+
+      expect(response.status).toBe(HttpStatus.OK);
+      expect(response.body.txRef).toBe(testPaymentTxRef);
+      expect(response.body.status).toBe("PENDING");
+      expect(response.body.amountExpected).toBe(50000);
+    });
+
+    it("should return 404 for non-existent payment", async () => {
+      const response = await request(app.getHttpServer())
+        .get("/api/payments/status/non-existent-txref")
+        .set("Cookie", testUserCookie);
+
+      expect(response.status).toBe(HttpStatus.NOT_FOUND);
+    });
+
+    it("should reject access to payment owned by another user", async () => {
+      const otherEmail = uniqueEmail("other-user-status");
+      const otherCookie = await factory.authenticateAndGetCookie(otherEmail, "user");
+
+      const response = await request(app.getHttpServer())
+        .get(`/api/payments/status/${testPaymentTxRef}`)
+        .set("Cookie", otherCookie);
+
+      expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+      expect(response.body.message).toContain("permission");
+    });
+  });
+
+  describe("POST /api/payments/:txRef/refund", () => {
+    let successfulPaymentTxRef: string;
+
+    beforeAll(async () => {
+      const payment = await factory.createPayment(testBookingId, {
+        amountExpected: 50000,
+        amountCharged: 50000,
+        status: "SUCCESSFUL",
+        flutterwaveTransactionId: "FLW-12345",
+        confirmedAt: new Date(),
+      });
+      successfulPaymentTxRef = payment.txRef;
+    });
+
+    it("should return 401 when not authenticated", async () => {
+      const response = await request(app.getHttpServer())
+        .post(`/api/payments/${successfulPaymentTxRef}/refund`)
+        .send({ amount: 25000, reason: "Customer cancellation" });
+
+      expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+    });
+
+    it("should reject refund when user does not own the payment", async () => {
+      const response = await request(app.getHttpServer())
+        .post(`/api/payments/${successfulPaymentTxRef}/refund`)
+        .set("Cookie", otherUserCookie)
+        .send({ amount: 25000, reason: "Customer cancellation" });
+
+      expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+      expect(response.body.message).toContain("permission");
+    });
+
+    it("should initiate refund for booking owner", async () => {
+      const mockRefundResult = {
+        success: true,
+        refundId: 12345,
+        status: "pending",
+      };
+      vi.spyOn(flutterwaveService, "initiateRefund").mockResolvedValueOnce(mockRefundResult);
+
+      const response = await request(app.getHttpServer())
+        .post(`/api/payments/${successfulPaymentTxRef}/refund`)
+        .set("Cookie", testUserCookie)
+        .send({ amount: 25000, reason: "Customer cancellation" });
+
+      expect(response.status).toBe(HttpStatus.CREATED);
+      expect(response.body.success).toBe(true);
+      expect(response.body.refundId).toBeDefined();
+    });
+
+    it("should return 404 for non-existent payment", async () => {
+      const response = await request(app.getHttpServer())
+        .post("/api/payments/non-existent-txref/refund")
+        .set("Cookie", testUserCookie)
+        .send({ amount: 25000, reason: "Customer cancellation" });
+
+      expect(response.status).toBe(HttpStatus.NOT_FOUND);
+    });
+
+    it("should reject refund for non-successful payment", async () => {
+      const pendingPayment = await factory.createPayment(testBookingId, {
+        status: "PENDING",
+      });
+
+      const response = await request(app.getHttpServer())
+        .post(`/api/payments/${pendingPayment.txRef}/refund`)
+        .set("Cookie", testUserCookie)
+        .send({ amount: 25000, reason: "Customer cancellation" });
+
+      expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+      expect(response.body.message).toContain("not successful");
+    });
+
+    it("should reject refund amount exceeding payment amount", async () => {
+      const excessPayment = await factory.createPayment(testBookingId, {
+        status: "SUCCESSFUL",
+        flutterwaveTransactionId: `FLW-EXCESS-${Date.now()}`,
+      });
+
+      const response = await request(app.getHttpServer())
+        .post(`/api/payments/${excessPayment.txRef}/refund`)
+        .set("Cookie", testUserCookie)
+        .send({ amount: 100000, reason: "Too much refund" });
+
+      expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+      expect(response.body.message).toContain("exceed");
+    });
+
+    it("should validate refund request body with Zod schema", async () => {
+      const response = await request(app.getHttpServer())
+        .post(`/api/payments/${successfulPaymentTxRef}/refund`)
+        .set("Cookie", testUserCookie)
+        .send({ amount: 50 }); // Below minimum of 100
+
+      expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+      expect(response.body.message).toBe("Validation failed");
+    });
+  });
+});

--- a/test/payments.e2e-spec.ts
+++ b/test/payments.e2e-spec.ts
@@ -9,7 +9,7 @@ import { AuthEmailService } from "../src/modules/auth/auth-email.service";
 import { DatabaseService } from "../src/modules/database/database.service";
 import { FlutterwaveService } from "../src/modules/flutterwave/flutterwave.service";
 import { TestDataFactory, uniqueEmail } from "./helpers";
-import { PaymentAttemptStatus, PaymentStatus } from "@prisma/client";
+import { PaymentAttemptStatus } from "@prisma/client";
 
 describe("Payments E2E Tests", () => {
   let app: INestApplication;
@@ -102,17 +102,21 @@ describe("Payments E2E Tests", () => {
     });
 
     it("should reject payment for non-existent booking", async () => {
+      // Use a valid CUID format that doesn't exist in the database
+      const nonExistentCuid = "cm5nonexistent00000000001";
+
       const response = await request(app.getHttpServer())
         .post("/api/payments/initialize")
         .set("Cookie", testUserCookie)
         .send({
           type: "booking",
-          entityId: "non-existent-id",
+          entityId: nonExistentCuid,
           amount: 50000,
           callbackUrl: "https://example.com/callback",
         });
 
-      expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+      expect(response.status).toBe(HttpStatus.NOT_FOUND);
+      expect(response.body.message).toBe("Booking not found");
     });
 
     it("should reject payment for booking owned by another user", async () => {

--- a/test/payments.e2e-spec.ts
+++ b/test/payments.e2e-spec.ts
@@ -118,12 +118,9 @@ describe("Payments E2E Tests", () => {
     });
 
     it("should reject payment for booking owned by another user", async () => {
-      const otherEmail = uniqueEmail("other-user");
-      const otherCookie = await factory.authenticateAndGetCookie(otherEmail, "user");
-
       const response = await request(app.getHttpServer())
         .post("/api/payments/initialize")
-        .set("Cookie", otherCookie)
+        .set("Cookie", otherUserCookie)
         .send({
           type: "booking",
           entityId: testBookingId,
@@ -189,12 +186,9 @@ describe("Payments E2E Tests", () => {
     });
 
     it("should reject access to payment owned by another user", async () => {
-      const otherEmail = uniqueEmail("other-user-status");
-      const otherCookie = await factory.authenticateAndGetCookie(otherEmail, "user");
-
       const response = await request(app.getHttpServer())
         .get(`/api/payments/status/${testPaymentTxRef}`)
-        .set("Cookie", otherCookie);
+        .set("Cookie", otherUserCookie);
 
       expect(response.status).toBe(HttpStatus.BAD_REQUEST);
       expect(response.body.message).toContain("permission");
@@ -277,6 +271,7 @@ describe("Payments E2E Tests", () => {
     it("should reject refund amount exceeding payment amount", async () => {
       const excessPayment = await factory.createPayment(testBookingId, {
         status: "SUCCESSFUL",
+        amountCharged: 50000,
         flutterwaveTransactionId: `FLW-EXCESS-${Date.now()}`,
       });
 

--- a/test/payments.e2e-spec.ts
+++ b/test/payments.e2e-spec.ts
@@ -9,6 +9,7 @@ import { AuthEmailService } from "../src/modules/auth/auth-email.service";
 import { DatabaseService } from "../src/modules/database/database.service";
 import { FlutterwaveService } from "../src/modules/flutterwave/flutterwave.service";
 import { TestDataFactory, uniqueEmail } from "./helpers";
+import { PaymentAttemptStatus, PaymentStatus } from "@prisma/client";
 
 describe("Payments E2E Tests", () => {
   let app: INestApplication;
@@ -151,7 +152,10 @@ describe("Payments E2E Tests", () => {
     let testPaymentTxRef: string;
 
     beforeAll(async () => {
-      const payment = await factory.createPayment(testBookingId);
+      const payment = await factory.createPayment(testBookingId, {
+        amountExpected: 50000,
+        status: PaymentAttemptStatus.PENDING,
+      });
       testPaymentTxRef = payment.txRef;
     });
 

--- a/test/payments.e2e-spec.ts
+++ b/test/payments.e2e-spec.ts
@@ -80,10 +80,8 @@ describe("Payments E2E Tests", () => {
 
     it("should initialize payment for a booking", async () => {
       const mockPaymentIntent = {
-        success: true,
+        paymentIntentId: `booking_${testBookingId}`,
         checkoutUrl: "https://checkout.flutterwave.com/v3/hosted/pay/abc123",
-        paymentIntentId: "FLW-MOCK-123",
-        txRef: `booking_${testBookingId}`,
       };
       vi.spyOn(flutterwaveService, "createPaymentIntent").mockResolvedValueOnce(mockPaymentIntent);
 
@@ -98,9 +96,8 @@ describe("Payments E2E Tests", () => {
         });
 
       expect(response.status).toBe(HttpStatus.CREATED);
-      expect(response.body.success).toBe(true);
-      expect(response.body.checkoutUrl).toBeDefined();
-      expect(response.body.txRef).toBeDefined();
+      expect(response.body.paymentIntentId).toBe(mockPaymentIntent.paymentIntentId);
+      expect(response.body.checkoutUrl).toBe(mockPaymentIntent.checkoutUrl);
     });
 
     it("should reject payment for non-existent booking", async () => {


### PR DESCRIPTION
Add customer-facing payment API endpoints:
- POST /api/payments/initialize - Initialize payment for booking/extension
- GET /api/payments/status/:txRef - Get payment status
- POST /api/payments/:txRef/refund - Initiate refund

Key changes:
- Add PaymentApiService with ownership validation
- Add PaymentController with SessionGuard protection
- Add Zod validation for request DTOs
- Add ZodValidationPipe for consistent error responses
- Update GlobalExceptionFilter to include validation errors
- Add comprehensive unit tests for PaymentApiService
- Add E2E tests for all payment endpoints

Test infrastructure improvements:
- Add createExtension and createPayment fixtures with Prisma types
- Add ExtensionWithBookingLeg and PaymentWithRelations types
- Add automatic rate limit clearing in TestDataFactory auth methods
- Simplify E2E test helper types using Partial<Prisma.XxxUncheckedCreateInput>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces customer-facing payment flows with strong validation and safer refund handling.
> 
> - **New APIs**: `POST /api/payments/initialize`, `GET /api/payments/status/:txRef`, `POST /api/payments/:txRef/refund` via `PaymentController` + `PaymentApiService` with ownership checks and server-validated amounts
> - **Refund idempotency & states**: Adds `Payment.refundIdempotencyKey` (unique) and `PaymentAttemptStatus.REFUND_ERROR`; Flutterwave refunds include `X-Idempotency-Key`, distinguish provider rejection vs network/unknown (rethrow) and set DB to `REFUND_FAILED` or `REFUND_ERROR` accordingly; race-safe status transitions using `updateMany` guards
> - **Validation & errors**: Zod DTOs + `ZodValidationPipe` returning `{ message, errors }`; `GlobalExceptionFilter` now surfaces `errors` in responses
> - **Flutterwave**: `initiateRefund` signature updated (idempotencyKey), header support, refined error propagation; tests updated
> - **Schema/types/tests**: Prisma schema changes; new fixtures/types; comprehensive unit tests for `PaymentApiService` and E2E tests for all payment endpoints; e2e setup seeds roles
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffb9543d12190c695ffeb7ebeec32c4332d433fc. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->