### PR TITLE
feat(booking): add booking confirmation on successful payment

### DIFF
--- a/src/modules/booking/booking-confirmation.service.spec.ts
+++ b/src/modules/booking/booking-confirmation.service.spec.ts
@@ -1,0 +1,268 @@
+import { getQueueToken } from "@nestjs/bullmq";
+import { Test, TestingModule } from "@nestjs/testing";
+import type { Payment } from "@prisma/client";
+import { BookingStatus, PaymentAttemptStatus, PaymentStatus } from "@prisma/client";
+import { Decimal } from "@prisma/client/runtime/library";
+import { Queue } from "bullmq";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NOTIFICATIONS_QUEUE } from "../../config/constants";
+import {
+  createBooking,
+  createCar,
+  createUser,
+} from "../../shared/helper.fixtures";
+import type { BookingWithRelations } from "../../types";
+import { DatabaseService } from "../database/database.service";
+import { NotificationType } from "../notification/notification.interface";
+import { BookingConfirmationService } from "./booking-confirmation.service";
+
+// Helper to create mock Payment objects with required fields for testing
+function createMockPayment(overrides: Partial<Payment>): Payment {
+  return {
+    id: "payment-123",
+    bookingId: "booking-123",
+    extensionId: null,
+    txRef: "tx-ref-123",
+    flutterwaveTransactionId: "12345",
+    flutterwaveReference: null,
+    amountExpected: new Decimal(10000),
+    amountCharged: new Decimal(10000),
+    currency: "NGN",
+    feeChargedByProvider: null,
+    status: PaymentAttemptStatus.SUCCESSFUL,
+    paymentProviderStatus: null,
+    paymentMethod: null,
+    initiatedAt: new Date(),
+    confirmedAt: new Date(),
+    lastVerifiedAt: null,
+    webhookPayload: null,
+    verificationResponse: null,
+    refundIdempotencyKey: null,
+    ...overrides,
+  };
+}
+
+// Helper to create mock BookingWithRelations for testing using fixtures
+function createMockBookingWithRelations(
+  overrides: Partial<BookingWithRelations> = {},
+): BookingWithRelations {
+  return createBooking({
+    status: BookingStatus.PENDING,
+    paymentStatus: PaymentStatus.UNPAID,
+    user: createUser(),
+    car: createCar(),
+    chauffeur: null,
+    legs: [],
+    ...overrides,
+  });
+}
+
+describe("BookingConfirmationService", () => {
+  let service: BookingConfirmationService;
+  let databaseService: DatabaseService;
+  let notificationQueue: Queue;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BookingConfirmationService,
+        {
+          provide: DatabaseService,
+          useValue: {
+            booking: {
+              findUnique: vi.fn(),
+              update: vi.fn(),
+            },
+          },
+        },
+        {
+          provide: getQueueToken(NOTIFICATIONS_QUEUE),
+          useValue: {
+            add: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<BookingConfirmationService>(BookingConfirmationService);
+    databaseService = module.get<DatabaseService>(DatabaseService);
+    notificationQueue = module.get<Queue>(getQueueToken(NOTIFICATIONS_QUEUE));
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+
+  describe("confirmFromPayment", () => {
+    it("should confirm a PENDING booking and update to CONFIRMED", async () => {
+      const mockPayment = createMockPayment({
+        id: "payment-123",
+        bookingId: "booking-123",
+        txRef: "tx-ref-123",
+      });
+      const mockBooking = createMockBookingWithRelations({
+        id: "booking-123",
+        status: BookingStatus.PENDING,
+        paymentStatus: PaymentStatus.UNPAID,
+      });
+
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValueOnce(mockBooking);
+      vi.mocked(databaseService.booking.update).mockResolvedValueOnce({
+        ...mockBooking,
+        status: BookingStatus.CONFIRMED,
+        paymentStatus: PaymentStatus.PAID,
+      });
+      vi.mocked(notificationQueue.add).mockResolvedValueOnce({} as any);
+
+      const result = await service.confirmFromPayment(mockPayment);
+
+      expect(result).toBe(true);
+      expect(databaseService.booking.findUnique).toHaveBeenCalledWith({
+        where: { id: "booking-123" },
+        include: {
+          chauffeur: true,
+          user: true,
+          car: { include: { owner: true } },
+          legs: { include: { extensions: true } },
+        },
+      });
+      expect(databaseService.booking.update).toHaveBeenCalledWith({
+        where: { id: "booking-123" },
+        data: {
+          status: BookingStatus.CONFIRMED,
+          paymentStatus: PaymentStatus.PAID,
+        },
+      });
+    });
+
+    it("should queue booking confirmation notification after confirmation", async () => {
+      const mockPayment = createMockPayment({
+        id: "payment-123",
+        bookingId: "booking-123",
+      });
+      const mockBooking = createMockBookingWithRelations({
+        id: "booking-123",
+        status: BookingStatus.PENDING,
+      });
+
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValueOnce(mockBooking);
+      vi.mocked(databaseService.booking.update).mockResolvedValueOnce({
+        ...mockBooking,
+        status: BookingStatus.CONFIRMED,
+      });
+      vi.mocked(notificationQueue.add).mockResolvedValueOnce({} as any);
+
+      await service.confirmFromPayment(mockPayment);
+
+      expect(notificationQueue.add).toHaveBeenCalledWith(
+        "send-notification",
+        expect.objectContaining({
+          type: NotificationType.BOOKING_CONFIRMED,
+          bookingId: "booking-123",
+          templateData: expect.objectContaining({
+            subject: "Your booking is confirmed!",
+          }),
+        }),
+        { priority: 1 },
+      );
+    });
+
+    it("should return false when payment has no bookingId", async () => {
+      const mockPayment = createMockPayment({
+        id: "payment-123",
+        bookingId: null,
+        txRef: "tx-ref-123",
+      });
+
+      const result = await service.confirmFromPayment(mockPayment);
+
+      expect(result).toBe(false);
+      expect(databaseService.booking.findUnique).not.toHaveBeenCalled();
+      expect(databaseService.booking.update).not.toHaveBeenCalled();
+    });
+
+    it("should return false when booking is not found", async () => {
+      const mockPayment = createMockPayment({
+        id: "payment-123",
+        bookingId: "non-existent-booking",
+      });
+
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValueOnce(null);
+
+      const result = await service.confirmFromPayment(mockPayment);
+
+      expect(result).toBe(false);
+      expect(databaseService.booking.update).not.toHaveBeenCalled();
+    });
+
+    it("should return false when booking is not in PENDING status", async () => {
+      const mockPayment = createMockPayment({
+        id: "payment-123",
+        bookingId: "booking-123",
+      });
+      const mockBooking = createMockBookingWithRelations({
+        id: "booking-123",
+        status: BookingStatus.CONFIRMED, // Already confirmed
+      });
+
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValueOnce(mockBooking);
+
+      const result = await service.confirmFromPayment(mockPayment);
+
+      expect(result).toBe(false);
+      expect(databaseService.booking.update).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      BookingStatus.ACTIVE,
+      BookingStatus.COMPLETED,
+      BookingStatus.CANCELLED,
+      BookingStatus.REJECTED,
+    ])(
+      "should return false when booking is in %s status (idempotency)",
+      async (bookingStatus) => {
+        const mockPayment = createMockPayment({
+          id: "payment-123",
+          bookingId: "booking-123",
+        });
+        const mockBooking = createMockBookingWithRelations({
+          id: "booking-123",
+          status: bookingStatus,
+        });
+
+        vi.mocked(databaseService.booking.findUnique).mockResolvedValueOnce(mockBooking);
+
+        const result = await service.confirmFromPayment(mockPayment);
+
+        expect(result).toBe(false);
+        expect(databaseService.booking.update).not.toHaveBeenCalled();
+      },
+    );
+
+    it("should not fail confirmation if notification queueing fails", async () => {
+      const mockPayment = createMockPayment({
+        id: "payment-123",
+        bookingId: "booking-123",
+      });
+      const mockBooking = createMockBookingWithRelations({
+        id: "booking-123",
+        status: BookingStatus.PENDING,
+      });
+
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValueOnce(mockBooking);
+      vi.mocked(databaseService.booking.update).mockResolvedValueOnce({
+        ...mockBooking,
+        status: BookingStatus.CONFIRMED,
+      });
+      vi.mocked(notificationQueue.add).mockRejectedValueOnce(
+        new Error("Queue connection failed"),
+      );
+
+      // Should not throw, should still return true
+      const result = await service.confirmFromPayment(mockPayment);
+
+      expect(result).toBe(true);
+      expect(databaseService.booking.update).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/modules/booking/booking-confirmation.service.ts
+++ b/src/modules/booking/booking-confirmation.service.ts
@@ -1,0 +1,146 @@
+import { InjectQueue } from "@nestjs/bullmq";
+import { Injectable, Logger } from "@nestjs/common";
+import { BookingStatus, PaymentStatus, type Payment } from "@prisma/client";
+import { Queue } from "bullmq";
+import { NOTIFICATIONS_QUEUE } from "../../config/constants";
+import { normaliseBookingDetails } from "../../shared/helper";
+import type { BookingWithRelations } from "../../types";
+import { DatabaseService } from "../database/database.service";
+import {
+  CLIENT_RECIPIENT_TYPE,
+  DEFAULT_CHANNELS,
+  SEND_NOTIFICATION_JOB_NAME,
+} from "../notification/notification.const";
+import { NotificationType, type NotificationJobData } from "../notification/notification.interface";
+
+/**
+ * Service for confirming bookings after successful payment.
+ *
+ * This service handles:
+ * - Updating booking status from PENDING to CONFIRMED
+ * - Updating booking payment status to PAID
+ * - Queueing notifications to inform the customer
+ */
+@Injectable()
+export class BookingConfirmationService {
+  private readonly logger = new Logger(BookingConfirmationService.name);
+
+  constructor(
+    private readonly databaseService: DatabaseService,
+    @InjectQueue(NOTIFICATIONS_QUEUE)
+    private readonly notificationQueue: Queue<NotificationJobData>,
+  ) {}
+
+  /**
+   * Confirm a booking after successful payment verification.
+   *
+   * Called by PaymentWebhookService when a charge.completed webhook
+   * is verified as successful.
+   *
+   * @param payment - The payment record that was just confirmed
+   * @returns true if booking was confirmed, false if confirmation was skipped
+   */
+  async confirmFromPayment(payment: Payment): Promise<boolean> {
+    const { bookingId, txRef } = payment;
+
+    if (!bookingId) {
+      this.logger.warn("Payment has no associated booking, skipping confirmation", {
+        paymentId: payment.id,
+        txRef,
+      });
+      return false;
+    }
+
+    // Fetch booking with all relations needed for notification
+    const booking = await this.databaseService.booking.findUnique({
+      where: { id: bookingId },
+      include: {
+        chauffeur: true,
+        user: true,
+        car: { include: { owner: true } },
+        legs: { include: { extensions: true } },
+      },
+    });
+
+    if (!booking) {
+      this.logger.warn("Booking not found for payment", {
+        bookingId,
+        paymentId: payment.id,
+        txRef,
+      });
+      return false;
+    }
+
+    // Only confirm PENDING bookings - other states should not be modified
+    if (booking.status !== BookingStatus.PENDING) {
+      this.logger.log("Booking not in PENDING status, skipping confirmation", {
+        bookingId,
+        currentStatus: booking.status,
+        txRef,
+      });
+      return false;
+    }
+
+    // Confirm the booking
+    await this.databaseService.booking.update({
+      where: { id: bookingId },
+      data: {
+        status: BookingStatus.CONFIRMED,
+        paymentStatus: PaymentStatus.PAID,
+      },
+    });
+
+    this.logger.log("Booking confirmed after payment", {
+      bookingId,
+      oldStatus: booking.status,
+      newStatus: BookingStatus.CONFIRMED,
+      paymentId: payment.id,
+      txRef,
+    });
+
+    // Queue notification asynchronously (don't block webhook response)
+    await this.queueBookingConfirmedNotification(booking as BookingWithRelations);
+
+    return true;
+  }
+
+  /**
+   * Queue a booking confirmation notification.
+   * Uses the notification queue to avoid blocking the webhook handler.
+   */
+  private async queueBookingConfirmedNotification(booking: BookingWithRelations): Promise<void> {
+    try {
+      const bookingDetails = normaliseBookingDetails(booking);
+
+      const jobData: NotificationJobData = {
+        id: `booking-confirmed-${booking.id}-${Date.now()}`,
+        type: NotificationType.BOOKING_CONFIRMED,
+        channels: DEFAULT_CHANNELS,
+        bookingId: booking.id,
+        recipients: {
+          [CLIENT_RECIPIENT_TYPE]: {
+            email: bookingDetails.customerEmail,
+            phoneNumber: bookingDetails.customerPhone,
+          },
+        },
+        templateData: {
+          ...bookingDetails,
+          subject: "Your booking is confirmed!",
+        },
+      };
+
+      await this.notificationQueue.add(SEND_NOTIFICATION_JOB_NAME, jobData, { priority: 1 });
+
+      this.logger.log("Queued booking confirmation notification", {
+        bookingId: booking.id,
+        notificationId: jobData.id,
+      });
+    } catch (error) {
+      // Log but don't throw - notification failure shouldn't fail the confirmation
+      this.logger.error("Failed to queue booking confirmation notification", {
+        bookingId: booking.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}

--- a/src/modules/booking/booking.module.ts
+++ b/src/modules/booking/booking.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { NotificationModule } from "../notification/notification.module";
+import { BookingConfirmationService } from "./booking-confirmation.service";
+
+@Module({
+  imports: [NotificationModule],
+  providers: [BookingConfirmationService],
+  exports: [BookingConfirmationService],
+})
+export class BookingModule {}

--- a/src/modules/notification/notification.interface.ts
+++ b/src/modules/notification/notification.interface.ts
@@ -9,6 +9,7 @@ export enum NotificationType {
   BOOKING_STATUS_CHANGE = "booking-status-change",
   BOOKING_REMINDER_START = "booking-reminder-start",
   BOOKING_REMINDER_END = "booking-reminder-end",
+  BOOKING_CONFIRMED = "booking-confirmed",
 }
 
 export interface EmailNotificationData {

--- a/src/modules/notification/template-data.interface.ts
+++ b/src/modules/notification/template-data.interface.ts
@@ -37,11 +37,19 @@ export interface BookingReminderTemplateData extends NormalisedBookingLegDetails
 }
 
 /**
+ * Template data specific to booking confirmation after payment
+ */
+export interface BookingConfirmedTemplateData extends NormalisedBookingDetails {
+  subject: string;
+}
+
+/**
  * Union type for all possible template data structures
  */
 export type TemplateData =
   | BookingStatusTemplateData
   | BookingReminderTemplateData
+  | BookingConfirmedTemplateData
   | BaseTemplateData;
 
 /**
@@ -58,4 +66,19 @@ export function isBookingReminderTemplateData(
   data: TemplateData,
 ): data is BookingReminderTemplateData {
   return "legStartTime" in data && "legEndTime" in data && "bookingId" in data;
+}
+
+/**
+ * Type guard to check if template data is for booking confirmation
+ */
+export function isBookingConfirmedTemplateData(
+  data: TemplateData,
+): data is BookingConfirmedTemplateData {
+  // BookingConfirmedTemplateData has NormalisedBookingDetails fields but no oldStatus/newStatus
+  return (
+    "bookingReference" in data &&
+    "totalAmount" in data &&
+    !("oldStatus" in data) &&
+    !("legStartTime" in data)
+  );
 }

--- a/src/modules/notification/template-mappers/booking-confirmed-mapper.ts
+++ b/src/modules/notification/template-mappers/booking-confirmed-mapper.ts
@@ -1,0 +1,30 @@
+import { NotificationType } from "../notification.interface";
+import { type TemplateData } from "../template-data.interface";
+import { Template } from "../whatsapp.service";
+import { BaseTemplateMapper } from "./base-template-mapper";
+
+export class BookingConfirmedMapper extends BaseTemplateMapper {
+  canHandle(type: NotificationType): boolean {
+    return type === NotificationType.BOOKING_CONFIRMED;
+  }
+
+  getTemplateKey(type: NotificationType, _recipientType: string): Template | null {
+    if (!this.canHandle(type)) return null;
+    return Template.BookingConfirmation;
+  }
+
+  mapVariables(
+    templateData: TemplateData,
+    _recipientType: string,
+  ): Record<string, string | number> {
+    return {
+      "1": this.getValue(templateData, "customerName"),
+      "2": this.getValue(templateData, "carName"),
+      "3": this.getValue(templateData, "startDate"),
+      "4": this.getValue(templateData, "endDate"),
+      "5": this.getValue(templateData, "pickupLocation"),
+      "6": this.getValue(templateData, "returnLocation"),
+      "7": this.getValue(templateData, "totalAmount"),
+    };
+  }
+}

--- a/src/modules/notification/template-mappers/index.ts
+++ b/src/modules/notification/template-mappers/index.ts
@@ -1,4 +1,5 @@
 export { BaseTemplateMapper, type TemplateVariableMapper } from "./base-template-mapper";
+export { BookingConfirmedMapper } from "./booking-confirmed-mapper";
 export { BookingReminderEndMapper } from "./booking-reminder-end-mapper";
 export { BookingReminderStartMapper } from "./booking-reminder-start-mapper";
 export { BookingStatusMapper } from "./booking-status-mapper";

--- a/src/modules/notification/whatsapp.service.ts
+++ b/src/modules/notification/whatsapp.service.ts
@@ -9,6 +9,7 @@ export enum Template {
   ChauffeurBookingLegStartReminder = "chauffeurBookingLegStartReminder",
   ClientBookingLegEndReminder = "clientBookingLegEndReminder",
   ChauffeurBookingLegEndReminder = "chauffeurBookingLegEndReminder",
+  BookingConfirmation = "bookingConfirmation",
 }
 
 const contentSidMap: Record<Template, string> = {
@@ -17,6 +18,7 @@ const contentSidMap: Record<Template, string> = {
   [Template.ChauffeurBookingLegStartReminder]: "HX8d44b0747c995713d129d77f4cc3c860",
   [Template.ClientBookingLegEndReminder]: "HX0c8470054c0ff1a0b43c06fe196e2ec3",
   [Template.ChauffeurBookingLegEndReminder]: "HX9faf29432a18e9f8f8283a5e281e5a3c",
+  [Template.BookingConfirmation]: "HXac9f0b83ee03d47fe2f2969173dac354",
 };
 
 @Injectable()

--- a/src/modules/payment/payment-webhook.service.spec.ts
+++ b/src/modules/payment/payment-webhook.service.spec.ts
@@ -1,8 +1,9 @@
 import { Test, TestingModule } from "@nestjs/testing";
-import type { Payment, PayoutTransaction } from "@prisma/client";
 import { PaymentAttemptStatus, PayoutTransactionStatus } from "@prisma/client";
 import { Decimal } from "@prisma/client/runtime/library";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createPaymentRecord, createPayoutTransaction } from "../../shared/helper.fixtures";
+import { BookingConfirmationService } from "../booking/booking-confirmation.service";
 import { DatabaseService } from "../database/database.service";
 import type {
   FlutterwaveChargeData,
@@ -12,6 +13,10 @@ import type {
 } from "../flutterwave/flutterwave.interface";
 import { FlutterwaveService } from "../flutterwave/flutterwave.service";
 import { PaymentWebhookService } from "./payment-webhook.service";
+
+const mockBookingConfirmationService = {
+  confirmFromPayment: vi.fn(),
+};
 
 // Helper to create mock verification data matching webhook charge data
 function createMockVerificationData(
@@ -41,57 +46,11 @@ function createMockVerificationData(
   };
 }
 
-// Helper to create mock Payment objects with only required fields for testing
-function createMockPayment(overrides: Partial<Payment>): Payment {
-  return {
-    id: "payment-123",
-    bookingId: null,
-    extensionId: null,
-    txRef: "tx-ref-123",
-    flutterwaveTransactionId: null,
-    flutterwaveReference: null,
-    amountExpected: new Decimal(10000),
-    amountCharged: null,
-    currency: "NGN",
-    feeChargedByProvider: null,
-    status: PaymentAttemptStatus.PENDING,
-    paymentProviderStatus: null,
-    paymentMethod: null,
-    initiatedAt: new Date(),
-    confirmedAt: null,
-    lastVerifiedAt: null,
-    webhookPayload: null,
-    verificationResponse: null,
-    refundIdempotencyKey: null,
-    ...overrides,
-  };
-}
-
-// Helper to create mock PayoutTransaction objects with only required fields for testing
-function createMockPayoutTransaction(overrides: Partial<PayoutTransaction>): PayoutTransaction {
-  return {
-    id: "payout-123",
-    fleetOwnerId: "fleet-owner-123",
-    bookingId: null,
-    extensionId: null,
-    amountToPay: new Decimal(5000),
-    amountPaid: null,
-    currency: "NGN",
-    status: PayoutTransactionStatus.PROCESSING,
-    payoutProviderReference: null,
-    payoutMethodDetails: null,
-    initiatedAt: new Date(),
-    processedAt: null,
-    completedAt: null,
-    notes: null,
-    ...overrides,
-  };
-}
-
 describe("PaymentWebhookService", () => {
   let service: PaymentWebhookService;
   let databaseService: DatabaseService;
   let flutterwaveService: FlutterwaveService;
+  let bookingConfirmationService: BookingConfirmationService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -116,12 +75,20 @@ describe("PaymentWebhookService", () => {
             verifyTransaction: vi.fn(),
           },
         },
+        {
+          provide: BookingConfirmationService,
+          useValue: mockBookingConfirmationService,
+        },
       ],
     }).compile();
 
     service = module.get<PaymentWebhookService>(PaymentWebhookService);
     databaseService = module.get<DatabaseService>(DatabaseService);
     flutterwaveService = module.get<FlutterwaveService>(FlutterwaveService);
+    bookingConfirmationService = module.get<BookingConfirmationService>(BookingConfirmationService);
+
+    // Reset mocks between tests
+    vi.clearAllMocks();
   });
 
   it("should be defined", () => {
@@ -157,7 +124,7 @@ describe("PaymentWebhookService", () => {
     };
 
     it("should update payment status to SUCCESSFUL when charge is successful", async () => {
-      const mockPayment = createMockPayment({
+      const mockPayment = createPaymentRecord({
         id: "payment-123",
         txRef: "tx-ref-123",
         status: PaymentAttemptStatus.PENDING,
@@ -188,9 +155,77 @@ describe("PaymentWebhookService", () => {
       });
     });
 
+    it("should call bookingConfirmationService when payment is successful", async () => {
+      const mockPayment = createPaymentRecord({
+        id: "payment-123",
+        txRef: "tx-ref-123",
+        status: PaymentAttemptStatus.PENDING,
+      });
+
+      vi.mocked(flutterwaveService.verifyTransaction).mockResolvedValueOnce({
+        status: "success",
+        message: "Transaction verified",
+        data: createMockVerificationData(mockChargeData),
+      });
+      vi.mocked(databaseService.payment.findFirst).mockResolvedValueOnce(mockPayment);
+      vi.mocked(databaseService.payment.update).mockResolvedValueOnce(mockPayment);
+      vi.mocked(bookingConfirmationService.confirmFromPayment).mockResolvedValueOnce(true);
+
+      await service.handleWebhook({ event: "charge.completed", data: mockChargeData });
+
+      expect(bookingConfirmationService.confirmFromPayment).toHaveBeenCalledWith(mockPayment);
+    });
+
+    it("should not call bookingConfirmationService when payment fails", async () => {
+      const failedChargeData = { ...mockChargeData, status: "failed" };
+      const mockPayment = createPaymentRecord({
+        id: "payment-123",
+        txRef: "tx-ref-123",
+        status: PaymentAttemptStatus.PENDING,
+      });
+
+      vi.mocked(flutterwaveService.verifyTransaction).mockResolvedValueOnce({
+        status: "success",
+        message: "Transaction verified",
+        data: createMockVerificationData(failedChargeData, { status: "failed" }),
+      });
+      vi.mocked(databaseService.payment.findFirst).mockResolvedValueOnce(mockPayment);
+      vi.mocked(databaseService.payment.update).mockResolvedValueOnce(mockPayment);
+
+      await service.handleWebhook({ event: "charge.completed", data: failedChargeData });
+
+      expect(bookingConfirmationService.confirmFromPayment).not.toHaveBeenCalled();
+    });
+
+    it("should handle uppercase status from Flutterwave verification (case-insensitive)", async () => {
+      const mockPayment = createPaymentRecord({
+        id: "payment-123",
+        txRef: "tx-ref-123",
+        status: PaymentAttemptStatus.PENDING,
+      });
+
+      // Flutterwave may return status in different cases (e.g., "SUCCESSFUL", "Successful")
+      vi.mocked(flutterwaveService.verifyTransaction).mockResolvedValueOnce({
+        status: "success",
+        message: "Transaction verified",
+        data: createMockVerificationData(mockChargeData, { status: "SUCCESSFUL" }),
+      });
+      vi.mocked(databaseService.payment.findFirst).mockResolvedValueOnce(mockPayment);
+      vi.mocked(databaseService.payment.update).mockResolvedValueOnce(mockPayment);
+
+      await service.handleWebhook({ event: "charge.completed", data: mockChargeData });
+
+      expect(databaseService.payment.update).toHaveBeenCalledWith({
+        where: { id: "payment-123" },
+        data: expect.objectContaining({
+          status: "SUCCESSFUL",
+        }),
+      });
+    });
+
     it("should update payment status to FAILED when verified status is failed", async () => {
       const failedChargeData = { ...mockChargeData, status: "failed" };
-      const mockPayment = createMockPayment({
+      const mockPayment = createPaymentRecord({
         id: "payment-123",
         txRef: "tx-ref-123",
         status: PaymentAttemptStatus.PENDING,
@@ -215,7 +250,7 @@ describe("PaymentWebhookService", () => {
     });
 
     it("should skip processing if payment already successful (idempotency)", async () => {
-      const mockPayment = createMockPayment({
+      const mockPayment = createPaymentRecord({
         id: "payment-123",
         txRef: "tx-ref-123",
         status: PaymentAttemptStatus.SUCCESSFUL,
@@ -234,7 +269,7 @@ describe("PaymentWebhookService", () => {
     });
 
     it("should skip processing if payment already failed (idempotency)", async () => {
-      const mockPayment = createMockPayment({
+      const mockPayment = createPaymentRecord({
         id: "payment-123",
         txRef: "tx-ref-123",
         status: PaymentAttemptStatus.FAILED,
@@ -261,7 +296,7 @@ describe("PaymentWebhookService", () => {
     ])(
       "should skip processing if payment is in %s state (idempotency - preserves refund states)",
       async (refundStatus) => {
-        const mockPayment = createMockPayment({
+        const mockPayment = createPaymentRecord({
           id: "payment-123",
           txRef: "tx-ref-123",
           status: refundStatus,
@@ -410,7 +445,7 @@ describe("PaymentWebhookService", () => {
     it("should use verified status (not webhook status) for payment state", async () => {
       // Webhook claims "successful" but verification shows "failed"
       const webhookWithWrongStatus = { ...mockChargeData, status: "successful" };
-      const mockPayment = createMockPayment({
+      const mockPayment = createPaymentRecord({
         id: "payment-123",
         txRef: "tx-ref-123",
         status: PaymentAttemptStatus.PENDING,
@@ -458,7 +493,7 @@ describe("PaymentWebhookService", () => {
     };
 
     it("should update payout transaction status to PAID_OUT when transfer is successful", async () => {
-      const mockPayout = createMockPayoutTransaction({
+      const mockPayout = createPayoutTransaction({
         id: "payout-123",
         payoutProviderReference: "payout-ref-123",
         status: PayoutTransactionStatus.PROCESSING,
@@ -483,7 +518,7 @@ describe("PaymentWebhookService", () => {
 
     it("should update payout transaction status to FAILED when transfer fails", async () => {
       const failedTransferData = { ...mockTransferData, status: "FAILED" };
-      const mockPayout = createMockPayoutTransaction({
+      const mockPayout = createPayoutTransaction({
         id: "payout-123",
         payoutProviderReference: "payout-ref-123",
         status: PayoutTransactionStatus.PROCESSING,
@@ -504,7 +539,7 @@ describe("PaymentWebhookService", () => {
     });
 
     it("should skip processing if payout already finalized (idempotency)", async () => {
-      const mockPayout = createMockPayoutTransaction({
+      const mockPayout = createPayoutTransaction({
         id: "payout-123",
         payoutProviderReference: "payout-ref-123",
         status: PayoutTransactionStatus.PAID_OUT,
@@ -589,7 +624,7 @@ describe("PaymentWebhookService", () => {
     };
 
     it("should update payment status to REFUNDED for full refund", async () => {
-      const mockPayment = createMockPayment({
+      const mockPayment = createPaymentRecord({
         id: "payment-123",
         flutterwaveTransactionId: "12345",
         status: PaymentAttemptStatus.REFUND_PROCESSING,
@@ -619,7 +654,7 @@ describe("PaymentWebhookService", () => {
 
     it("should update payment status to PARTIALLY_REFUNDED for partial refund", async () => {
       const partialRefundData = { ...mockRefundData, AmountRefunded: 5000 };
-      const mockPayment = createMockPayment({
+      const mockPayment = createPaymentRecord({
         id: "payment-123",
         flutterwaveTransactionId: "12345",
         status: PaymentAttemptStatus.REFUND_PROCESSING,
@@ -641,7 +676,7 @@ describe("PaymentWebhookService", () => {
 
     it("should update payment status to REFUND_FAILED when refund fails", async () => {
       const failedRefundData = { ...mockRefundData, status: "failed" };
-      const mockPayment = createMockPayment({
+      const mockPayment = createPaymentRecord({
         id: "payment-123",
         flutterwaveTransactionId: "12345",
         status: PaymentAttemptStatus.REFUND_PROCESSING,
@@ -662,7 +697,7 @@ describe("PaymentWebhookService", () => {
     });
 
     it("should skip processing if payment not in REFUND_PROCESSING state (idempotency)", async () => {
-      const mockPayment = createMockPayment({
+      const mockPayment = createPaymentRecord({
         id: "payment-123",
         flutterwaveTransactionId: "12345",
         status: PaymentAttemptStatus.REFUNDED,
@@ -703,7 +738,7 @@ describe("PaymentWebhookService", () => {
     });
 
     it("should treat as partial refund when amountCharged is null", async () => {
-      const mockPayment = createMockPayment({
+      const mockPayment = createPaymentRecord({
         id: "payment-123",
         flutterwaveTransactionId: "12345",
         status: PaymentAttemptStatus.REFUND_PROCESSING,

--- a/src/modules/payment/payment-webhook.service.ts
+++ b/src/modules/payment/payment-webhook.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from "@nestjs/common";
-import { PaymentAttemptStatus, PayoutTransactionStatus } from "@prisma/client";
+import { BookingStatus, PaymentAttemptStatus, PayoutTransactionStatus } from "@prisma/client";
 import { BookingConfirmationService } from "../booking/booking-confirmation.service";
 import { DatabaseService } from "../database/database.service";
 import type {
@@ -161,24 +161,14 @@ export class PaymentWebhookService {
         return;
       }
 
-      // Find and update the payment record
+      // Find the payment record with booking relation (needed for idempotency recovery check)
       const payment = await this.databaseService.payment.findFirst({
         where: { txRef: tx_ref },
+        include: { booking: true },
       });
 
       if (!payment) {
         this.logger.warn("Payment not found for webhook", { txRef: tx_ref });
-        return;
-      }
-
-      // Skip if already processed (idempotency)
-      // Only process webhooks for PENDING payments - all other states are terminal or in-progress refunds
-      // This prevents delayed/duplicate webhooks from overwriting refund states (REFUNDED, PARTIALLY_REFUNDED, etc.)
-      if (payment.status !== PaymentAttemptStatus.PENDING) {
-        this.logger.log("Payment not in PENDING state, skipping", {
-          txRef: tx_ref,
-          currentStatus: payment.status,
-        });
         return;
       }
 
@@ -189,6 +179,39 @@ export class PaymentWebhookService {
         verifiedStatus.toLowerCase() === "successful"
           ? PaymentAttemptStatus.SUCCESSFUL
           : PaymentAttemptStatus.FAILED;
+
+      // Idempotency check with recovery logic
+      // If payment is already in a terminal state, check if we need to retry booking confirmation
+      if (payment.status !== PaymentAttemptStatus.PENDING) {
+        // Recovery case: Payment is SUCCESSFUL but booking is still PENDING
+        // This can happen if payment update succeeded but booking confirmation failed on a previous attempt
+        // In this case, we should retry the booking confirmation to recover from the inconsistent state
+        if (
+          payment.status === PaymentAttemptStatus.SUCCESSFUL &&
+          payment.booking?.status === BookingStatus.PENDING
+        ) {
+          this.logger.log(
+            "Payment already SUCCESSFUL but booking still PENDING, retrying confirmation for recovery",
+            {
+              txRef: tx_ref,
+              paymentStatus: payment.status,
+              bookingStatus: payment.booking.status,
+              bookingId: payment.booking.id,
+            },
+          );
+          await this.bookingConfirmationService.confirmFromPayment(payment);
+          return;
+        }
+
+        // Normal idempotency: payment is already processed and booking is not in PENDING state
+        // Skip to prevent duplicate processing or overwriting refund states
+        this.logger.log("Payment already processed, skipping", {
+          txRef: tx_ref,
+          currentStatus: payment.status,
+          bookingStatus: payment.booking?.status,
+        });
+        return;
+      }
 
       // Update payment status
       await this.databaseService.payment.update({

--- a/src/modules/payment/payment-webhook.service.ts
+++ b/src/modules/payment/payment-webhook.service.ts
@@ -151,7 +151,15 @@ export class PaymentWebhookService {
       }
 
       // Use verified status for payment state (trust server-side verification over webhook)
+      // Validate status exists and is a string before calling toLowerCase()
       const verifiedStatus = verificationData.status;
+      if (!verifiedStatus || typeof verifiedStatus !== "string") {
+        this.logger.warn(
+          "Missing or invalid status in transaction verification, skipping to prevent errors",
+          { txRef: tx_ref, transactionId, status: verifiedStatus },
+        );
+        return;
+      }
 
       // Find and update the payment record
       const payment = await this.databaseService.payment.findFirst({

--- a/src/modules/payment/payment.module.ts
+++ b/src/modules/payment/payment.module.ts
@@ -4,6 +4,7 @@ import { BullModule } from "@nestjs/bullmq";
 import { Module } from "@nestjs/common";
 import { PAYOUTS_QUEUE } from "../../config/constants";
 import { AuthModule } from "../auth/auth.module";
+import { BookingModule } from "../booking/booking.module";
 import { DatabaseModule } from "../database/database.module";
 import { FlutterwaveModule } from "../flutterwave/flutterwave.module";
 import { PaymentController } from "./payment.controller";
@@ -17,6 +18,7 @@ import { PaymentWebhookService } from "./payment-webhook.service";
     FlutterwaveModule,
     DatabaseModule,
     AuthModule,
+    BookingModule,
     BullModule.registerQueue({
       name: PAYOUTS_QUEUE,
       defaultJobOptions: {

--- a/src/shared/helper.fixtures.ts
+++ b/src/shared/helper.fixtures.ts
@@ -8,9 +8,12 @@ import {
   FleetOwnerStatus,
   PaymentAttemptStatus,
   PaymentStatus,
+  PayoutTransactionStatus,
   ServiceTier,
   Status,
   VehicleType,
+  type Payment,
+  type PayoutTransaction,
 } from "@prisma/client";
 import { Decimal } from "@prisma/client/runtime/library";
 import { BookingWithRelations, ExtensionWithBookingLeg, PaymentWithRelations } from "../types";
@@ -276,6 +279,58 @@ export function createPayment(overrides: Partial<PaymentWithRelations> = {}): Pa
     refundIdempotencyKey: null,
     booking: { id: "booking-123", status: BookingStatus.CONFIRMED, userId: "user-123" },
     extension: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Create a raw Payment record for testing (without relations).
+ * Use this for webhook tests that don't need nested relations.
+ */
+export function createPaymentRecord(overrides: Partial<Payment> = {}): Payment {
+  return {
+    id: "payment-123",
+    bookingId: null,
+    extensionId: null,
+    txRef: "tx-ref-123",
+    flutterwaveTransactionId: null,
+    flutterwaveReference: null,
+    amountExpected: new Decimal(10000),
+    amountCharged: null,
+    currency: "NGN",
+    feeChargedByProvider: null,
+    status: PaymentAttemptStatus.PENDING,
+    paymentProviderStatus: null,
+    paymentMethod: null,
+    initiatedAt: new Date("2024-01-01T00:00:00Z"),
+    confirmedAt: null,
+    lastVerifiedAt: null,
+    webhookPayload: null,
+    verificationResponse: null,
+    refundIdempotencyKey: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Create a mock PayoutTransaction for testing.
+ */
+export function createPayoutTransaction(overrides: Partial<PayoutTransaction> = {}): PayoutTransaction {
+  return {
+    id: "payout-123",
+    fleetOwnerId: "fleet-owner-123",
+    bookingId: null,
+    extensionId: null,
+    amountToPay: new Decimal(5000),
+    amountPaid: null,
+    currency: "NGN",
+    status: PayoutTransactionStatus.PROCESSING,
+    payoutProviderReference: null,
+    payoutMethodDetails: null,
+    initiatedAt: new Date("2024-01-01T00:00:00Z"),
+    processedAt: null,
+    completedAt: null,
+    notes: null,
     ...overrides,
   };
 }

--- a/src/templates/emails.tsx
+++ b/src/templates/emails.tsx
@@ -269,6 +269,39 @@ export async function renderBookingReminderEmail(
   );
 }
 
+export async function renderBookingConfirmationEmail(booking: NormalisedBookingDetails) {
+  const customerName = booking.customerName;
+  const carName = booking.carName;
+  const previewText = "Your booking is confirmed!";
+
+  return await render(
+    <EmailTemplate previewText={previewText} pageTitle="Booking Confirmation">
+      <Heading as="h2" className="text-xl font-semibold mb-4">
+        Booking Confirmed!
+      </Heading>
+      <Text className="mb-3">Hello {customerName},</Text>
+      <Text className="mb-3">
+        Your booking for the <span className="font-semibold">{carName}</span> has been confirmed.
+      </Text>
+      <Section className="border border-gray-200 rounded-md p-4 bg-gray-50">
+        <Text className="font-semibold mb-2 underline">
+          Booking Details (Booking Reference: {booking.bookingReference})
+        </Text>
+        <DetailListItem label="Start Date & Time" value={booking.startDate} />
+        <DetailListItem label="End Date & Time" value={booking.endDate} />
+        <DetailListItem label="Pickup Location" value={booking.pickupLocation} />
+        <DetailListItem label="Drop-off Location" value={booking.returnLocation} />
+        <Hr className="my-2 border-gray-300" />
+        <DetailListItem label="Total Amount" value={booking.totalAmount} />
+      </Section>
+      <Text className="mb-3">
+        Please be at the pickup location on time. You'll be assigned a chauffeur shortly, and we
+        will notify you with their details.
+      </Text>
+    </EmailTemplate>,
+  );
+}
+
 export interface AuthOTPEmailProps {
   readonly otp: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,7 +47,6 @@ export type BookingWithRelations = Prisma.BookingGetPayload<{
   include: {
     chauffeur: true;
     user: true;
-    guestUser: true;
     car: { include: { owner: true } };
     legs: {
       include: {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -349,6 +349,15 @@ export class TestDataFactory {
       where: { id: payoutTransactionId },
     });
   }
+
+  /**
+   * Get a booking by ID.
+   */
+  async getBookingById(bookingId: string) {
+    return this.prisma.booking.findUnique({
+      where: { id: bookingId },
+    });
+  }
 }
 
 /**

--- a/test/setup.e2e.ts
+++ b/test/setup.e2e.ts
@@ -1,0 +1,20 @@
+import { vi } from "vitest";
+
+// Mock email template rendering functions to avoid React dependency in e2e tests
+// The NotificationProcessor imports these functions which use @react-email/components (React)
+// Since BullMQ workers are created independently of NestJS DI, we need to mock at module level
+vi.mock("../src/templates/emails", () => ({
+  renderBookingConfirmationEmail: vi
+    .fn()
+    .mockResolvedValue("<html>Mocked booking confirmation</html>"),
+  renderBookingStatusUpdateEmail: vi.fn().mockResolvedValue("<html>Mocked status update</html>"),
+  renderBookingReminderEmail: vi.fn().mockResolvedValue("<html>Mocked reminder</html>"),
+  renderAuthOTPEmail: vi.fn().mockResolvedValue("<html>Mocked OTP email</html>"),
+}));
+
+// Mock the EmailService to prevent actual API calls to Resend during e2e tests
+vi.mock("../src/modules/notification/email.service", () => ({
+  EmailService: vi.fn().mockImplementation(() => ({
+    sendEmail: vi.fn().mockResolvedValue(undefined),
+  })),
+}));

--- a/vitest.e2e.config.mjs
+++ b/vitest.e2e.config.mjs
@@ -20,6 +20,8 @@ export default defineConfig({
     environment: "node",
     // 3. Optional: Point to your container setup if using Testcontainers
     globalSetup: "./test/e2e.setup.ts",
+    // 4. Setup file for mocking modules (runs before each test file)
+    setupFiles: ["./test/setup.e2e.ts"],
     // 4. Increase timeout to allow external services to start
     testTimeout: 30000,
     hookTimeout: 30000,


### PR DESCRIPTION
- Create BookingModule with BookingConfirmationService
- Add BOOKING_CONFIRMED notification type and template mapper
- Integrate BookingConfirmationService into PaymentWebhookService
- Update booking status to CONFIRMED and paymentStatus to PAID after successful charge.completed webhook
- Queue booking confirmation notifications via BullMQ for async delivery
- Add createPaymentRecord and createPayoutTransaction fixtures
- Add unit tests for BookingConfirmationService (11 tests)
- Add E2E tests for booking confirmation flow (2 tests)
- Update PaymentWebhookService tests with BookingConfirmationService mock

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces automated booking confirmation and notifications upon verified payment.
> 
> - New `BookingConfirmationService` and `BookingModule`; updates booking from `PENDING`→`CONFIRMED` and `paymentStatus` to `PAID`
> - Integrates into `PaymentWebhookService` with stricter verification, case-insensitive status handling, idempotency, and recovery when payment is SUCCESSFUL but booking remains `PENDING`
> - Expands notifications: adds `BOOKING_CONFIRMED` type, email template, WhatsApp template/mapper, and processor support
> - Updates `whatsapp.service` with `BookingConfirmation` template SID
> - Test coverage: unit tests for confirmation flow and webhook logic; E2E tests validating booking confirmation and payout/refund paths; new fixtures/helpers and e2e setup mocks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df9e3fce05b0dd27910dd8151c6f42527eb2aa3f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->