### PR TITLE
feat(rates): add RatesService with platform fee caching

### DIFF
--- a/src/modules/rates/rates.interface.ts
+++ b/src/modules/rates/rates.interface.ts
@@ -1,0 +1,16 @@
+import type { Decimal } from "@prisma/client/runtime/library";
+
+/**
+ * Platform rates used for booking and extension calculations.
+ * All percentage rates are stored as decimals (e.g., 10% = 10.00).
+ */
+export interface PlatformRates {
+  /** Platform service fee charged to customer (percentage) */
+  platformCustomerServiceFeeRatePercent: Decimal;
+  /** Commission taken from fleet owner's earnings (percentage) */
+  platformFleetOwnerCommissionRatePercent: Decimal;
+  /** VAT rate applied to bookings (percentage) */
+  vatRatePercent: Decimal;
+  /** Security detail addon rate (flat amount per leg) */
+  securityDetailRate: Decimal;
+}

--- a/src/modules/rates/rates.module.ts
+++ b/src/modules/rates/rates.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { RatesService } from "./rates.service";
+
+@Module({
+  providers: [RatesService],
+  exports: [RatesService],
+})
+export class RatesModule {}

--- a/src/modules/rates/rates.module.ts
+++ b/src/modules/rates/rates.module.ts
@@ -1,7 +1,9 @@
 import { Module } from "@nestjs/common";
+import { DatabaseModule } from "../database/database.module";
 import { RatesService } from "./rates.service";
 
 @Module({
+  imports: [DatabaseModule],
   providers: [RatesService],
   exports: [RatesService],
 })

--- a/src/modules/rates/rates.service.spec.ts
+++ b/src/modules/rates/rates.service.spec.ts
@@ -1,0 +1,164 @@
+import { Test, type TestingModule } from "@nestjs/testing";
+import { Decimal } from "@prisma/client/runtime/library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DatabaseService } from "../database/database.service";
+import { RatesService } from "./rates.service";
+
+describe("RatesService", () => {
+  let service: RatesService;
+  let databaseService: {
+    platformFeeRate: { findMany: ReturnType<typeof vi.fn> };
+    taxRate: { findFirst: ReturnType<typeof vi.fn> };
+    addonRate: { findFirst: ReturnType<typeof vi.fn> };
+  };
+
+  const mockPlatformRates = [
+    {
+      id: "rate-1",
+      feeType: "PLATFORM_SERVICE_FEE",
+      ratePercent: new Decimal("10.00"),
+      effectiveSince: new Date("2024-01-01"),
+      effectiveUntil: null,
+    },
+    {
+      id: "rate-2",
+      feeType: "FLEET_OWNER_COMMISSION",
+      ratePercent: new Decimal("5.00"),
+      effectiveSince: new Date("2024-01-01"),
+      effectiveUntil: null,
+    },
+  ];
+
+  const mockVatRate = {
+    id: "vat-1",
+    ratePercent: new Decimal("7.50"),
+    effectiveSince: new Date("2024-01-01"),
+    effectiveUntil: null,
+    description: "Nigerian VAT",
+  };
+
+  const mockSecurityDetailRate = {
+    id: "addon-1",
+    addonType: "SECURITY_DETAIL",
+    rateAmount: new Decimal("5000.00"),
+    effectiveSince: new Date("2024-01-01"),
+    effectiveUntil: null,
+  };
+
+  beforeEach(async () => {
+    databaseService = {
+      platformFeeRate: { findMany: vi.fn() },
+      taxRate: { findFirst: vi.fn() },
+      addonRate: { findFirst: vi.fn() },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [RatesService, { provide: DatabaseService, useValue: databaseService }],
+    }).compile();
+
+    service = module.get<RatesService>(RatesService);
+
+    // Reset mocks to default successful responses
+    databaseService.platformFeeRate.findMany.mockResolvedValue(mockPlatformRates);
+    databaseService.taxRate.findFirst.mockResolvedValue(mockVatRate);
+    databaseService.addonRate.findFirst.mockResolvedValue(mockSecurityDetailRate);
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+
+  describe("getRates", () => {
+    it("should fetch and return all platform rates", async () => {
+      const rates = await service.getRates();
+
+      expect(rates).toEqual({
+        platformCustomerServiceFeeRatePercent: new Decimal("10.00"),
+        platformFleetOwnerCommissionRatePercent: new Decimal("5.00"),
+        vatRatePercent: new Decimal("7.50"),
+        securityDetailRate: new Decimal("5000.00"),
+      });
+
+      expect(databaseService.platformFeeRate.findMany).toHaveBeenCalledTimes(1);
+      expect(databaseService.taxRate.findFirst).toHaveBeenCalledTimes(1);
+      expect(databaseService.addonRate.findFirst).toHaveBeenCalledTimes(1);
+    });
+
+    it("should cache rates and return cached data on subsequent calls", async () => {
+      // First call - fetches from database
+      const rates1 = await service.getRates();
+
+      // Second call - should use cache
+      const rates2 = await service.getRates();
+
+      expect(rates1).toEqual(rates2);
+      expect(databaseService.platformFeeRate.findMany).toHaveBeenCalledTimes(1);
+      expect(databaseService.taxRate.findFirst).toHaveBeenCalledTimes(1);
+      expect(databaseService.addonRate.findFirst).toHaveBeenCalledTimes(1);
+    });
+
+    it("should throw error when platform service fee rate is not found", async () => {
+      databaseService.platformFeeRate.findMany.mockResolvedValue([
+        mockPlatformRates[1], // Only fleet owner commission, no service fee
+      ]);
+
+      await expect(service.getRates()).rejects.toThrow("No active platform service fee rate found");
+    });
+
+    it("should throw error when fleet owner commission rate is not found", async () => {
+      databaseService.platformFeeRate.findMany.mockResolvedValue([
+        mockPlatformRates[0], // Only service fee, no commission
+      ]);
+
+      await expect(service.getRates()).rejects.toThrow(
+        "No active fleet owner commission rate found",
+      );
+    });
+
+    it("should throw error when VAT rate is not found", async () => {
+      databaseService.taxRate.findFirst.mockResolvedValue(null);
+
+      await expect(service.getRates()).rejects.toThrow("No active VAT rate found");
+    });
+
+    it("should throw error when security detail rate is not found", async () => {
+      databaseService.addonRate.findFirst.mockResolvedValue(null);
+
+      await expect(service.getRates()).rejects.toThrow("No active security detail rate found");
+    });
+
+    it("should query with correct effective date filters", async () => {
+      vi.useFakeTimers();
+      const fixedDate = new Date("2024-06-15T12:00:00Z");
+      vi.setSystemTime(fixedDate);
+
+      await service.getRates();
+
+      expect(databaseService.platformFeeRate.findMany).toHaveBeenCalledWith({
+        where: {
+          feeType: { in: ["PLATFORM_SERVICE_FEE", "FLEET_OWNER_COMMISSION"] },
+          effectiveSince: { lte: fixedDate },
+          OR: [{ effectiveUntil: { gt: fixedDate } }, { effectiveUntil: null }],
+        },
+        orderBy: { effectiveSince: "desc" },
+      });
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe("clearCache", () => {
+    it("should clear the cache and force re-fetch on next getRates call", async () => {
+      // First call - fetches from database
+      await service.getRates();
+      expect(databaseService.platformFeeRate.findMany).toHaveBeenCalledTimes(1);
+
+      // Clear cache
+      service.clearCache();
+
+      // Second call - should fetch again
+      await service.getRates();
+      expect(databaseService.platformFeeRate.findMany).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/modules/rates/rates.service.spec.ts
+++ b/src/modules/rates/rates.service.spec.ts
@@ -145,6 +145,23 @@ describe("RatesService", () => {
 
       vi.useRealTimers();
     });
+
+    it("should re-fetch rates after cache TTL expires", async () => {
+      vi.useFakeTimers();
+
+      // First call - fetches from database
+      await service.getRates();
+      expect(databaseService.platformFeeRate.findMany).toHaveBeenCalledTimes(1);
+
+      // Advance time past TTL (5 minutes + 1ms)
+      vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+
+      // Third call - should re-fetch due to TTL expiration
+      await service.getRates();
+      expect(databaseService.platformFeeRate.findMany).toHaveBeenCalledTimes(2);
+
+      vi.useRealTimers();
+    });
   });
 
   describe("clearCache", () => {

--- a/src/modules/rates/rates.service.ts
+++ b/src/modules/rates/rates.service.ts
@@ -1,0 +1,127 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { DatabaseService } from "../database/database.service";
+import type { PlatformRates } from "./rates.interface";
+
+/**
+ * Service for fetching platform rates (fees, VAT, addon rates).
+ *
+ * Implements in-memory caching with 5-minute TTL to reduce database load
+ * since rates change infrequently.
+ */
+@Injectable()
+export class RatesService {
+  private readonly logger = new Logger(RatesService.name);
+
+  private readonly cache: {
+    data: PlatformRates | null;
+    timestamp: number;
+  } = {
+    data: null,
+    timestamp: 0,
+  };
+
+  private readonly CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  /**
+   * Get current platform rates for booking/extension calculations.
+   *
+   * Rates are cached for 5 minutes to reduce database load.
+   * Throws an error if any required rate is not found.
+   */
+  async getRates(): Promise<PlatformRates> {
+    const now = Date.now();
+
+    // Return cached data if still valid
+    if (this.cache.data && now - this.cache.timestamp < this.CACHE_TTL_MS) {
+      this.logger.debug("Returning cached rates");
+      return this.cache.data;
+    }
+
+    this.logger.debug("Fetching rates from database");
+    const currentDate = new Date();
+
+    // Run all rate queries in parallel for better performance
+    const [platformRates, vatRate, securityDetailAddonRate] = await Promise.all([
+      // Get both platform fee rates in a single query
+      this.databaseService.platformFeeRate.findMany({
+        where: {
+          feeType: { in: ["PLATFORM_SERVICE_FEE", "FLEET_OWNER_COMMISSION"] },
+          effectiveSince: { lte: currentDate },
+          OR: [{ effectiveUntil: { gt: currentDate } }, { effectiveUntil: null }],
+        },
+        orderBy: { effectiveSince: "desc" },
+      }),
+      // Get VAT rate
+      this.databaseService.taxRate.findFirst({
+        where: {
+          effectiveSince: { lte: currentDate },
+          OR: [{ effectiveUntil: { gt: currentDate } }, { effectiveUntil: null }],
+        },
+        orderBy: { effectiveSince: "desc" },
+      }),
+      // Get security detail addon rate
+      this.databaseService.addonRate.findFirst({
+        where: {
+          addonType: "SECURITY_DETAIL",
+          effectiveSince: { lte: currentDate },
+          OR: [{ effectiveUntil: { gt: currentDate } }, { effectiveUntil: null }],
+        },
+        orderBy: { effectiveSince: "desc" },
+      }),
+    ]);
+
+    // Extract the specific rates from the array
+    const platformFeeRate = platformRates.find((rate) => rate.feeType === "PLATFORM_SERVICE_FEE");
+    const fleetOwnerCommissionRate = platformRates.find(
+      (rate) => rate.feeType === "FLEET_OWNER_COMMISSION",
+    );
+
+    // Validate all rates are found
+    if (!platformFeeRate) {
+      throw new Error("No active platform service fee rate found");
+    }
+
+    if (!fleetOwnerCommissionRate) {
+      throw new Error("No active fleet owner commission rate found");
+    }
+
+    if (!vatRate) {
+      throw new Error("No active VAT rate found");
+    }
+
+    if (!securityDetailAddonRate) {
+      throw new Error("No active security detail rate found");
+    }
+
+    const result: PlatformRates = {
+      platformCustomerServiceFeeRatePercent: platformFeeRate.ratePercent,
+      platformFleetOwnerCommissionRatePercent: fleetOwnerCommissionRate.ratePercent,
+      vatRatePercent: vatRate.ratePercent,
+      securityDetailRate: securityDetailAddonRate.rateAmount,
+    };
+
+    // Cache the result
+    this.cache.data = result;
+    this.cache.timestamp = now;
+
+    this.logger.debug("Rates fetched and cached", {
+      platformFee: platformFeeRate.ratePercent.toString(),
+      fleetOwnerCommission: fleetOwnerCommissionRate.ratePercent.toString(),
+      vat: vatRate.ratePercent.toString(),
+      securityDetail: securityDetailAddonRate.rateAmount.toString(),
+    });
+
+    return result;
+  }
+
+  /**
+   * Clear the rates cache. Useful for testing or when rates are updated.
+   */
+  clearCache(): void {
+    this.cache.data = null;
+    this.cache.timestamp = 0;
+    this.logger.debug("Rates cache cleared");
+  }
+}


### PR DESCRIPTION
Add RatesService module for fetching platform rates (customer fee, fleet owner commission, VAT, security detail addon) with 5-minute in-memory caching.

- Parallel DB queries for PlatformFeeRate, TaxRate, AddonRate
- Effective date filtering for current rates
- Cache with clearCache() method for testing
- Comprehensive unit tests (9 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a service and module to provide current platform rates with in-memory caching for performance.
> 
> - New `RatesService` with 5-minute cache, parallel DB queries, and effective-date filters for `platformFeeRate`, `taxRate`, and `addonRate`
> - Returns `PlatformRates` (`platformCustomerServiceFeeRatePercent`, `platformFleetOwnerCommissionRatePercent`, `vatRatePercent`, `securityDetailRate`)
> - `RatesModule` exports the service; `rates.interface.ts` defines the shape
> - Unit tests cover success path, caching/TTL behavior, effective-date queries, and missing-rate errors
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49d8c3501931d9e2820bbd08041b1550ed6e0361. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->