### PR TITLE
feat(booking): add booking DTOs and interfaces

### DIFF
--- a/src/modules/booking/booking.interface.ts
+++ b/src/modules/booking/booking.interface.ts
@@ -1,0 +1,68 @@
+import type { BookingStatus, Prisma } from "@prisma/client";
+
+export interface CreateBookingResponse {
+  bookingId: string;
+  bookingReference: string;
+  checkoutUrl: string;
+  totalAmount: string;
+  status: BookingStatus;
+}
+
+export type BookingApiResponse = Prisma.BookingGetPayload<{
+  include: {
+    car: {
+      select: {
+        id: true;
+        make: true;
+        model: true;
+        year: true;
+        plateNumber: true;
+        primaryImageUrl: true;
+      };
+    };
+    user: {
+      select: {
+        id: true;
+        name: true;
+        email: true;
+      };
+    };
+    legs: true;
+  };
+}>;
+
+/**
+ * Booking financial breakdown for display (all amounts as strings for Decimal precision)
+ */
+export interface BookingFinancialsResponse {
+  netTotal: string;
+  securityDetailCost: string;
+  fuelUpgradeCost: string;
+  netTotalWithAddons: string;
+  platformCustomerServiceFeeRatePercent: string;
+  platformCustomerServiceFeeAmount: string;
+  subtotalBeforeDiscounts: string;
+  referralDiscountAmount: string;
+  creditsUsed: string;
+  subtotalAfterDiscounts: string;
+  vatRatePercent: string;
+  vatAmount: string;
+  totalAmount: string;
+  numberOfLegs: number;
+  legPrices: Array<{
+    legDate: string;
+    price: string;
+  }>;
+}
+
+/**
+ * Booking availability check result
+ */
+export interface CarAvailabilityResult {
+  available: boolean;
+  conflictingBookings?: Array<{
+    id: string;
+    startDate: Date;
+    endDate: Date;
+  }>;
+}

--- a/src/modules/booking/dto/create-booking.dto.ts
+++ b/src/modules/booking/dto/create-booking.dto.ts
@@ -1,0 +1,164 @@
+import { z } from "zod";
+
+/**
+ * Booking type enum values matching Prisma schema
+ */
+export const BOOKING_TYPES = ["DAY", "NIGHT", "FULL_DAY", "AIRPORT_PICKUP"] as const;
+export type BookingType = (typeof BOOKING_TYPES)[number];
+
+/**
+ * Pickup time format validation
+ * Accepts: "9 AM", "9:00 AM", "11 PM", "2:30 PM"
+ */
+const pickupTimeRegex = /^(1[0-2]|[1-9])(:[0-5]\d)?\s?(AM|PM)$/i;
+
+/**
+ * Core booking fields shared between logged-in and guest bookings
+ */
+const coreBookingFields = z.object({
+  carId: z.string().min(1, "Car ID is required"),
+  startDate: z.coerce.date("Invalid start date format"),
+  endDate: z.coerce.date("Invalid end date format"),
+  pickupAddress: z.string().min(1, "Pickup address is required"),
+  bookingType: z.enum(BOOKING_TYPES, {
+    message: "Booking type must be DAY, NIGHT, FULL_DAY, or AIRPORT_PICKUP",
+  }),
+  pickupTime: z.string().optional(),
+  flightNumber: z.string().optional(),
+  includeSecurityDetail: z.boolean().default(false),
+  requiresFullTank: z.boolean().default(false),
+  specialRequests: z.string().optional(),
+  useCredits: z.number().min(0).default(0),
+  clientTotalAmount: z.string().optional(), // Decimal string for price validation
+});
+
+/**
+ * Drop-off address schema (required when sameLocation is false)
+ */
+const dropOffSchema = z.object({
+  dropOffAddress: z.string().min(1, "Drop-off address is required"),
+});
+
+/**
+ * Guest booking fields (when user is not authenticated)
+ */
+const guestInfoSchema = z.object({
+  guestEmail: z.email("Invalid email address"),
+  guestName: z.string().min(2, "Name must be at least 2 characters"),
+  guestPhone: z.string().min(10, "Phone number must be at least 10 digits"),
+});
+
+/**
+ * Logged-in user booking schema with same location
+ */
+const bookingSchemaSameLocation = coreBookingFields.extend({
+  sameLocation: z.literal(true),
+});
+
+/**
+ * Logged-in user booking schema with different location
+ */
+const bookingSchemaDifferentLocation = coreBookingFields
+  .extend({
+    sameLocation: z.literal(false),
+  })
+  .extend(dropOffSchema.shape);
+
+/**
+ * Guest booking schema with same location
+ */
+const guestSchemaSameLocation = bookingSchemaSameLocation.extend(guestInfoSchema.shape);
+
+/**
+ * Guest booking schema with different location
+ */
+const guestSchemaDifferentLocation = bookingSchemaDifferentLocation.extend(guestInfoSchema.shape);
+
+/**
+ * Discriminated union for logged-in user bookings
+ */
+const loggedInUserBookingSchema = z.discriminatedUnion("sameLocation", [
+  bookingSchemaSameLocation,
+  bookingSchemaDifferentLocation,
+]);
+
+/**
+ * Discriminated union for guest bookings
+ */
+const guestUserBookingSchema = z.discriminatedUnion("sameLocation", [
+  guestSchemaSameLocation,
+  guestSchemaDifferentLocation,
+]);
+
+/**
+ * Pickup time validation refinement
+ */
+function validatePickupTime(data: { bookingType: BookingType; pickupTime?: string }): boolean {
+  if (data.bookingType === "DAY" || data.bookingType === "FULL_DAY") {
+    return (
+      typeof data.pickupTime === "string" &&
+      data.pickupTime.trim() !== "" &&
+      pickupTimeRegex.test(data.pickupTime.trim())
+    );
+  }
+  return true;
+}
+
+/**
+ * Flight number validation refinement
+ */
+function validateFlightNumber(data: { bookingType: BookingType; flightNumber?: string }): boolean {
+  if (data.bookingType === "AIRPORT_PICKUP") {
+    return typeof data.flightNumber === "string" && data.flightNumber.trim() !== "";
+  }
+  return true;
+}
+
+/**
+ * Apply common booking refinements to a schema
+ */
+function withBookingRefinements<
+  T extends z.ZodType<{ bookingType: BookingType; pickupTime?: string; flightNumber?: string }>,
+>(schema: T) {
+  return schema
+    .refine(validatePickupTime, {
+      message: "Pickup time is required for DAY and FULL_DAY bookings (format: H:MM AM/PM)",
+      path: ["pickupTime"],
+    })
+    .refine(validateFlightNumber, {
+      message: "Flight number is required for AIRPORT_PICKUP bookings",
+      path: ["flightNumber"],
+    });
+}
+
+/**
+ * Full booking schema for logged-in users (with refinements)
+ */
+export const createBookingSchema = withBookingRefinements(loggedInUserBookingSchema);
+
+/**
+ * Full booking schema for guest users (with refinements)
+ */
+export const createGuestBookingSchema = withBookingRefinements(guestUserBookingSchema);
+
+/**
+ * Type inference for logged-in user booking DTO
+ */
+export type CreateBookingDto = z.infer<typeof loggedInUserBookingSchema>;
+
+/**
+ * Type inference for guest booking DTO
+ */
+export type CreateGuestBookingDto = z.infer<typeof guestUserBookingSchema>;
+
+/**
+ * Union type for both booking types
+ */
+export type CreateBookingInput = CreateBookingDto | CreateGuestBookingDto;
+
+/**
+ * Type guard to check if booking input is a guest booking
+ */
+export function isGuestBooking(input: CreateBookingInput): input is CreateGuestBookingDto {
+  return "guestEmail" in input && "guestName" in input && "guestPhone" in input;
+}

--- a/src/modules/booking/dto/create-booking.dto.ts
+++ b/src/modules/booking/dto/create-booking.dto.ts
@@ -118,7 +118,13 @@ function validateFlightNumber(data: { bookingType: BookingType; flightNumber?: s
  * Apply common booking refinements to a schema
  */
 function withBookingRefinements<
-  T extends z.ZodType<{ bookingType: BookingType; pickupTime?: string; flightNumber?: string }>,
+  T extends z.ZodType<{
+    bookingType: BookingType;
+    pickupTime?: string;
+    flightNumber?: string;
+    startDate: Date;
+    endDate: Date;
+  }>,
 >(schema: T) {
   return schema
     .refine(validatePickupTime, {
@@ -128,6 +134,10 @@ function withBookingRefinements<
     .refine(validateFlightNumber, {
       message: "Flight number is required for AIRPORT_PICKUP bookings",
       path: ["flightNumber"],
+    })
+    .refine((data) => data.endDate >= data.startDate, {
+      message: "End date must be on or after start date",
+      path: ["endDate"],
     });
 }
 


### PR DESCRIPTION
- Add Zod schemas for booking creation with discriminated union
- Support both logged-in and guest booking flows
- Add conditional validation for pickupTime and flightNumber
- Add response interfaces using Prisma GetPayload types
- Add BookingFinancialsResponse and CarAvailabilityResult types

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces booking creation DTOs and response types to support both authenticated and guest flows with strict validation.
> 
> - Adds Zod schemas in `dto/create-booking.dto.ts` using discriminated unions on `sameLocation`, with conditional refinements for `pickupTime` (DAY/FULL_DAY), `flightNumber` (AIRPORT_PICKUP), and date range validation
> - Exposes `createBookingSchema`, `createGuestBookingSchema`, `CreateBookingDto`, `CreateGuestBookingDto`, `CreateBookingInput`, and `isGuestBooking`
> - Adds API response interfaces in `booking.interface.ts`: `CreateBookingResponse`, `BookingApiResponse` (via Prisma `BookingGetPayload` with `car`, `user`, `legs`), `BookingFinancialsResponse`, and `CarAvailabilityResult`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e497ffeff0e35279fa5ef4a8b6cde087c38e8c29. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->