### PR TITLE
feat(booking): add BookingValidationService for booking creation validation

### DIFF
--- a/src/modules/booking/booking-validation.service.spec.ts
+++ b/src/modules/booking/booking-validation.service.spec.ts
@@ -1,0 +1,544 @@
+import { BadRequestException } from "@nestjs/common";
+import { Test, TestingModule } from "@nestjs/testing";
+import type { Booking, Car, User } from "@prisma/client";
+import { BookingStatus, PaymentStatus } from "@prisma/client";
+import { Decimal } from "@prisma/client/runtime/library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DatabaseService } from "../database/database.service";
+import { BookingValidationService } from "./booking-validation.service";
+import type { CreateBookingDto, CreateGuestBookingDto } from "./dto/create-booking.dto";
+
+// Helper to create partial mock data with type safety
+const mockCar = (data: Partial<Car>) => data as Car;
+const mockBooking = (data: Partial<Booking>) => data as Booking;
+const mockUser = (data: Partial<User>) => data as User;
+
+describe("BookingValidationService", () => {
+  let service: BookingValidationService;
+  let databaseService: DatabaseService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BookingValidationService,
+        {
+          provide: DatabaseService,
+          useValue: {
+            car: {
+              findUnique: vi.fn(),
+            },
+            booking: {
+              findMany: vi.fn(),
+            },
+            user: {
+              findUnique: vi.fn(),
+            },
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<BookingValidationService>(BookingValidationService);
+    databaseService = module.get<DatabaseService>(DatabaseService);
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+
+  describe("validateDates", () => {
+    it("should pass validation for valid future booking", () => {
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      tomorrow.setHours(10, 0, 0, 0);
+
+      const dayAfterTomorrow = new Date(tomorrow);
+      dayAfterTomorrow.setDate(dayAfterTomorrow.getDate() + 1);
+
+      const result = service.validateDates({
+        startDate: tomorrow,
+        endDate: dayAfterTomorrow,
+        bookingType: "DAY",
+        pickupTime: "9 AM",
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it("should fail validation when end date is before start date", () => {
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+
+      const result = service.validateDates({
+        startDate: tomorrow,
+        endDate: yesterday,
+        bookingType: "DAY",
+        pickupTime: "9 AM",
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual({
+        field: "endDate",
+        message: "End date must be on or after start date",
+      });
+    });
+
+    it("should fail validation when booking start is in the past", () => {
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+
+      const today = new Date();
+
+      const result = service.validateDates({
+        startDate: yesterday,
+        endDate: today,
+        bookingType: "DAY",
+        pickupTime: "9 AM",
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual({
+        field: "startDate",
+        message: "Booking start time cannot be in the past",
+      });
+    });
+
+    it("should fail validation for same-day DAY booking after 11 AM", () => {
+      // Mock current time to be 11 AM or later
+      const now = new Date();
+      now.setHours(11, 0, 0, 0);
+      vi.setSystemTime(now);
+
+      const result = service.validateDates({
+        startDate: now,
+        endDate: now,
+        bookingType: "DAY",
+        pickupTime: "1 PM",
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual({
+        field: "startDate",
+        message: "Same-day DAY bookings cannot be made at or after 11 AM",
+      });
+
+      vi.useRealTimers();
+    });
+
+    it("should pass validation for same-day DAY booking before 11 AM", () => {
+      // Mock current time to be 9 AM
+      const now = new Date();
+      now.setHours(9, 0, 0, 0);
+      vi.setSystemTime(now);
+
+      const laterToday = new Date(now);
+      laterToday.setHours(14, 0, 0, 0);
+
+      const result = service.validateDates({
+        startDate: laterToday,
+        endDate: laterToday,
+        bookingType: "DAY",
+        pickupTime: "1 PM",
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+
+      vi.useRealTimers();
+    });
+
+    it("should fail validation for airport pickup without 1-hour advance notice", () => {
+      const now = new Date();
+      const thirtyMinutesFromNow = new Date(now.getTime() + 30 * 60 * 1000);
+
+      const result = service.validateDates({
+        startDate: thirtyMinutesFromNow,
+        endDate: thirtyMinutesFromNow,
+        bookingType: "AIRPORT_PICKUP",
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual({
+        field: "startDate",
+        message: "Airport pickup bookings require at least 1 hour advance notice",
+      });
+    });
+
+    it("should pass validation for airport pickup with sufficient advance notice", () => {
+      const now = new Date();
+      const twoHoursFromNow = new Date(now.getTime() + 2 * 60 * 60 * 1000);
+      const threeHoursFromNow = new Date(now.getTime() + 3 * 60 * 60 * 1000);
+
+      const result = service.validateDates({
+        startDate: twoHoursFromNow,
+        endDate: threeHoursFromNow,
+        bookingType: "AIRPORT_PICKUP",
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it("should not apply same-day restriction to NIGHT bookings", () => {
+      // Mock current time to be 2 PM
+      const now = new Date();
+      now.setHours(14, 0, 0, 0);
+      vi.setSystemTime(now);
+
+      const laterToday = new Date(now);
+      laterToday.setHours(23, 0, 0, 0);
+
+      const result = service.validateDates({
+        startDate: laterToday,
+        endDate: laterToday,
+        bookingType: "NIGHT",
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe("checkCarAvailability", () => {
+    it("should pass when car exists and no conflicting bookings", async () => {
+      vi.mocked(databaseService.car.findUnique).mockResolvedValueOnce(mockCar({ id: "car-123" }));
+      vi.mocked(databaseService.booking.findMany).mockResolvedValueOnce([]);
+
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+
+      const dayAfterTomorrow = new Date(tomorrow);
+      dayAfterTomorrow.setDate(dayAfterTomorrow.getDate() + 1);
+
+      const result = await service.checkCarAvailability({
+        carId: "car-123",
+        startDate: tomorrow,
+        endDate: dayAfterTomorrow,
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it("should fail when car does not exist", async () => {
+      vi.mocked(databaseService.car.findUnique).mockResolvedValueOnce(null);
+
+      const result = await service.checkCarAvailability({
+        carId: "non-existent-car",
+        startDate: new Date(),
+        endDate: new Date(),
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual({
+        field: "carId",
+        message: "Car not found",
+      });
+    });
+
+    it("should fail when there are conflicting bookings", async () => {
+      vi.mocked(databaseService.car.findUnique).mockResolvedValueOnce(mockCar({ id: "car-123" }));
+      vi.mocked(databaseService.booking.findMany).mockResolvedValueOnce([
+        mockBooking({
+          id: "existing-booking",
+          startDate: new Date("2025-02-01T09:00:00Z"),
+          endDate: new Date("2025-02-01T21:00:00Z"),
+          bookingReference: "BK-EXISTING",
+        }),
+      ]);
+
+      const result = await service.checkCarAvailability({
+        carId: "car-123",
+        startDate: new Date("2025-02-01T10:00:00Z"),
+        endDate: new Date("2025-02-01T18:00:00Z"),
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual({
+        field: "carId",
+        message:
+          "Car is not available for the selected dates. Please choose different dates or another vehicle.",
+      });
+    });
+
+    it("should exclude specified booking when checking availability", async () => {
+      vi.mocked(databaseService.car.findUnique).mockResolvedValueOnce(mockCar({ id: "car-123" }));
+      vi.mocked(databaseService.booking.findMany).mockResolvedValueOnce([]);
+
+      const result = await service.checkCarAvailability({
+        carId: "car-123",
+        startDate: new Date(),
+        endDate: new Date(),
+        excludeBookingId: "booking-to-exclude",
+      });
+
+      expect(result.valid).toBe(true);
+      expect(databaseService.booking.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            id: { not: "booking-to-exclude" },
+          }),
+        }),
+      );
+    });
+
+    it("should only check bookings with CONFIRMED/ACTIVE status and PAID payment", async () => {
+      vi.mocked(databaseService.car.findUnique).mockResolvedValueOnce(mockCar({ id: "car-123" }));
+      vi.mocked(databaseService.booking.findMany).mockResolvedValueOnce([]);
+
+      await service.checkCarAvailability({
+        carId: "car-123",
+        startDate: new Date(),
+        endDate: new Date(),
+      });
+
+      expect(databaseService.booking.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            paymentStatus: PaymentStatus.PAID,
+            status: { in: [BookingStatus.CONFIRMED, BookingStatus.ACTIVE] },
+          }),
+        }),
+      );
+    });
+  });
+
+  describe("validateGuestEmail", () => {
+    it("should pass for authenticated user booking (no guest email)", async () => {
+      const input: CreateBookingDto = {
+        carId: "car-123",
+        startDate: new Date(),
+        endDate: new Date(),
+        pickupAddress: "123 Main St",
+        bookingType: "DAY",
+        sameLocation: true,
+        includeSecurityDetail: false,
+        requiresFullTank: false,
+        useCredits: 0,
+      };
+
+      const result = await service.validateGuestEmail(input);
+
+      expect(result.valid).toBe(true);
+      expect(databaseService.user.findUnique).not.toHaveBeenCalled();
+    });
+
+    it("should pass for guest booking with unregistered email", async () => {
+      vi.mocked(databaseService.user.findUnique).mockResolvedValueOnce(null);
+
+      const input: CreateGuestBookingDto = {
+        carId: "car-123",
+        startDate: new Date(),
+        endDate: new Date(),
+        pickupAddress: "123 Main St",
+        bookingType: "DAY",
+        sameLocation: true,
+        includeSecurityDetail: false,
+        requiresFullTank: false,
+        useCredits: 0,
+        guestEmail: "newuser@example.com",
+        guestName: "John Doe",
+        guestPhone: "1234567890",
+      };
+
+      const result = await service.validateGuestEmail(input);
+
+      expect(result.valid).toBe(true);
+      expect(databaseService.user.findUnique).toHaveBeenCalledWith({
+        where: { email: "newuser@example.com" },
+        select: { id: true },
+      });
+    });
+
+    it("should fail for guest booking with already registered email", async () => {
+      vi.mocked(databaseService.user.findUnique).mockResolvedValueOnce(
+        mockUser({ id: "existing-user" }),
+      );
+
+      const input: CreateGuestBookingDto = {
+        carId: "car-123",
+        startDate: new Date(),
+        endDate: new Date(),
+        pickupAddress: "123 Main St",
+        bookingType: "DAY",
+        sameLocation: true,
+        includeSecurityDetail: false,
+        requiresFullTank: false,
+        useCredits: 0,
+        guestEmail: "existing@example.com",
+        guestName: "John Doe",
+        guestPhone: "1234567890",
+      };
+
+      const result = await service.validateGuestEmail(input);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual({
+        field: "guestEmail",
+        message: "This email is already registered. Please log in to make a booking.",
+      });
+    });
+  });
+
+  describe("validatePriceMatch", () => {
+    it("should pass when no client total is provided", () => {
+      const result = service.validatePriceMatch(undefined, new Decimal("10000"));
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it("should pass when prices match exactly", () => {
+      const result = service.validatePriceMatch("10000", new Decimal("10000"));
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it("should pass when prices are within tolerance", () => {
+      const result = service.validatePriceMatch("10000.005", new Decimal("10000"));
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it("should fail when prices differ significantly", () => {
+      const result = service.validatePriceMatch("9000", new Decimal("10000"));
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual({
+        field: "clientTotalAmount",
+        message: "Price mismatch. Please refresh and try again.",
+      });
+    });
+
+    it("should fail for invalid price format", () => {
+      const result = service.validatePriceMatch("not-a-number", new Decimal("10000"));
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual({
+        field: "clientTotalAmount",
+        message: "Invalid price format",
+      });
+    });
+  });
+
+  describe("validateAll", () => {
+    it("should throw BadRequestException when validation fails", async () => {
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+
+      const input: CreateBookingDto = {
+        carId: "car-123",
+        startDate: yesterday,
+        endDate: yesterday,
+        pickupAddress: "123 Main St",
+        bookingType: "DAY",
+        sameLocation: true,
+        includeSecurityDetail: false,
+        requiresFullTank: false,
+        useCredits: 0,
+      };
+
+      await expect(service.validateAll(input)).rejects.toThrow(BadRequestException);
+    });
+
+    it("should not throw when all validations pass", async () => {
+      vi.mocked(databaseService.car.findUnique).mockResolvedValueOnce(mockCar({ id: "car-123" }));
+      vi.mocked(databaseService.booking.findMany).mockResolvedValueOnce([]);
+
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      tomorrow.setHours(10, 0, 0, 0);
+
+      const dayAfterTomorrow = new Date(tomorrow);
+      dayAfterTomorrow.setDate(dayAfterTomorrow.getDate() + 1);
+
+      const input: CreateBookingDto = {
+        carId: "car-123",
+        startDate: tomorrow,
+        endDate: dayAfterTomorrow,
+        pickupAddress: "123 Main St",
+        bookingType: "DAY",
+        pickupTime: "9 AM",
+        sameLocation: true,
+        includeSecurityDetail: false,
+        requiresFullTank: false,
+        useCredits: 0,
+      };
+
+      await expect(service.validateAll(input)).resolves.toBeUndefined();
+    });
+
+    it("should include price validation when serverTotal is provided", async () => {
+      vi.mocked(databaseService.car.findUnique).mockResolvedValueOnce(mockCar({ id: "car-123" }));
+      vi.mocked(databaseService.booking.findMany).mockResolvedValueOnce([]);
+
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      tomorrow.setHours(10, 0, 0, 0);
+
+      const dayAfterTomorrow = new Date(tomorrow);
+      dayAfterTomorrow.setDate(dayAfterTomorrow.getDate() + 1);
+
+      const input: CreateBookingDto = {
+        carId: "car-123",
+        startDate: tomorrow,
+        endDate: dayAfterTomorrow,
+        pickupAddress: "123 Main St",
+        bookingType: "DAY",
+        pickupTime: "9 AM",
+        sameLocation: true,
+        includeSecurityDetail: false,
+        requiresFullTank: false,
+        useCredits: 0,
+        clientTotalAmount: "5000", // Intentionally wrong
+      };
+
+      await expect(service.validateAll(input, new Decimal("10000"))).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it("should aggregate all validation errors", async () => {
+      vi.mocked(databaseService.car.findUnique).mockResolvedValueOnce(null);
+      vi.mocked(databaseService.user.findUnique).mockResolvedValueOnce(
+        mockUser({ id: "existing-user" }),
+      );
+
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+
+      const input: CreateGuestBookingDto = {
+        carId: "non-existent-car",
+        startDate: yesterday,
+        endDate: yesterday,
+        pickupAddress: "123 Main St",
+        bookingType: "DAY",
+        sameLocation: true,
+        includeSecurityDetail: false,
+        requiresFullTank: false,
+        useCredits: 0,
+        guestEmail: "existing@example.com",
+        guestName: "John Doe",
+        guestPhone: "1234567890",
+      };
+
+      try {
+        await service.validateAll(input);
+        expect.fail("Should have thrown BadRequestException");
+      } catch (error) {
+        expect(error).toBeInstanceOf(BadRequestException);
+        const response = (error as BadRequestException).getResponse() as { errors: unknown[] };
+        // Should have multiple errors: past date, car not found, guest email registered
+        expect(response.errors.length).toBeGreaterThanOrEqual(2);
+      }
+    });
+  });
+});

--- a/src/modules/booking/booking-validation.service.spec.ts
+++ b/src/modules/booking/booking-validation.service.spec.ts
@@ -59,7 +59,6 @@ describe("BookingValidationService", () => {
         startDate: tomorrow,
         endDate: dayAfterTomorrow,
         bookingType: "DAY",
-        pickupTime: "9 AM",
       });
 
       expect(result.valid).toBe(true);
@@ -77,7 +76,6 @@ describe("BookingValidationService", () => {
         startDate: tomorrow,
         endDate: yesterday,
         bookingType: "DAY",
-        pickupTime: "9 AM",
       });
 
       expect(result.valid).toBe(false);
@@ -97,7 +95,6 @@ describe("BookingValidationService", () => {
         startDate: yesterday,
         endDate: today,
         bookingType: "DAY",
-        pickupTime: "9 AM",
       });
 
       expect(result.valid).toBe(false);
@@ -119,7 +116,6 @@ describe("BookingValidationService", () => {
           startDate: now,
           endDate: now,
           bookingType: "DAY",
-          pickupTime: "1 PM",
         });
 
         expect(result.valid).toBe(false);
@@ -147,7 +143,6 @@ describe("BookingValidationService", () => {
           startDate: laterToday,
           endDate: laterToday,
           bookingType: "DAY",
-          pickupTime: "1 PM",
         });
 
         expect(result.valid).toBe(true);

--- a/src/modules/booking/booking-validation.service.ts
+++ b/src/modules/booking/booking-validation.service.ts
@@ -1,0 +1,315 @@
+import { BadRequestException, Injectable, Logger } from "@nestjs/common";
+import { BookingStatus, PaymentStatus } from "@prisma/client";
+import { Decimal } from "@prisma/client/runtime/library";
+import { DatabaseService } from "../database/database.service";
+import {
+  AIRPORT_PICKUP_MIN_ADVANCE_MS,
+  BOOKING_BUFFER_HOURS,
+  PRICE_TOLERANCE,
+  SAME_DAY_BOOKING_CUTOFF_HOUR,
+} from "./booking.const";
+import {
+  CarAvailabilityInput,
+  DateValidationInput,
+  ValidationError,
+  ValidationResult,
+} from "./booking.interface";
+import type { CreateBookingInput } from "./dto/create-booking.dto";
+import { isGuestBooking } from "./dto/create-booking.dto";
+
+/**
+ * Service for validating booking creation requests.
+ *
+ * This service handles:
+ * - Date/time validation (past bookings, same-day rules, airport lead time)
+ * - Car availability checking with buffer zones
+ * - Guest email validation (prevent duplicate accounts)
+ * - Price validation (client vs server calculation)
+ */
+@Injectable()
+export class BookingValidationService {
+  private readonly logger = new Logger(BookingValidationService.name);
+
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  /**
+   * Validate booking dates and times based on business rules.
+   *
+   * Rules:
+   * - End date must be >= start date (already validated in DTO)
+   * - Cannot book in the past
+   * - Airport pickup: minimum 1-hour advance notice
+   * - Same-day DAY bookings: not allowed after 11 AM
+   *
+   * @param input - Date validation input
+   * @returns Validation result with any errors
+   */
+  validateDates(input: DateValidationInput): ValidationResult {
+    const errors: ValidationError[] = [];
+    const now = new Date();
+
+    const { startDate, endDate, bookingType } = input;
+
+    // Rule: End date must be >= start date
+    if (endDate < startDate) {
+      errors.push({
+        field: "endDate",
+        message: "End date must be on or after start date",
+      });
+    }
+
+    // Rule: Airport pickup requires minimum 1-hour advance notice
+    if (bookingType === "AIRPORT_PICKUP") {
+      const oneHourFromNow = new Date(now.getTime() + AIRPORT_PICKUP_MIN_ADVANCE_MS);
+      if (startDate < oneHourFromNow) {
+        errors.push({
+          field: "startDate",
+          message: "Airport pickup bookings require at least 1 hour advance notice",
+        });
+      }
+    } else {
+      // Rule: Cannot book in the past (for non-airport bookings)
+      if (startDate < now) {
+        errors.push({
+          field: "startDate",
+          message: "Booking start time cannot be in the past",
+        });
+      }
+
+      // Rule: Same-day DAY bookings not allowed after 11 AM
+      if (bookingType === "DAY") {
+        const isSameDay =
+          startDate.getFullYear() === now.getFullYear() &&
+          startDate.getMonth() === now.getMonth() &&
+          startDate.getDate() === now.getDate();
+
+        if (isSameDay && now.getHours() >= SAME_DAY_BOOKING_CUTOFF_HOUR) {
+          errors.push({
+            field: "startDate",
+            message: "Same-day DAY bookings cannot be made at or after 11 AM",
+          });
+        }
+      }
+    }
+
+    return {
+      valid: errors.length === 0,
+      errors,
+    };
+  }
+
+  /**
+   * Check if a car is available for the requested booking period.
+   *
+   * A car is unavailable if there are overlapping bookings with:
+   * - Status: CONFIRMED or ACTIVE
+   * - PaymentStatus: PAID
+   *
+   * A 2-hour buffer is applied between bookings for car preparation.
+   *
+   * @param input - Car availability check input
+   * @returns Validation result with any conflicts
+   */
+  async checkCarAvailability(input: CarAvailabilityInput): Promise<ValidationResult> {
+    const errors: ValidationError[] = [];
+    const { carId, startDate, endDate, excludeBookingId } = input;
+
+    // Verify car exists
+    const car = await this.databaseService.car.findUnique({
+      where: { id: carId },
+      select: { id: true },
+    });
+
+    if (!car) {
+      errors.push({
+        field: "carId",
+        message: "Car not found",
+      });
+      return { valid: false, errors };
+    }
+
+    // Calculate buffered time window
+    const bufferedStart = new Date(startDate.getTime() - BOOKING_BUFFER_HOURS * 60 * 60 * 1000);
+    const bufferedEnd = new Date(endDate.getTime() + BOOKING_BUFFER_HOURS * 60 * 60 * 1000);
+
+    // Find conflicting bookings
+    const conflictingBookings = await this.databaseService.booking.findMany({
+      where: {
+        carId,
+        paymentStatus: PaymentStatus.PAID,
+        status: { in: [BookingStatus.CONFIRMED, BookingStatus.ACTIVE] },
+        // Exclude current booking if this is an update
+        ...(excludeBookingId && { id: { not: excludeBookingId } }),
+        // Check for overlap with buffer
+        OR: [
+          // New booking starts during existing booking (with buffer)
+          {
+            startDate: { lte: bufferedEnd },
+            endDate: { gte: bufferedStart },
+          },
+        ],
+      },
+      select: {
+        id: true,
+        startDate: true,
+        endDate: true,
+        bookingReference: true,
+      },
+    });
+
+    if (conflictingBookings.length > 0) {
+      this.logger.log("Car availability conflict found", {
+        carId,
+        requestedStart: startDate.toISOString(),
+        requestedEnd: endDate.toISOString(),
+        conflictingBookings: conflictingBookings.map((b) => ({
+          id: b.id,
+          reference: b.bookingReference,
+          start: b.startDate.toISOString(),
+          end: b.endDate.toISOString(),
+        })),
+      });
+
+      errors.push({
+        field: "carId",
+        message:
+          "Car is not available for the selected dates. Please choose different dates or another vehicle.",
+      });
+    }
+
+    return {
+      valid: errors.length === 0,
+      errors,
+    };
+  }
+
+  /**
+   * Validate that a guest email is not already registered as a user.
+   *
+   * This prevents guest bookings from users who should log in instead.
+   *
+   * @param input - Booking input (guest or authenticated)
+   * @returns Validation result
+   */
+  async validateGuestEmail(input: CreateBookingInput): Promise<ValidationResult> {
+    const errors: ValidationError[] = [];
+
+    // Only validate if this is a guest booking
+    if (!isGuestBooking(input)) {
+      return { valid: true, errors: [] };
+    }
+
+    const existingUser = await this.databaseService.user.findUnique({
+      where: { email: input.guestEmail },
+      select: { id: true },
+    });
+
+    if (existingUser) {
+      this.logger.log("Guest email already registered", {
+        email: input.guestEmail.replace(/(.{2}).*(@.*)/, "$1***$2"), // Mask email
+      });
+
+      errors.push({
+        field: "guestEmail",
+        message: "This email is already registered. Please log in to make a booking.",
+      });
+    }
+
+    return {
+      valid: errors.length === 0,
+      errors,
+    };
+  }
+
+  /**
+   * Validate that client-provided total matches server calculation.
+   *
+   * This prevents price manipulation attacks where the client sends
+   * a lower amount than the actual calculated price.
+   *
+   * @param clientTotal - Total amount sent by client (as string)
+   * @param serverTotal - Total amount calculated by server
+   * @returns Validation result
+   */
+  validatePriceMatch(clientTotal: string | undefined, serverTotal: Decimal): ValidationResult {
+    const errors: ValidationError[] = [];
+
+    // Skip validation if client didn't provide a total
+    if (!clientTotal) {
+      return { valid: true, errors: [] };
+    }
+
+    try {
+      const clientDecimal = new Decimal(clientTotal);
+      const difference = clientDecimal.minus(serverTotal).abs();
+
+      if (difference.greaterThan(PRICE_TOLERANCE)) {
+        this.logger.warn("Price mismatch detected", {
+          clientTotal: clientDecimal.toString(),
+          serverTotal: serverTotal.toString(),
+          difference: difference.toString(),
+        });
+
+        errors.push({
+          field: "clientTotalAmount",
+          message: "Price mismatch. Please refresh and try again.",
+        });
+      }
+    } catch {
+      errors.push({
+        field: "clientTotalAmount",
+        message: "Invalid price format",
+      });
+    }
+
+    return {
+      valid: errors.length === 0,
+      errors,
+    };
+  }
+
+  /**
+   * Run all validations and throw if any fail.
+   *
+   * @param input - Booking input
+   * @param serverTotal - Server-calculated total (optional)
+   * @throws BadRequestException if validation fails
+   */
+  async validateAll(input: CreateBookingInput, serverTotal?: Decimal): Promise<void> {
+    const allErrors: ValidationError[] = [];
+
+    // Date validation
+    const dateResult = this.validateDates({
+      startDate: input.startDate,
+      endDate: input.endDate,
+      bookingType: input.bookingType,
+      pickupTime: input.pickupTime,
+    });
+    allErrors.push(...dateResult.errors);
+
+    // Car availability
+    const availabilityResult = await this.checkCarAvailability({
+      carId: input.carId,
+      startDate: input.startDate,
+      endDate: input.endDate,
+    });
+    allErrors.push(...availabilityResult.errors);
+
+    // Guest email validation
+    const guestResult = await this.validateGuestEmail(input);
+    allErrors.push(...guestResult.errors);
+
+    // Price validation (if server total provided)
+    if (serverTotal) {
+      const priceResult = this.validatePriceMatch(input.clientTotalAmount, serverTotal);
+      allErrors.push(...priceResult.errors);
+    }
+
+    if (allErrors.length > 0) {
+      throw new BadRequestException({
+        message: "Validation failed",
+        errors: allErrors,
+      });
+    }
+  }
+}

--- a/src/modules/booking/booking-validation.service.ts
+++ b/src/modules/booking/booking-validation.service.ts
@@ -314,7 +314,6 @@ export class BookingValidationService {
       startDate: input.startDate,
       endDate: input.endDate,
       bookingType: input.bookingType,
-      pickupTime: input.pickupTime,
     });
     allErrors.push(...dateResult.errors);
 

--- a/src/modules/booking/booking-validation.service.ts
+++ b/src/modules/booking/booking-validation.service.ts
@@ -141,13 +141,8 @@ export class BookingValidationService {
         // Exclude current booking if this is an update
         ...(excludeBookingId && { id: { not: excludeBookingId } }),
         // Check for overlap with buffer
-        OR: [
-          // New booking starts during existing booking (with buffer)
-          {
-            startDate: { lte: bufferedEnd },
-            endDate: { gte: bufferedStart },
-          },
-        ],
+        startDate: { lt: bufferedEnd },
+        endDate: { gt: bufferedStart },
       },
       select: {
         id: true,

--- a/src/modules/booking/booking.const.ts
+++ b/src/modules/booking/booking.const.ts
@@ -1,0 +1,25 @@
+import { Decimal } from "@prisma/client/runtime/library";
+
+/**
+ * Buffer time in hours between bookings for car preparation/turnaround.
+ * This extends existing booking windows by 2 hours on each side.
+ */
+export const BOOKING_BUFFER_HOURS = 2;
+
+/**
+ * Cutoff hour for same-day DAY bookings (11 AM Lagos time).
+ * Same-day DAY bookings are not allowed at or after this hour.
+ */
+export const SAME_DAY_BOOKING_CUTOFF_HOUR = 11;
+
+/**
+ * Minimum advance notice required for airport pickup bookings (in milliseconds).
+ * Airport pickups require at least 1 hour advance notice.
+ */
+export const AIRPORT_PICKUP_MIN_ADVANCE_MS = 60 * 60 * 1000; // 1 hour
+
+/**
+ * Tolerance for price validation between client and server amounts.
+ * Allows for minor rounding differences in Decimal calculations.
+ */
+export const PRICE_TOLERANCE = new Decimal("0.01");

--- a/src/modules/booking/booking.interface.ts
+++ b/src/modules/booking/booking.interface.ts
@@ -71,7 +71,6 @@ export interface DateValidationInput {
   startDate: Date;
   endDate: Date;
   bookingType: BookingType;
-  pickupTime?: string;
 }
 
 export interface CarAvailabilityInput {

--- a/src/modules/booking/booking.interface.ts
+++ b/src/modules/booking/booking.interface.ts
@@ -1,4 +1,4 @@
-import type { BookingStatus, Prisma } from "@prisma/client";
+import type { BookingStatus, BookingType, Prisma } from "@prisma/client";
 
 export interface CreateBookingResponse {
   bookingId: string;
@@ -65,4 +65,28 @@ export interface CarAvailabilityResult {
     startDate: Date;
     endDate: Date;
   }>;
+}
+
+export interface DateValidationInput {
+  startDate: Date;
+  endDate: Date;
+  bookingType: BookingType;
+  pickupTime?: string;
+}
+
+export interface CarAvailabilityInput {
+  carId: string;
+  startDate: Date;
+  endDate: Date;
+  excludeBookingId?: string;
+}
+
+export interface ValidationError {
+  field: string;
+  message: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: ValidationError[];
 }


### PR DESCRIPTION
Implement a comprehensive validation service for booking creation with:

- Date validation: past booking prevention, same-day DAY booking cutoff (11 AM), airport pickup 1-hour advance notice requirement
- Car availability checking with a 2-hour buffer between bookings
- Guest email validation to prevent duplicate accounts
- Price match validation between client and server calculations

Includes 26 unit tests covering all validation scenarios.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a centralized `BookingValidationService` for end-to-end booking creation checks.
> 
> - Adds `booking-validation.service.ts` with `validateDates`, `checkCarAvailability`, `validateGuestEmail`, `validatePriceMatch`, and `validateAll` (aggregates errors with `BadRequestException`).
> - Enforces rules: no past bookings, same-day `DAY` cutoff at 11 AM, `AIRPORT_PICKUP` 1‑hour notice, and car status/approval gating; availability uses a 2‑hour buffer and only considers `PAID` + (`CONFIRMED`|`ACTIVE`) bookings.
> - Adds pricing tolerance via `PRICE_TOLERANCE` and constants in `booking.const`.
> - Extends `booking.interface` with `DateValidationInput`, `CarAvailabilityInput`, `ValidationError`, and `ValidationResult`.
> - Includes comprehensive unit tests in `booking-validation.service.spec.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92d155da408803262abc8fdbb391b89973ce2812. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->