### PR TITLE
feat(notification): add fleet owner notification on booking confirmation

### DIFF
--- a/src/modules/booking/booking-confirmation.service.ts
+++ b/src/modules/booking/booking-confirmation.service.ts
@@ -111,13 +111,21 @@ export class BookingConfirmationService {
    * Uses the notification queue to avoid blocking the webhook handler.
    */
   private async queueBookingConfirmedNotification(booking: BookingWithRelations): Promise<void> {
-    const bookingDetails = normaliseBookingDetails(booking);
+    try {
+      const bookingDetails = normaliseBookingDetails(booking);
 
-    // Queue customer notification
-    await this.queueCustomerNotification(booking.id, bookingDetails);
+      // Queue customer notification
+      await this.queueCustomerNotification(booking.id, bookingDetails);
 
-    // Queue fleet owner notification
-    await this.queueFleetOwnerNotification(booking, bookingDetails);
+      // Queue fleet owner notification
+      await this.queueFleetOwnerNotification(booking, bookingDetails);
+    } catch (error) {
+      // Log but don't throw - notification failure shouldn't fail the confirmation
+      this.logger.error("Failed to queue booking notifications", {
+        bookingId: booking.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   /**

--- a/src/modules/booking/booking-confirmation.service.ts
+++ b/src/modules/booking/booking-confirmation.service.ts
@@ -9,6 +9,7 @@ import { DatabaseService } from "../database/database.service";
 import {
   CLIENT_RECIPIENT_TYPE,
   DEFAULT_CHANNELS,
+  FLEET_OWNER_RECIPIENT_TYPE,
   SEND_NOTIFICATION_JOB_NAME,
 } from "../notification/notification.const";
 import { NotificationType, type NotificationJobData } from "../notification/notification.interface";
@@ -110,14 +111,28 @@ export class BookingConfirmationService {
    * Uses the notification queue to avoid blocking the webhook handler.
    */
   private async queueBookingConfirmedNotification(booking: BookingWithRelations): Promise<void> {
-    try {
-      const bookingDetails = normaliseBookingDetails(booking);
+    const bookingDetails = normaliseBookingDetails(booking);
 
+    // Queue customer notification
+    await this.queueCustomerNotification(booking.id, bookingDetails);
+
+    // Queue fleet owner notification
+    await this.queueFleetOwnerNotification(booking, bookingDetails);
+  }
+
+  /**
+   * Queue notification to the customer about their confirmed booking.
+   */
+  private async queueCustomerNotification(
+    bookingId: string,
+    bookingDetails: ReturnType<typeof normaliseBookingDetails>,
+  ): Promise<void> {
+    try {
       const jobData: NotificationJobData = {
-        id: `booking-confirmed-${booking.id}-${Date.now()}`,
+        id: `booking-confirmed-${bookingId}-${Date.now()}`,
         type: NotificationType.BOOKING_CONFIRMED,
         channels: DEFAULT_CHANNELS,
-        bookingId: booking.id,
+        bookingId,
         recipients: {
           [CLIENT_RECIPIENT_TYPE]: {
             email: bookingDetails.customerEmail,
@@ -133,13 +148,68 @@ export class BookingConfirmationService {
       await this.notificationQueue.add(SEND_NOTIFICATION_JOB_NAME, jobData, { priority: 1 });
 
       this.logger.log("Queued booking confirmation notification", {
-        bookingId: booking.id,
+        bookingId,
         notificationId: jobData.id,
       });
     } catch (error) {
       // Log but don't throw - notification failure shouldn't fail the confirmation
       this.logger.error("Failed to queue booking confirmation notification", {
+        bookingId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  /**
+   * Queue notification to the fleet owner about the new booking.
+   * Fleet owner needs to assign a chauffeur for the booking.
+   */
+  private async queueFleetOwnerNotification(
+    booking: BookingWithRelations,
+    bookingDetails: ReturnType<typeof normaliseBookingDetails>,
+  ): Promise<void> {
+    const ownerEmail = booking.car?.owner?.email;
+    const ownerPhone = booking.car?.owner?.phoneNumber;
+
+    // Skip if fleet owner has no contact info
+    if (!ownerEmail && !ownerPhone) {
+      this.logger.warn("Fleet owner has no contact info, skipping notification", {
         bookingId: booking.id,
+        ownerId: booking.car?.owner?.id,
+      });
+      return;
+    }
+
+    try {
+      const jobData: NotificationJobData = {
+        id: `fleet-owner-new-booking-${booking.id}-${Date.now()}`,
+        type: NotificationType.FLEET_OWNER_NEW_BOOKING,
+        channels: DEFAULT_CHANNELS,
+        bookingId: booking.id,
+        recipients: {
+          [FLEET_OWNER_RECIPIENT_TYPE]: {
+            email: ownerEmail ?? undefined,
+            phoneNumber: ownerPhone ?? undefined,
+          },
+        },
+        templateData: {
+          ...bookingDetails,
+          subject: "New Booking Alert",
+        },
+      };
+
+      await this.notificationQueue.add(SEND_NOTIFICATION_JOB_NAME, jobData, { priority: 1 });
+
+      this.logger.log("Queued fleet owner new booking notification", {
+        bookingId: booking.id,
+        notificationId: jobData.id,
+        ownerId: booking.car?.owner?.id,
+      });
+    } catch (error) {
+      // Log but don't throw - notification failure shouldn't fail the confirmation
+      this.logger.error("Failed to queue fleet owner notification", {
+        bookingId: booking.id,
+        ownerId: booking.car?.owner?.id,
         error: error instanceof Error ? error.message : String(error),
       });
     }

--- a/src/modules/notification/notification.const.ts
+++ b/src/modules/notification/notification.const.ts
@@ -3,4 +3,8 @@ import { NotificationChannel } from "./notification.interface";
 export const DEFAULT_CHANNELS = [NotificationChannel.EMAIL, NotificationChannel.WHATSAPP];
 export const STATUS_CHANGE_JOB_OPTIONS = { priority: 1 };
 export const SEND_NOTIFICATION_JOB_NAME = "send-notification";
-export { CHAUFFEUR_RECIPIENT_TYPE, CLIENT_RECIPIENT_TYPE } from "./template-data.interface";
+export {
+  CHAUFFEUR_RECIPIENT_TYPE,
+  CLIENT_RECIPIENT_TYPE,
+  FLEET_OWNER_RECIPIENT_TYPE,
+} from "./template-data.interface";

--- a/src/modules/notification/notification.interface.ts
+++ b/src/modules/notification/notification.interface.ts
@@ -10,6 +10,7 @@ export enum NotificationType {
   BOOKING_REMINDER_START = "booking-reminder-start",
   BOOKING_REMINDER_END = "booking-reminder-end",
   BOOKING_CONFIRMED = "booking-confirmed",
+  FLEET_OWNER_NEW_BOOKING = "fleet-owner-new-booking",
 }
 
 export interface EmailNotificationData {

--- a/src/modules/notification/template-data.interface.ts
+++ b/src/modules/notification/template-data.interface.ts
@@ -2,7 +2,11 @@ import { NormalisedBookingDetails, NormalisedBookingLegDetails } from "../../typ
 
 export const CLIENT_RECIPIENT_TYPE = "client" as const;
 export const CHAUFFEUR_RECIPIENT_TYPE = "chauffeur" as const;
-export type RecipientType = typeof CLIENT_RECIPIENT_TYPE | typeof CHAUFFEUR_RECIPIENT_TYPE;
+export const FLEET_OWNER_RECIPIENT_TYPE = "fleetOwner" as const;
+export type RecipientType =
+  | typeof CLIENT_RECIPIENT_TYPE
+  | typeof CHAUFFEUR_RECIPIENT_TYPE
+  | typeof FLEET_OWNER_RECIPIENT_TYPE;
 
 /**
  * Base template data that all notification templates can use

--- a/src/modules/notification/template-mappers/booking-reminder-end-mapper.spec.ts
+++ b/src/modules/notification/template-mappers/booking-reminder-end-mapper.spec.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { NotificationType } from "../notification.interface";
+import {
+  CHAUFFEUR_RECIPIENT_TYPE,
+  CLIENT_RECIPIENT_TYPE,
+  FLEET_OWNER_RECIPIENT_TYPE,
+  RecipientType,
+} from "../template-data.interface";
 import { Template } from "../whatsapp.service";
 import { BookingReminderEndMapper } from "./booking-reminder-end-mapper";
 
@@ -26,27 +32,36 @@ describe("BookingReminderEndMapper", () => {
 
   describe("getTemplateKey", () => {
     it("should return ChauffeurBookingLegEndReminder for chauffeur recipient", () => {
-      expect(mapper.getTemplateKey(NotificationType.BOOKING_REMINDER_END, "chauffeur")).toBe(
-        Template.ChauffeurBookingLegEndReminder,
-      );
+      expect(
+        mapper.getTemplateKey(NotificationType.BOOKING_REMINDER_END, CHAUFFEUR_RECIPIENT_TYPE),
+      ).toBe(Template.ChauffeurBookingLegEndReminder);
     });
 
     it("should return ClientBookingLegEndReminder for client recipient", () => {
-      expect(mapper.getTemplateKey(NotificationType.BOOKING_REMINDER_END, "client")).toBe(
-        Template.ClientBookingLegEndReminder,
-      );
+      expect(
+        mapper.getTemplateKey(NotificationType.BOOKING_REMINDER_END, CLIENT_RECIPIENT_TYPE),
+      ).toBe(Template.ClientBookingLegEndReminder);
     });
 
     it("should return null for fleetOwner recipient", () => {
-      expect(mapper.getTemplateKey(NotificationType.BOOKING_REMINDER_END, "fleetOwner")).toBeNull();
+      expect(
+        mapper.getTemplateKey(NotificationType.BOOKING_REMINDER_END, FLEET_OWNER_RECIPIENT_TYPE),
+      ).toBeNull();
     });
 
     it("should return null for unknown recipient types", () => {
-      expect(mapper.getTemplateKey(NotificationType.BOOKING_REMINDER_END, "unknown")).toBeNull();
+      expect(
+        mapper.getTemplateKey(
+          NotificationType.BOOKING_REMINDER_END,
+          "unknown" as unknown as RecipientType,
+        ),
+      ).toBeNull();
     });
 
     it("should return null for other notification types", () => {
-      expect(mapper.getTemplateKey(NotificationType.BOOKING_CONFIRMED, "client")).toBeNull();
+      expect(
+        mapper.getTemplateKey(NotificationType.BOOKING_CONFIRMED, CLIENT_RECIPIENT_TYPE),
+      ).toBeNull();
     });
   });
 
@@ -64,7 +79,7 @@ describe("BookingReminderEndMapper", () => {
     };
 
     it("should map chauffeur variables correctly", () => {
-      const variables = mapper.mapVariables(mockTemplateData, "chauffeur");
+      const variables = mapper.mapVariables(mockTemplateData, CHAUFFEUR_RECIPIENT_TYPE);
 
       expect(variables).toEqual({
         "1": "John Driver",
@@ -78,7 +93,7 @@ describe("BookingReminderEndMapper", () => {
     });
 
     it("should map client variables correctly with bookingId", () => {
-      const variables = mapper.mapVariables(mockTemplateData, "client");
+      const variables = mapper.mapVariables(mockTemplateData, CLIENT_RECIPIENT_TYPE);
 
       expect(variables).toEqual({
         "1": "Jane Customer",
@@ -98,7 +113,7 @@ describe("BookingReminderEndMapper", () => {
         carName: "BMW X5",
       };
 
-      const variables = mapper.mapVariables(incompleteData, "client");
+      const variables = mapper.mapVariables(incompleteData, CLIENT_RECIPIENT_TYPE);
 
       expect(variables["1"]).toBe("Jane Customer");
       expect(variables["2"]).toBe("BMW X5");

--- a/src/modules/notification/template-mappers/booking-reminder-end-mapper.spec.ts
+++ b/src/modules/notification/template-mappers/booking-reminder-end-mapper.spec.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { NotificationType } from "../notification.interface";
+import { Template } from "../whatsapp.service";
+import { BookingReminderEndMapper } from "./booking-reminder-end-mapper";
+
+describe("BookingReminderEndMapper", () => {
+  const mapper = new BookingReminderEndMapper();
+
+  describe("canHandle", () => {
+    it("should return true for BOOKING_REMINDER_END type", () => {
+      expect(mapper.canHandle(NotificationType.BOOKING_REMINDER_END)).toBe(true);
+    });
+
+    it("should return false for BOOKING_REMINDER_START type", () => {
+      expect(mapper.canHandle(NotificationType.BOOKING_REMINDER_START)).toBe(false);
+    });
+
+    it("should return false for BOOKING_CONFIRMED type", () => {
+      expect(mapper.canHandle(NotificationType.BOOKING_CONFIRMED)).toBe(false);
+    });
+
+    it("should return false for FLEET_OWNER_NEW_BOOKING type", () => {
+      expect(mapper.canHandle(NotificationType.FLEET_OWNER_NEW_BOOKING)).toBe(false);
+    });
+  });
+
+  describe("getTemplateKey", () => {
+    it("should return ChauffeurBookingLegEndReminder for chauffeur recipient", () => {
+      expect(mapper.getTemplateKey(NotificationType.BOOKING_REMINDER_END, "chauffeur")).toBe(
+        Template.ChauffeurBookingLegEndReminder,
+      );
+    });
+
+    it("should return ClientBookingLegEndReminder for client recipient", () => {
+      expect(mapper.getTemplateKey(NotificationType.BOOKING_REMINDER_END, "client")).toBe(
+        Template.ClientBookingLegEndReminder,
+      );
+    });
+
+    it("should return null for fleetOwner recipient", () => {
+      expect(mapper.getTemplateKey(NotificationType.BOOKING_REMINDER_END, "fleetOwner")).toBeNull();
+    });
+
+    it("should return null for unknown recipient types", () => {
+      expect(mapper.getTemplateKey(NotificationType.BOOKING_REMINDER_END, "unknown")).toBeNull();
+    });
+
+    it("should return null for other notification types", () => {
+      expect(mapper.getTemplateKey(NotificationType.BOOKING_CONFIRMED, "client")).toBeNull();
+    });
+  });
+
+  describe("mapVariables", () => {
+    const mockTemplateData = {
+      chauffeurName: "John Driver",
+      carName: "Toyota Camry (2022)",
+      legStartTime: "10:00 AM",
+      legEndTime: "6:00 PM",
+      pickupLocation: "Lagos Airport",
+      returnLocation: "Victoria Island",
+      customerName: "Jane Customer",
+      bookingId: "booking-123",
+      subject: "Booking Reminder",
+    };
+
+    it("should map chauffeur variables correctly", () => {
+      const variables = mapper.mapVariables(mockTemplateData, "chauffeur");
+
+      expect(variables).toEqual({
+        "1": "John Driver",
+        "2": "Toyota Camry (2022)",
+        "3": "10:00 AM",
+        "4": "6:00 PM",
+        "5": "Lagos Airport",
+        "6": "Victoria Island",
+        "7": "Jane Customer",
+      });
+    });
+
+    it("should map client variables correctly with bookingId", () => {
+      const variables = mapper.mapVariables(mockTemplateData, "client");
+
+      expect(variables).toEqual({
+        "1": "Jane Customer",
+        "2": "Toyota Camry (2022)",
+        "3": "10:00 AM",
+        "4": "6:00 PM",
+        "5": "Lagos Airport",
+        "6": "Victoria Island",
+        "7": "John Driver",
+        "8": "booking-123",
+      });
+    });
+
+    it("should return empty string for missing fields", () => {
+      const incompleteData = {
+        customerName: "Jane Customer",
+        carName: "BMW X5",
+      };
+
+      const variables = mapper.mapVariables(incompleteData, "client");
+
+      expect(variables["1"]).toBe("Jane Customer");
+      expect(variables["2"]).toBe("BMW X5");
+      expect(variables["3"]).toBe("");
+      expect(variables["4"]).toBe("");
+      expect(variables["5"]).toBe("");
+      expect(variables["6"]).toBe("");
+      expect(variables["7"]).toBe("");
+      expect(variables["8"]).toBe("");
+    });
+  });
+});

--- a/src/modules/notification/template-mappers/booking-reminder-end-mapper.ts
+++ b/src/modules/notification/template-mappers/booking-reminder-end-mapper.ts
@@ -33,7 +33,8 @@ export class BookingReminderEndMapper extends BaseTemplateMapper {
         "6": this.getValue(templateData, "returnLocation"),
         "7": this.getValue(templateData, "customerName"), // Customer name for chauffeur
       };
-    } else {
+    }
+    if (recipientType === "client") {
       // ClientBookingLegEndReminder template variables
       return {
         "1": this.getValue(templateData, "customerName"),
@@ -46,5 +47,7 @@ export class BookingReminderEndMapper extends BaseTemplateMapper {
         "8": this.getValue(templateData, "bookingId"), // Booking ID for end reminders
       };
     }
+    // Unsupported recipient type
+    return {};
   }
 }

--- a/src/modules/notification/template-mappers/booking-reminder-end-mapper.ts
+++ b/src/modules/notification/template-mappers/booking-reminder-end-mapper.ts
@@ -1,5 +1,10 @@
 import { NotificationType } from "../notification.interface";
-import { type TemplateData } from "../template-data.interface";
+import {
+  CHAUFFEUR_RECIPIENT_TYPE,
+  CLIENT_RECIPIENT_TYPE,
+  RecipientType,
+  type TemplateData,
+} from "../template-data.interface";
 import { Template } from "../whatsapp.service";
 import { BaseTemplateMapper } from "./base-template-mapper";
 
@@ -8,21 +13,21 @@ export class BookingReminderEndMapper extends BaseTemplateMapper {
     return type === NotificationType.BOOKING_REMINDER_END;
   }
 
-  getTemplateKey(type: NotificationType, recipientType: string): Template | null {
+  getTemplateKey(type: NotificationType, recipientType: RecipientType): Template | null {
     if (!this.canHandle(type)) return null;
 
     // Booking reminders are only for clients and chauffeurs, not fleet owners
-    if (recipientType === "chauffeur") {
+    if (recipientType === CHAUFFEUR_RECIPIENT_TYPE) {
       return Template.ChauffeurBookingLegEndReminder;
     }
-    if (recipientType === "client") {
+    if (recipientType === CLIENT_RECIPIENT_TYPE) {
       return Template.ClientBookingLegEndReminder;
     }
     return null;
   }
 
   mapVariables(templateData: TemplateData, recipientType: string): Record<string, string | number> {
-    if (recipientType === "chauffeur") {
+    if (recipientType === CHAUFFEUR_RECIPIENT_TYPE) {
       // ChauffeurBookingLegEndReminder template variables
       return {
         "1": this.getValue(templateData, "chauffeurName"),
@@ -34,7 +39,7 @@ export class BookingReminderEndMapper extends BaseTemplateMapper {
         "7": this.getValue(templateData, "customerName"), // Customer name for chauffeur
       };
     }
-    if (recipientType === "client") {
+    if (recipientType === CLIENT_RECIPIENT_TYPE) {
       // ClientBookingLegEndReminder template variables
       return {
         "1": this.getValue(templateData, "customerName"),

--- a/src/modules/notification/template-mappers/booking-reminder-end-mapper.ts
+++ b/src/modules/notification/template-mappers/booking-reminder-end-mapper.ts
@@ -11,9 +11,14 @@ export class BookingReminderEndMapper extends BaseTemplateMapper {
   getTemplateKey(type: NotificationType, recipientType: string): Template | null {
     if (!this.canHandle(type)) return null;
 
-    return recipientType === "chauffeur"
-      ? Template.ChauffeurBookingLegEndReminder
-      : Template.ClientBookingLegEndReminder;
+    // Booking reminders are only for clients and chauffeurs, not fleet owners
+    if (recipientType === "chauffeur") {
+      return Template.ChauffeurBookingLegEndReminder;
+    }
+    if (recipientType === "client") {
+      return Template.ClientBookingLegEndReminder;
+    }
+    return null;
   }
 
   mapVariables(templateData: TemplateData, recipientType: string): Record<string, string | number> {

--- a/src/modules/notification/template-mappers/booking-reminder-start-mapper.spec.ts
+++ b/src/modules/notification/template-mappers/booking-reminder-start-mapper.spec.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { NotificationType } from "../notification.interface";
+import { Template } from "../whatsapp.service";
+import { BookingReminderStartMapper } from "./booking-reminder-start-mapper";
+
+describe("BookingReminderStartMapper", () => {
+  const mapper = new BookingReminderStartMapper();
+
+  describe("canHandle", () => {
+    it("should return true for BOOKING_REMINDER_START type", () => {
+      expect(mapper.canHandle(NotificationType.BOOKING_REMINDER_START)).toBe(true);
+    });
+
+    it("should return false for BOOKING_REMINDER_END type", () => {
+      expect(mapper.canHandle(NotificationType.BOOKING_REMINDER_END)).toBe(false);
+    });
+
+    it("should return false for BOOKING_CONFIRMED type", () => {
+      expect(mapper.canHandle(NotificationType.BOOKING_CONFIRMED)).toBe(false);
+    });
+
+    it("should return false for FLEET_OWNER_NEW_BOOKING type", () => {
+      expect(mapper.canHandle(NotificationType.FLEET_OWNER_NEW_BOOKING)).toBe(false);
+    });
+  });
+
+  describe("getTemplateKey", () => {
+    it("should return ChauffeurBookingLegStartReminder for chauffeur recipient", () => {
+      expect(mapper.getTemplateKey(NotificationType.BOOKING_REMINDER_START, "chauffeur")).toBe(
+        Template.ChauffeurBookingLegStartReminder,
+      );
+    });
+
+    it("should return ClientBookingLegStartReminder for client recipient", () => {
+      expect(mapper.getTemplateKey(NotificationType.BOOKING_REMINDER_START, "client")).toBe(
+        Template.ClientBookingLegStartReminder,
+      );
+    });
+
+    it("should return null for fleetOwner recipient", () => {
+      expect(mapper.getTemplateKey(NotificationType.BOOKING_REMINDER_START, "fleetOwner")).toBeNull();
+    });
+
+    it("should return null for unknown recipient types", () => {
+      expect(mapper.getTemplateKey(NotificationType.BOOKING_REMINDER_START, "unknown")).toBeNull();
+    });
+
+    it("should return null for other notification types", () => {
+      expect(mapper.getTemplateKey(NotificationType.BOOKING_CONFIRMED, "client")).toBeNull();
+    });
+  });
+
+  describe("mapVariables", () => {
+    const mockTemplateData = {
+      chauffeurName: "John Driver",
+      carName: "Toyota Camry (2022)",
+      legStartTime: "10:00 AM",
+      legEndTime: "6:00 PM",
+      pickupLocation: "Lagos Airport",
+      returnLocation: "Victoria Island",
+      customerName: "Jane Customer",
+      subject: "Booking Reminder",
+    };
+
+    it("should map chauffeur variables correctly", () => {
+      const variables = mapper.mapVariables(mockTemplateData, "chauffeur");
+
+      expect(variables).toEqual({
+        "1": "John Driver",
+        "2": "Toyota Camry (2022)",
+        "3": "10:00 AM",
+        "4": "6:00 PM",
+        "5": "Lagos Airport",
+        "6": "Victoria Island",
+        "7": "Jane Customer",
+      });
+    });
+
+    it("should map client variables correctly", () => {
+      const variables = mapper.mapVariables(mockTemplateData, "client");
+
+      expect(variables).toEqual({
+        "1": "Jane Customer",
+        "2": "Toyota Camry (2022)",
+        "3": "10:00 AM",
+        "4": "6:00 PM",
+        "5": "Lagos Airport",
+        "6": "Victoria Island",
+        "7": "John Driver",
+      });
+    });
+
+    it("should return empty string for missing fields", () => {
+      const incompleteData = {
+        customerName: "Jane Customer",
+        carName: "BMW X5",
+      };
+
+      const variables = mapper.mapVariables(incompleteData, "client");
+
+      expect(variables["1"]).toBe("Jane Customer");
+      expect(variables["2"]).toBe("BMW X5");
+      expect(variables["3"]).toBe("");
+      expect(variables["4"]).toBe("");
+      expect(variables["5"]).toBe("");
+      expect(variables["6"]).toBe("");
+      expect(variables["7"]).toBe("");
+    });
+  });
+});

--- a/src/modules/notification/template-mappers/booking-reminder-start-mapper.spec.ts
+++ b/src/modules/notification/template-mappers/booking-reminder-start-mapper.spec.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { NotificationType } from "../notification.interface";
+import {
+  CHAUFFEUR_RECIPIENT_TYPE,
+  CLIENT_RECIPIENT_TYPE,
+  FLEET_OWNER_RECIPIENT_TYPE,
+  RecipientType,
+} from "../template-data.interface";
 import { Template } from "../whatsapp.service";
 import { BookingReminderStartMapper } from "./booking-reminder-start-mapper";
 
@@ -26,27 +32,36 @@ describe("BookingReminderStartMapper", () => {
 
   describe("getTemplateKey", () => {
     it("should return ChauffeurBookingLegStartReminder for chauffeur recipient", () => {
-      expect(mapper.getTemplateKey(NotificationType.BOOKING_REMINDER_START, "chauffeur")).toBe(
-        Template.ChauffeurBookingLegStartReminder,
-      );
+      expect(
+        mapper.getTemplateKey(NotificationType.BOOKING_REMINDER_START, CHAUFFEUR_RECIPIENT_TYPE),
+      ).toBe(Template.ChauffeurBookingLegStartReminder);
     });
 
     it("should return ClientBookingLegStartReminder for client recipient", () => {
-      expect(mapper.getTemplateKey(NotificationType.BOOKING_REMINDER_START, "client")).toBe(
-        Template.ClientBookingLegStartReminder,
-      );
+      expect(
+        mapper.getTemplateKey(NotificationType.BOOKING_REMINDER_START, CLIENT_RECIPIENT_TYPE),
+      ).toBe(Template.ClientBookingLegStartReminder);
     });
 
     it("should return null for fleetOwner recipient", () => {
-      expect(mapper.getTemplateKey(NotificationType.BOOKING_REMINDER_START, "fleetOwner")).toBeNull();
+      expect(
+        mapper.getTemplateKey(NotificationType.BOOKING_REMINDER_START, FLEET_OWNER_RECIPIENT_TYPE),
+      ).toBeNull();
     });
 
     it("should return null for unknown recipient types", () => {
-      expect(mapper.getTemplateKey(NotificationType.BOOKING_REMINDER_START, "unknown")).toBeNull();
+      expect(
+        mapper.getTemplateKey(
+          NotificationType.BOOKING_REMINDER_START,
+          "unknown" as unknown as RecipientType,
+        ),
+      ).toBeNull();
     });
 
     it("should return null for other notification types", () => {
-      expect(mapper.getTemplateKey(NotificationType.BOOKING_CONFIRMED, "client")).toBeNull();
+      expect(
+        mapper.getTemplateKey(NotificationType.BOOKING_CONFIRMED, CLIENT_RECIPIENT_TYPE),
+      ).toBeNull();
     });
   });
 
@@ -63,7 +78,7 @@ describe("BookingReminderStartMapper", () => {
     };
 
     it("should map chauffeur variables correctly", () => {
-      const variables = mapper.mapVariables(mockTemplateData, "chauffeur");
+      const variables = mapper.mapVariables(mockTemplateData, CHAUFFEUR_RECIPIENT_TYPE);
 
       expect(variables).toEqual({
         "1": "John Driver",
@@ -77,7 +92,7 @@ describe("BookingReminderStartMapper", () => {
     });
 
     it("should map client variables correctly", () => {
-      const variables = mapper.mapVariables(mockTemplateData, "client");
+      const variables = mapper.mapVariables(mockTemplateData, CLIENT_RECIPIENT_TYPE);
 
       expect(variables).toEqual({
         "1": "Jane Customer",
@@ -96,7 +111,7 @@ describe("BookingReminderStartMapper", () => {
         carName: "BMW X5",
       };
 
-      const variables = mapper.mapVariables(incompleteData, "client");
+      const variables = mapper.mapVariables(incompleteData, CLIENT_RECIPIENT_TYPE);
 
       expect(variables["1"]).toBe("Jane Customer");
       expect(variables["2"]).toBe("BMW X5");

--- a/src/modules/notification/template-mappers/booking-reminder-start-mapper.ts
+++ b/src/modules/notification/template-mappers/booking-reminder-start-mapper.ts
@@ -11,9 +11,14 @@ export class BookingReminderStartMapper extends BaseTemplateMapper {
   getTemplateKey(type: NotificationType, recipientType: string): Template | null {
     if (!this.canHandle(type)) return null;
 
-    return recipientType === "chauffeur"
-      ? Template.ChauffeurBookingLegStartReminder
-      : Template.ClientBookingLegStartReminder;
+    // Booking reminders are only for clients and chauffeurs, not fleet owners
+    if (recipientType === "chauffeur") {
+      return Template.ChauffeurBookingLegStartReminder;
+    }
+    if (recipientType === "client") {
+      return Template.ClientBookingLegStartReminder;
+    }
+    return null;
   }
 
   mapVariables(templateData: TemplateData, recipientType: string): Record<string, string | number> {

--- a/src/modules/notification/template-mappers/booking-reminder-start-mapper.ts
+++ b/src/modules/notification/template-mappers/booking-reminder-start-mapper.ts
@@ -1,5 +1,10 @@
 import { NotificationType } from "../notification.interface";
-import { type TemplateData } from "../template-data.interface";
+import {
+  CHAUFFEUR_RECIPIENT_TYPE,
+  CLIENT_RECIPIENT_TYPE,
+  RecipientType,
+  type TemplateData,
+} from "../template-data.interface";
 import { Template } from "../whatsapp.service";
 import { BaseTemplateMapper } from "./base-template-mapper";
 
@@ -8,14 +13,14 @@ export class BookingReminderStartMapper extends BaseTemplateMapper {
     return type === NotificationType.BOOKING_REMINDER_START;
   }
 
-  getTemplateKey(type: NotificationType, recipientType: string): Template | null {
+  getTemplateKey(type: NotificationType, recipientType: RecipientType): Template | null {
     if (!this.canHandle(type)) return null;
 
     // Booking reminders are only for clients and chauffeurs, not fleet owners
-    if (recipientType === "chauffeur") {
+    if (recipientType === CHAUFFEUR_RECIPIENT_TYPE) {
       return Template.ChauffeurBookingLegStartReminder;
     }
-    if (recipientType === "client") {
+    if (recipientType === CLIENT_RECIPIENT_TYPE) {
       return Template.ClientBookingLegStartReminder;
     }
     return null;
@@ -33,7 +38,8 @@ export class BookingReminderStartMapper extends BaseTemplateMapper {
         "6": this.getValue(templateData, "returnLocation"),
         "7": this.getValue(templateData, "customerName"), // Customer name for chauffeur
       };
-    } else {
+    }
+    if (recipientType === "client") {
       // ClientBookingLegStartReminder template variables
       return {
         "1": this.getValue(templateData, "customerName"),
@@ -45,5 +51,7 @@ export class BookingReminderStartMapper extends BaseTemplateMapper {
         "7": this.getValue(templateData, "chauffeurName"), // Chauffeur name for client
       };
     }
+    // Unsupported recipient type
+    return {};
   }
 }

--- a/src/modules/notification/template-mappers/fleet-owner-new-booking.mapper.spec.ts
+++ b/src/modules/notification/template-mappers/fleet-owner-new-booking.mapper.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { NotificationType } from "../notification.interface";
+import { Template } from "../whatsapp.service";
+import { FleetOwnerNewBookingMapper } from "./fleet-owner-new-booking.mapper";
+
+describe("FleetOwnerNewBookingMapper", () => {
+  const mapper = new FleetOwnerNewBookingMapper();
+
+  describe("canHandle", () => {
+    it("should return true for FLEET_OWNER_NEW_BOOKING type", () => {
+      expect(mapper.canHandle(NotificationType.FLEET_OWNER_NEW_BOOKING)).toBe(true);
+    });
+
+    it("should return false for BOOKING_CONFIRMED type", () => {
+      expect(mapper.canHandle(NotificationType.BOOKING_CONFIRMED)).toBe(false);
+    });
+
+    it("should return false for BOOKING_STATUS_CHANGE type", () => {
+      expect(mapper.canHandle(NotificationType.BOOKING_STATUS_CHANGE)).toBe(false);
+    });
+
+    it("should return false for BOOKING_REMINDER_START type", () => {
+      expect(mapper.canHandle(NotificationType.BOOKING_REMINDER_START)).toBe(false);
+    });
+
+    it("should return false for BOOKING_REMINDER_END type", () => {
+      expect(mapper.canHandle(NotificationType.BOOKING_REMINDER_END)).toBe(false);
+    });
+  });
+
+  describe("getTemplateKey", () => {
+    it("should return FleetOwnerBookingNotification template for FLEET_OWNER_NEW_BOOKING type", () => {
+      expect(mapper.getTemplateKey(NotificationType.FLEET_OWNER_NEW_BOOKING, "fleetOwner")).toBe(
+        Template.FleetOwnerBookingNotification,
+      );
+    });
+
+    it("should return null for other notification types", () => {
+      expect(mapper.getTemplateKey(NotificationType.BOOKING_CONFIRMED, "client")).toBeNull();
+    });
+  });
+
+  describe("mapVariables", () => {
+    const mockTemplateData = {
+      ownerName: "Fleet Owner Name",
+      carName: "Toyota Camry (2022)",
+      customerName: "John Doe",
+      startDate: "January 15, 2024 at 10:00 AM",
+      endDate: "January 16, 2024 at 6:00 PM",
+      pickupLocation: "Lagos Airport",
+      returnLocation: "Victoria Island",
+      totalAmount: "₦50,000",
+      id: "booking-123",
+      subject: "New Booking Alert",
+    };
+
+    it("should map all 9 variables correctly", () => {
+      const variables = mapper.mapVariables(mockTemplateData, "fleetOwner");
+
+      expect(variables).toEqual({
+        "1": "Fleet Owner Name",
+        "2": "Toyota Camry (2022)",
+        "3": "John Doe",
+        "4": "January 15, 2024 at 10:00 AM",
+        "5": "January 16, 2024 at 6:00 PM",
+        "6": "Lagos Airport",
+        "7": "Victoria Island",
+        "8": "₦50,000",
+        "9": "booking-123",
+      });
+    });
+
+    it("should return empty string for missing fields", () => {
+      const incompleteData = {
+        ownerName: "Fleet Owner",
+        carName: "BMW X5",
+      };
+
+      const variables = mapper.mapVariables(incompleteData, "fleetOwner");
+
+      expect(variables["1"]).toBe("Fleet Owner");
+      expect(variables["2"]).toBe("BMW X5");
+      expect(variables["3"]).toBe("");
+      expect(variables["4"]).toBe("");
+      expect(variables["5"]).toBe("");
+      expect(variables["6"]).toBe("");
+      expect(variables["7"]).toBe("");
+      expect(variables["8"]).toBe("");
+      expect(variables["9"]).toBe("");
+    });
+  });
+});

--- a/src/modules/notification/template-mappers/fleet-owner-new-booking.mapper.ts
+++ b/src/modules/notification/template-mappers/fleet-owner-new-booking.mapper.ts
@@ -1,0 +1,32 @@
+import { NotificationType } from "../notification.interface";
+import { type TemplateData } from "../template-data.interface";
+import { Template } from "../whatsapp.service";
+import { BaseTemplateMapper } from "./base-template-mapper";
+
+export class FleetOwnerNewBookingMapper extends BaseTemplateMapper {
+  canHandle(type: NotificationType): boolean {
+    return type === NotificationType.FLEET_OWNER_NEW_BOOKING;
+  }
+
+  getTemplateKey(type: NotificationType, _recipientType: string): Template | null {
+    if (!this.canHandle(type)) return null;
+    return Template.FleetOwnerBookingNotification;
+  }
+
+  mapVariables(
+    templateData: TemplateData,
+    _recipientType: string,
+  ): Record<string, string | number> {
+    return {
+      "1": this.getValue(templateData, "ownerName"),
+      "2": this.getValue(templateData, "carName"),
+      "3": this.getValue(templateData, "customerName"),
+      "4": this.getValue(templateData, "startDate"),
+      "5": this.getValue(templateData, "endDate"),
+      "6": this.getValue(templateData, "pickupLocation"),
+      "7": this.getValue(templateData, "returnLocation"),
+      "8": this.getValue(templateData, "totalAmount"),
+      "9": this.getValue(templateData, "id"),
+    };
+  }
+}

--- a/src/modules/notification/template-mappers/index.ts
+++ b/src/modules/notification/template-mappers/index.ts
@@ -4,3 +4,4 @@ export { BookingReminderEndMapper } from "./booking-reminder-end-mapper";
 export { BookingReminderStartMapper } from "./booking-reminder-start-mapper";
 export { BookingStatusMapper } from "./booking-status-mapper";
 export { FallbackTemplateMapper } from "./fallback-template-mapper";
+export { FleetOwnerNewBookingMapper } from "./fleet-owner-new-booking.mapper";

--- a/src/modules/notification/whatsapp.service.ts
+++ b/src/modules/notification/whatsapp.service.ts
@@ -10,6 +10,7 @@ export enum Template {
   ClientBookingLegEndReminder = "clientBookingLegEndReminder",
   ChauffeurBookingLegEndReminder = "chauffeurBookingLegEndReminder",
   BookingConfirmation = "bookingConfirmation",
+  FleetOwnerBookingNotification = "fleetOwnerBookingNotification",
 }
 
 const contentSidMap: Record<Template, string> = {
@@ -19,6 +20,7 @@ const contentSidMap: Record<Template, string> = {
   [Template.ClientBookingLegEndReminder]: "HX0c8470054c0ff1a0b43c06fe196e2ec3",
   [Template.ChauffeurBookingLegEndReminder]: "HX9faf29432a18e9f8f8283a5e281e5a3c",
   [Template.BookingConfirmation]: "HXac9f0b83ee03d47fe2f2969173dac354",
+  [Template.FleetOwnerBookingNotification]: "HXaeda40fabb6c33f323c1f101e0a10165",
 };
 
 @Injectable()

--- a/src/templates/emails.tsx
+++ b/src/templates/emails.tsx
@@ -332,3 +332,39 @@ export async function renderAuthOTPEmail({ otp }: AuthOTPEmailProps) {
     </EmailTemplate>,
   );
 }
+
+export async function renderFleetOwnerNewBookingEmail(booking: NormalisedBookingDetails) {
+  const previewText = "New Booking Alert - Action Required";
+  const dashboardUrl = `${WEBSITE_URL}/fleet-owner/bookings/${booking.id}?startDate=${encodeURIComponent(booking.startDate)}`;
+
+  return await render(
+    <EmailTemplate previewText={previewText} pageTitle="New Booking Notification">
+      <Heading as="h2" className="text-xl font-semibold mb-4">
+        New Booking Alert - Action Required
+      </Heading>
+      <Text className="mb-3">Hello {booking.ownerName},</Text>
+      <Text className="mb-3">
+        A new booking has been made for your{" "}
+        <span className="font-semibold">{booking.carName}</span>. Please{" "}
+        <Link href={dashboardUrl} className="text-blue-600 underline">
+          assign a chauffeur
+        </Link>{" "}
+        for this booking as soon as possible.
+      </Text>
+      <Section className="border border-gray-200 rounded-md p-4 bg-gray-50">
+        <Text className="font-semibold mb-2 underline">Booking Details</Text>
+        <DetailListItem label="Customer" value={booking.customerName} />
+        <DetailListItem label="Start Date & Time" value={booking.startDate} />
+        <DetailListItem label="End Date & Time" value={booking.endDate} />
+        <DetailListItem label="Car" value={booking.carName} />
+        <DetailListItem label="Pickup Location" value={booking.pickupLocation} />
+        <DetailListItem label="Drop-off Location" value={booking.returnLocation} />
+        <Hr className="my-2 border-gray-300" />
+        <DetailListItem label="Total Amount" value={booking.totalAmount} />
+      </Section>
+      <Text className="mt-4 text-sm text-gray-600">
+        If you have any questions, feel free to contact us.
+      </Text>
+    </EmailTemplate>,
+  );
+}

--- a/test/setup.e2e.ts
+++ b/test/setup.e2e.ts
@@ -10,6 +10,9 @@ vi.mock("../src/templates/emails", () => ({
   renderBookingStatusUpdateEmail: vi.fn().mockResolvedValue("<html>Mocked status update</html>"),
   renderBookingReminderEmail: vi.fn().mockResolvedValue("<html>Mocked reminder</html>"),
   renderAuthOTPEmail: vi.fn().mockResolvedValue("<html>Mocked OTP email</html>"),
+  renderFleetOwnerNewBookingEmail: vi
+    .fn()
+    .mockResolvedValue("<html>Mocked fleet owner notification</html>"),
 }));
 
 // Mock the EmailService to prevent actual API calls to Resend during e2e tests


### PR DESCRIPTION
When a booking is confirmed after successful payment, notify the fleet owner (or owner-driver) in addition to the customer. This enables fleet owners to promptly assign a chauffeur for the new booking.

Changes:
- Add FLEET_OWNER_NEW_BOOKING notification type
- Add FLEET_OWNER_RECIPIENT_TYPE for recipient routing
- Create FleetOwnerNewBookingMapper for WhatsApp template variables
- Add renderFleetOwnerNewBookingEmail for email notifications
- Update NotificationProcessor to handle fleet owner recipients
- Update BookingConfirmationService to queue fleet owner notification
- Add comprehensive unit tests for new functionality
- Add type guard for booking reminder recipient validation
- Update e2e test setup with fleet owner email mock

The notification includes booking details with a CTA link to assign a chauffeur from the fleet owner dashboard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds fleet owner notification flow and recipient handling across booking confirmation and notification pipeline.
> 
> - Introduces `NotificationType.FLEET_OWNER_NEW_BOOKING` and `FLEET_OWNER_RECIPIENT_TYPE`; updates `DEFAULT_CHANNELS` exports
> - `BookingConfirmationService`: after confirming a booking, queues both customer and fleet owner notifications (skips owner if no contact); robust error logging without failing confirmation
> - `NotificationProcessor`: supports fleet owner recipients for Email/WhatsApp; selects correct templates; validates reminder recipients; integrates new `FleetOwnerNewBookingMapper`
> - WhatsApp: adds `Template.FleetOwnerBookingNotification` and SID mapping
> - Emails: adds `renderFleetOwnerNewBookingEmail` template
> - Template mappers: adds `FleetOwnerNewBookingMapper`; refines booking reminder mappers to return `null` for unsupported recipients and uses typed recipient keys
> - Tests: expands unit coverage for service and mappers; updates e2e setup to mock new email renderer
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c25c4c1c86a86a51916c2b18b87cec9ba45428fb. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->