### PR TITLE
refactor: reduce cognitive complexity and improve type safety

### DIFF
--- a/.env.e2e
+++ b/.env.e2e
@@ -23,3 +23,4 @@ ENABLE_MANUAL_TRIGGERS=true
 SESSION_SECRET=e2e-test-secret-at-least-32-characters-long
 AUTH_BASE_URL=http://localhost:3001
 TRUSTED_ORIGINS=http://localhost:3001,http://localhost:3000
+HMAC_KEY=flutterwave-webhook-comparison-e2e

--- a/src/config/env.config.ts
+++ b/src/config/env.config.ts
@@ -42,6 +42,8 @@ export const envSchema = z.object({
   FLUTTERWAVE_WEBHOOK_SECRET: z.string().min(1, "FLUTTERWAVE_WEBHOOK_SECRET is required"),
   FLUTTERWAVE_WEBHOOK_URL: z.url("FLUTTERWAVE_WEBHOOK_URL must be a valid URL"),
 
+  HMAC_KEY: z.string().min(1, "HMAC_KEY is required"),
+
   ENABLE_MANUAL_TRIGGERS: z
     .union([z.boolean(), z.string()])
     .transform((val) => {

--- a/src/modules/notification/notification.processor.ts
+++ b/src/modules/notification/notification.processor.ts
@@ -333,7 +333,10 @@ export class NotificationProcessor extends WorkerHost {
     }
   }
 
-  private getWhatsAppTemplateKey(type: NotificationType, recipientType: string): Template | null {
+  private getWhatsAppTemplateKey(
+    type: NotificationType,
+    recipientType: RecipientType,
+  ): Template | null {
     const mapper = this.templateMappers.find((mapper) => mapper.canHandle(type));
     return mapper?.getTemplateKey(type, recipientType) || null;
   }
@@ -341,7 +344,7 @@ export class NotificationProcessor extends WorkerHost {
   private buildWhatsAppVariables(
     templateData: TemplateData,
     type: NotificationType,
-    recipientType: string,
+    recipientType: RecipientType,
   ): Record<string, string | number> {
     const mapper = this.templateMappers.find((mapper) => mapper.canHandle(type));
     return mapper?.mapVariables(templateData, recipientType) || {};

--- a/src/modules/notification/template-mappers/base-template-mapper.ts
+++ b/src/modules/notification/template-mappers/base-template-mapper.ts
@@ -1,17 +1,20 @@
 import { NotificationType } from "../notification.interface";
-import { type TemplateData } from "../template-data.interface";
+import { RecipientType, type TemplateData } from "../template-data.interface";
 import { Template } from "../whatsapp.service";
 
 export interface TemplateVariableMapper {
   /**
    * Gets the WhatsApp template key for a given notification type and recipient
    */
-  getTemplateKey(type: NotificationType, recipientType: string): Template | null;
+  getTemplateKey(type: NotificationType, recipientType: RecipientType): Template | null;
 
   /**
    * Maps template data to WhatsApp variables for a specific template
    */
-  mapVariables(templateData: TemplateData, recipientType: string): Record<string, string | number>;
+  mapVariables(
+    templateData: TemplateData,
+    recipientType: RecipientType,
+  ): Record<string, string | number>;
 
   /**
    * Checks if this mapper can handle the given notification type
@@ -20,10 +23,10 @@ export interface TemplateVariableMapper {
 }
 
 export abstract class BaseTemplateMapper implements TemplateVariableMapper {
-  abstract getTemplateKey(type: NotificationType, recipientType: string): Template | null;
+  abstract getTemplateKey(type: NotificationType, recipientType: RecipientType): Template | null;
   abstract mapVariables(
     templateData: TemplateData,
-    recipientType: string,
+    recipientType: RecipientType,
   ): Record<string, string | number>;
   abstract canHandle(type: NotificationType): boolean;
 

--- a/src/modules/notification/template-mappers/booking-reminder-start-mapper.ts
+++ b/src/modules/notification/template-mappers/booking-reminder-start-mapper.ts
@@ -26,8 +26,11 @@ export class BookingReminderStartMapper extends BaseTemplateMapper {
     return null;
   }
 
-  mapVariables(templateData: TemplateData, recipientType: string): Record<string, string | number> {
-    if (recipientType === "chauffeur") {
+  mapVariables(
+    templateData: TemplateData,
+    recipientType: RecipientType,
+  ): Record<string, string | number> {
+    if (recipientType === CHAUFFEUR_RECIPIENT_TYPE) {
       // ChauffeurBookingLegStartReminder template variables
       return {
         "1": this.getValue(templateData, "chauffeurName"),
@@ -39,7 +42,7 @@ export class BookingReminderStartMapper extends BaseTemplateMapper {
         "7": this.getValue(templateData, "customerName"), // Customer name for chauffeur
       };
     }
-    if (recipientType === "client") {
+    if (recipientType === CLIENT_RECIPIENT_TYPE) {
       // ClientBookingLegStartReminder template variables
       return {
         "1": this.getValue(templateData, "customerName"),


### PR DESCRIPTION
- Extract helper methods in PaymentApiService.initiateRefund to reduce cognitive complexity from 16 to under 15
- Extract helper methods in PaymentWebhookService.handleChargeCompleted to reduce cognitive complexity from 18 to under 15
- Fix booking reminder mappers to return null for unsupported recipient types (fleet owner), preventing incorrect WhatsApp messages
- Update template mapper interfaces to use RecipientType instead of string for better type safety
- Move HMAC_KEY from hardcoded constant to environment configuration for improved security and testability

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Payment refunds (PaymentApiService)**: Extracts `initiateRefund` into focused helpers (`fetchPaymentForRefund`, `validateRefundEligibility`, `getRefundIdempotencyKey`, `reserveRefund`, `executeRefund`, `handleRefundError`, `handleRefundResult`) with stricter idempotency and clearer error/log handling.
> - **Charge webhook processing (PaymentWebhookService)**: Splits `handleChargeCompleted` into `validateChargeWebhookFields`, `processVerifiedCharge`, `validateVerification`, `handleIdempotencyOrRecovery`, and `updatePaymentFromCharge` for reduced complexity and explicit recovery/idempotency.
> - **Webhook security (FlutterwaveWebhookGuard)**: Replaces hardcoded HMAC key with `HMAC_KEY` from env and uses it to HMAC-hash values before `timingSafeEqual` comparison.
> - **Notifications type-safety**: Updates template mapper interfaces and callers to use `RecipientType` instead of `string`; `BookingReminderStartMapper` now returns no template/variables for unsupported recipient types (e.g., fleet owners) to avoid incorrect WhatsApp sends.
> - **Config**: Adds `HMAC_KEY` to `env.config.ts` validation and `.env.e2e`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d66fa78a25c30e8ace96d2f3344fb84ce35063c4. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->