### PR TITLE
feat(booking): add BookingCalculationService for booking cost calculations

### DIFF
--- a/src/modules/booking/booking-calculation.interface.ts
+++ b/src/modules/booking/booking-calculation.interface.ts
@@ -20,7 +20,6 @@ export type CarPricing = Pick<
   | "nightRate"
   | "fullDayRate"
   | "airportPickupRate"
-  | "hourlyRate"
   | "fuelUpgradeRate"
   | "pricingIncludesFuel"
 >;

--- a/src/modules/booking/booking-calculation.interface.ts
+++ b/src/modules/booking/booking-calculation.interface.ts
@@ -1,0 +1,83 @@
+import type { BookingType, Car } from "@prisma/client";
+import type { Decimal } from "@prisma/client/runtime/library";
+import type { GeneratedLeg } from "./booking.interface";
+
+/**
+ * Price for a single booking leg
+ */
+export interface LegPrice {
+  legDate: Date;
+  price: Decimal;
+}
+
+/**
+ * Car pricing information needed for calculations.
+ * Derived from Prisma Car model to ensure type safety with DB schema.
+ */
+export type CarPricing = Pick<
+  Car,
+  | "dayRate"
+  | "nightRate"
+  | "fullDayRate"
+  | "airportPickupRate"
+  | "hourlyRate"
+  | "fuelUpgradeRate"
+  | "pricingIncludesFuel"
+>;
+
+/**
+ * Input for booking cost calculation
+ */
+export interface BookingCalculationInput {
+  bookingType: BookingType;
+  legs: GeneratedLeg[];
+  car: CarPricing;
+  includeSecurityDetail: boolean;
+  requiresFullTank: boolean;
+  /** User's available credit balance (optional) */
+  userCreditsBalance?: Decimal;
+  /** Amount of credits to use (cannot exceed balance or subtotal) */
+  creditsToUse?: Decimal;
+  /** Referral discount amount (if eligible) */
+  referralDiscountAmount?: Decimal;
+}
+
+/**
+ * Complete financial breakdown for a booking.
+ * All monetary amounts are Decimal for precision.
+ */
+export interface BookingFinancials {
+  // Leg pricing
+  legPrices: LegPrice[];
+  numberOfLegs: number;
+  netTotal: Decimal;
+
+  // Add-ons
+  securityDetailCost: Decimal;
+  fuelUpgradeCost: Decimal;
+  netTotalWithAddons: Decimal;
+
+  // Platform fee (customer pays)
+  /** Base amount for platform fee: netTotal + fuelUpgrade (excludes security) */
+  platformFeeBase: Decimal;
+  platformCustomerServiceFeeRatePercent: Decimal;
+  platformCustomerServiceFeeAmount: Decimal;
+
+  // Subtotals
+  subtotalBeforeDiscounts: Decimal;
+  referralDiscountAmount: Decimal;
+  creditsUsed: Decimal;
+  subtotalAfterDiscounts: Decimal;
+
+  // VAT
+  vatRatePercent: Decimal;
+  vatAmount: Decimal;
+
+  // Total customer pays
+  totalAmount: Decimal;
+
+  // Fleet owner side
+  platformFleetOwnerCommissionRatePercent: Decimal;
+  platformFleetOwnerCommissionAmount: Decimal;
+  fleetOwnerPayoutAmountNet: Decimal;
+}

--- a/src/modules/booking/booking-calculation.service.spec.ts
+++ b/src/modules/booking/booking-calculation.service.spec.ts
@@ -1,0 +1,638 @@
+import { Test, type TestingModule } from "@nestjs/testing";
+import { Decimal } from "@prisma/client/runtime/library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RatesService } from "../rates/rates.service";
+import type { BookingCalculationInput, CarPricing } from "./booking-calculation.interface";
+import { BookingCalculationService } from "./booking-calculation.service";
+import type { GeneratedLeg } from "./booking.interface";
+
+describe("BookingCalculationService", () => {
+  let service: BookingCalculationService;
+  let ratesService: { getRates: ReturnType<typeof vi.fn> };
+
+  // Standard mock rates
+  const mockRates = {
+    platformCustomerServiceFeeRatePercent: new Decimal("10.00"), // 10%
+    platformFleetOwnerCommissionRatePercent: new Decimal("5.00"), // 5%
+    vatRatePercent: new Decimal("7.50"), // 7.5%
+    securityDetailRate: new Decimal("5000.00"), // ₦5,000 per leg
+  };
+
+  // Standard mock car pricing
+  const mockCar: CarPricing = {
+    dayRate: 50000, // ₦50,000
+    nightRate: 30000, // ₦30,000
+    fullDayRate: 80000, // ₦80,000
+    airportPickupRate: 25000, // ₦25,000
+    hourlyRate: 5000, // ₦5,000
+    fuelUpgradeRate: 10000, // ₦10,000
+    pricingIncludesFuel: false,
+  };
+
+  // Helper to create legs
+  const createLegs = (count: number): GeneratedLeg[] => {
+    return Array.from({ length: count }, (_, i) => ({
+      legDate: new Date(`2025-03-0${i + 1}T00:00:00Z`),
+      legStartTime: new Date(`2025-03-0${i + 1}T09:00:00Z`),
+      legEndTime: new Date(`2025-03-0${i + 1}T21:00:00Z`),
+    }));
+  };
+
+  beforeEach(async () => {
+    ratesService = {
+      getRates: vi.fn().mockResolvedValue(mockRates),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [BookingCalculationService, { provide: RatesService, useValue: ratesService }],
+    }).compile();
+
+    service = module.get<BookingCalculationService>(BookingCalculationService);
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+
+  describe("leg pricing by booking type", () => {
+    it("should calculate DAY booking with dayRate", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "DAY",
+        legs: createLegs(2),
+        car: mockCar,
+        includeSecurityDetail: false,
+        requiresFullTank: false,
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      expect(result.legPrices).toHaveLength(2);
+      expect(result.legPrices[0].price.equals(new Decimal(50000))).toBe(true);
+      expect(result.legPrices[1].price.equals(new Decimal(50000))).toBe(true);
+      expect(result.netTotal.equals(new Decimal(100000))).toBe(true); // 50,000 × 2
+    });
+
+    it("should calculate NIGHT booking with nightRate", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "NIGHT",
+        legs: createLegs(3),
+        car: mockCar,
+        includeSecurityDetail: false,
+        requiresFullTank: false,
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      expect(result.netTotal.equals(new Decimal(90000))).toBe(true); // 30,000 × 3
+    });
+
+    it("should calculate FULL_DAY booking with fullDayRate", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "FULL_DAY",
+        legs: createLegs(2),
+        car: mockCar,
+        includeSecurityDetail: false,
+        requiresFullTank: false,
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      expect(result.netTotal.equals(new Decimal(160000))).toBe(true); // 80,000 × 2
+    });
+
+    it("should calculate AIRPORT_PICKUP booking with airportPickupRate", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "AIRPORT_PICKUP",
+        legs: createLegs(1),
+        car: mockCar,
+        includeSecurityDetail: false,
+        requiresFullTank: false,
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      expect(result.netTotal.equals(new Decimal(25000))).toBe(true); // 25,000 × 1
+    });
+  });
+
+  describe("security detail add-on", () => {
+    it("should add security detail cost when requested", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "DAY",
+        legs: createLegs(2),
+        car: mockCar,
+        includeSecurityDetail: true,
+        requiresFullTank: false,
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      // Security: 5,000 × 2 legs = 10,000
+      expect(result.securityDetailCost.equals(new Decimal(10000))).toBe(true);
+      expect(result.netTotalWithAddons.equals(new Decimal(110000))).toBe(true); // 100,000 + 10,000
+    });
+
+    it("should not add security detail cost when not requested", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "DAY",
+        legs: createLegs(2),
+        car: mockCar,
+        includeSecurityDetail: false,
+        requiresFullTank: false,
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      expect(result.securityDetailCost.equals(new Decimal(0))).toBe(true);
+    });
+  });
+
+  describe("fuel upgrade add-on", () => {
+    it("should add fuel upgrade cost when all conditions are met", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "DAY",
+        legs: createLegs(2), // <= 2 legs
+        car: { ...mockCar, pricingIncludesFuel: false },
+        includeSecurityDetail: false,
+        requiresFullTank: true,
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      expect(result.fuelUpgradeCost.equals(new Decimal(10000))).toBe(true);
+    });
+
+    it("should NOT add fuel upgrade when car pricing includes fuel", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "DAY",
+        legs: createLegs(2),
+        car: { ...mockCar, pricingIncludesFuel: true },
+        includeSecurityDetail: false,
+        requiresFullTank: true,
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      expect(result.fuelUpgradeCost.equals(new Decimal(0))).toBe(true);
+    });
+
+    it("should NOT add fuel upgrade when customer does not request full tank", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "DAY",
+        legs: createLegs(2),
+        car: mockCar,
+        includeSecurityDetail: false,
+        requiresFullTank: false,
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      expect(result.fuelUpgradeCost.equals(new Decimal(0))).toBe(true);
+    });
+
+    it("should NOT add fuel upgrade when booking has more than 2 legs", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "DAY",
+        legs: createLegs(3), // > 2 legs
+        car: mockCar,
+        includeSecurityDetail: false,
+        requiresFullTank: true,
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      expect(result.fuelUpgradeCost.equals(new Decimal(0))).toBe(true);
+    });
+
+    it("should NOT add fuel upgrade when fuelUpgradeRate is null", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "DAY",
+        legs: createLegs(2),
+        car: { ...mockCar, fuelUpgradeRate: null },
+        includeSecurityDetail: false,
+        requiresFullTank: true,
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      expect(result.fuelUpgradeCost.equals(new Decimal(0))).toBe(true);
+    });
+
+    it("should NOT add fuel upgrade when fuelUpgradeRate is 0", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "DAY",
+        legs: createLegs(2),
+        car: { ...mockCar, fuelUpgradeRate: 0 },
+        includeSecurityDetail: false,
+        requiresFullTank: true,
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      expect(result.fuelUpgradeCost.equals(new Decimal(0))).toBe(true);
+    });
+  });
+
+  describe("platform fee calculation", () => {
+    it("should calculate platform fee on netTotal + fuelUpgrade (excluding security)", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "DAY",
+        legs: createLegs(2),
+        car: mockCar,
+        includeSecurityDetail: true, // Should NOT affect platform fee base
+        requiresFullTank: true, // Should affect platform fee base
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      // Net: 100,000, Fuel: 10,000, Security: 10,000
+      // Platform fee base: 100,000 + 10,000 = 110,000 (excludes security)
+      // Platform fee: 110,000 × 10% = 11,000
+      expect(result.platformFeeBase.equals(new Decimal(110000))).toBe(true);
+      expect(result.platformCustomerServiceFeeAmount.equals(new Decimal(11000))).toBe(true);
+    });
+
+    it("should store platform fee rate percentage", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "DAY",
+        legs: createLegs(1),
+        car: mockCar,
+        includeSecurityDetail: false,
+        requiresFullTank: false,
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      expect(result.platformCustomerServiceFeeRatePercent.equals(new Decimal(10))).toBe(true);
+    });
+  });
+
+  describe("subtotal before discounts", () => {
+    it("should calculate subtotal as netTotalWithAddons + platformFee", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "DAY",
+        legs: createLegs(2),
+        car: mockCar,
+        includeSecurityDetail: true,
+        requiresFullTank: true,
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      // Net: 100,000
+      // Security: 10,000
+      // Fuel: 10,000
+      // NetWithAddons: 120,000
+      // Platform fee base: 110,000 (net + fuel)
+      // Platform fee: 11,000
+      // Subtotal: 120,000 + 11,000 = 131,000
+      expect(result.subtotalBeforeDiscounts.equals(new Decimal(131000))).toBe(true);
+    });
+  });
+
+  describe("referral discount", () => {
+    it("should apply referral discount", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "DAY",
+        legs: createLegs(1),
+        car: mockCar,
+        includeSecurityDetail: false,
+        requiresFullTank: false,
+        referralDiscountAmount: new Decimal(5000),
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      expect(result.referralDiscountAmount.equals(new Decimal(5000))).toBe(true);
+    });
+
+    it("should cap referral discount at subtotal (cannot go negative)", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "AIRPORT_PICKUP",
+        legs: createLegs(1),
+        car: mockCar,
+        includeSecurityDetail: false,
+        requiresFullTank: false,
+        referralDiscountAmount: new Decimal(999999), // Way more than subtotal
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      // Net: 25,000, Platform fee: 2,500, Subtotal: 27,500
+      // Referral capped at 27,500
+      expect(result.referralDiscountAmount.equals(result.subtotalBeforeDiscounts)).toBe(true);
+      expect(result.subtotalAfterDiscounts.equals(new Decimal(0))).toBe(true);
+    });
+
+    it("should handle zero referral discount", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "DAY",
+        legs: createLegs(1),
+        car: mockCar,
+        includeSecurityDetail: false,
+        requiresFullTank: false,
+        referralDiscountAmount: new Decimal(0),
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      expect(result.referralDiscountAmount.equals(new Decimal(0))).toBe(true);
+    });
+
+    it("should handle undefined referral discount", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "DAY",
+        legs: createLegs(1),
+        car: mockCar,
+        includeSecurityDetail: false,
+        requiresFullTank: false,
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      expect(result.referralDiscountAmount.equals(new Decimal(0))).toBe(true);
+    });
+  });
+
+  describe("credits usage", () => {
+    it("should apply credits when available", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "DAY",
+        legs: createLegs(1),
+        car: mockCar,
+        includeSecurityDetail: false,
+        requiresFullTank: false,
+        userCreditsBalance: new Decimal(10000),
+        creditsToUse: new Decimal(5000),
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      expect(result.creditsUsed.equals(new Decimal(5000))).toBe(true);
+    });
+
+    it("should cap credits at user balance", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "DAY",
+        legs: createLegs(1),
+        car: mockCar,
+        includeSecurityDetail: false,
+        requiresFullTank: false,
+        userCreditsBalance: new Decimal(3000), // Only 3,000 available
+        creditsToUse: new Decimal(5000), // Trying to use 5,000
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      expect(result.creditsUsed.equals(new Decimal(3000))).toBe(true); // Capped at balance
+    });
+
+    it("should cap credits at remaining subtotal after referral discount", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "AIRPORT_PICKUP",
+        legs: createLegs(1),
+        car: mockCar,
+        includeSecurityDetail: false,
+        requiresFullTank: false,
+        referralDiscountAmount: new Decimal(20000), // Leaves 7,500 remaining
+        userCreditsBalance: new Decimal(50000),
+        creditsToUse: new Decimal(50000), // Trying to use all
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      // Net: 25,000, Platform fee: 2,500, Subtotal: 27,500
+      // After referral: 27,500 - 20,000 = 7,500
+      // Credits capped at 7,500
+      expect(result.creditsUsed.equals(new Decimal(7500))).toBe(true);
+    });
+
+    it("should handle zero credits", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "DAY",
+        legs: createLegs(1),
+        car: mockCar,
+        includeSecurityDetail: false,
+        requiresFullTank: false,
+        userCreditsBalance: new Decimal(10000),
+        creditsToUse: new Decimal(0),
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      expect(result.creditsUsed.equals(new Decimal(0))).toBe(true);
+    });
+  });
+
+  describe("VAT calculation", () => {
+    it("should calculate VAT on subtotal after discounts", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "DAY",
+        legs: createLegs(1),
+        car: mockCar,
+        includeSecurityDetail: false,
+        requiresFullTank: false,
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      // Net: 50,000, Platform fee: 5,000, Subtotal: 55,000
+      // No discounts, so subtotal after = 55,000
+      // VAT: 55,000 × 7.5% = 4,125
+      expect(result.vatRatePercent.equals(new Decimal(7.5))).toBe(true);
+      expect(result.vatAmount.equals(new Decimal(4125))).toBe(true);
+    });
+
+    it("should calculate VAT after applying discounts", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "DAY",
+        legs: createLegs(1),
+        car: mockCar,
+        includeSecurityDetail: false,
+        requiresFullTank: false,
+        referralDiscountAmount: new Decimal(5000),
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      // Net: 50,000, Platform fee: 5,000, Subtotal: 55,000
+      // After referral: 55,000 - 5,000 = 50,000
+      // VAT: 50,000 × 7.5% = 3,750
+      expect(result.vatAmount.equals(new Decimal(3750))).toBe(true);
+    });
+  });
+
+  describe("total amount", () => {
+    it("should calculate total as subtotalAfterDiscounts + VAT", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "DAY",
+        legs: createLegs(1),
+        car: mockCar,
+        includeSecurityDetail: false,
+        requiresFullTank: false,
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      // Subtotal: 55,000, VAT: 4,125
+      // Total: 55,000 + 4,125 = 59,125
+      expect(result.totalAmount.equals(new Decimal(59125))).toBe(true);
+    });
+  });
+
+  describe("fleet owner commission and payout", () => {
+    it("should calculate fleet owner commission on platformFeeBase", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "DAY",
+        legs: createLegs(2),
+        car: mockCar,
+        includeSecurityDetail: true,
+        requiresFullTank: true,
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      // Platform fee base: 110,000 (net + fuel, excludes security)
+      // Commission: 110,000 × 5% = 5,500
+      expect(result.platformFleetOwnerCommissionRatePercent.equals(new Decimal(5))).toBe(true);
+      expect(result.platformFleetOwnerCommissionAmount.equals(new Decimal(5500))).toBe(true);
+    });
+
+    it("should calculate fleet owner payout (netTotal + security - commission)", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "DAY",
+        legs: createLegs(2),
+        car: mockCar,
+        includeSecurityDetail: true,
+        requiresFullTank: true,
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      // Net: 100,000
+      // Security: 10,000
+      // Commission: 5,500
+      // Payout: 100,000 + 10,000 - 5,500 = 104,500
+      expect(result.fleetOwnerPayoutAmountNet.equals(new Decimal(104500))).toBe(true);
+    });
+
+    it("should NOT include fuel upgrade in fleet owner payout", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "DAY",
+        legs: createLegs(2),
+        car: mockCar,
+        includeSecurityDetail: false,
+        requiresFullTank: true, // Fuel upgrade applies
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      // Net: 100,000
+      // Fuel: 10,000 (NOT included in payout)
+      // Commission: 110,000 × 5% = 5,500
+      // Payout: 100,000 - 5,500 = 94,500 (fuel NOT included)
+      expect(result.fleetOwnerPayoutAmountNet.equals(new Decimal(94500))).toBe(true);
+    });
+  });
+
+  describe("complete calculation scenario", () => {
+    it("should correctly calculate a complete booking with all options", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "DAY",
+        legs: createLegs(2),
+        car: mockCar,
+        includeSecurityDetail: true,
+        requiresFullTank: true,
+        referralDiscountAmount: new Decimal(10000),
+        userCreditsBalance: new Decimal(20000),
+        creditsToUse: new Decimal(5000),
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      // Step 1: Leg pricing
+      // Net: 50,000 × 2 = 100,000
+      expect(result.netTotal.equals(new Decimal(100000))).toBe(true);
+
+      // Step 2: Add-ons
+      // Security: 5,000 × 2 = 10,000
+      // Fuel: 10,000
+      // NetWithAddons: 100,000 + 10,000 + 10,000 = 120,000
+      expect(result.securityDetailCost.equals(new Decimal(10000))).toBe(true);
+      expect(result.fuelUpgradeCost.equals(new Decimal(10000))).toBe(true);
+      expect(result.netTotalWithAddons.equals(new Decimal(120000))).toBe(true);
+
+      // Step 3: Platform fee
+      // Base: 100,000 + 10,000 = 110,000 (excludes security)
+      // Fee: 110,000 × 10% = 11,000
+      expect(result.platformFeeBase.equals(new Decimal(110000))).toBe(true);
+      expect(result.platformCustomerServiceFeeAmount.equals(new Decimal(11000))).toBe(true);
+
+      // Step 4: Subtotal before discounts
+      // 120,000 + 11,000 = 131,000
+      expect(result.subtotalBeforeDiscounts.equals(new Decimal(131000))).toBe(true);
+
+      // Step 5: Apply discounts
+      // Referral: 10,000
+      // After referral: 131,000 - 10,000 = 121,000
+      // Credits: 5,000
+      // After credits: 121,000 - 5,000 = 116,000
+      expect(result.referralDiscountAmount.equals(new Decimal(10000))).toBe(true);
+      expect(result.creditsUsed.equals(new Decimal(5000))).toBe(true);
+      expect(result.subtotalAfterDiscounts.equals(new Decimal(116000))).toBe(true);
+
+      // Step 6: VAT
+      // 116,000 × 7.5% = 8,700
+      expect(result.vatAmount.equals(new Decimal(8700))).toBe(true);
+
+      // Step 7: Total
+      // 116,000 + 8,700 = 124,700
+      expect(result.totalAmount.equals(new Decimal(124700))).toBe(true);
+
+      // Step 8: Fleet owner
+      // Commission: 110,000 × 5% = 5,500
+      // Payout: 100,000 + 10,000 - 5,500 = 104,500
+      expect(result.platformFleetOwnerCommissionAmount.equals(new Decimal(5500))).toBe(true);
+      expect(result.fleetOwnerPayoutAmountNet.equals(new Decimal(104500))).toBe(true);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle single leg booking", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "AIRPORT_PICKUP",
+        legs: createLegs(1),
+        car: mockCar,
+        includeSecurityDetail: false,
+        requiresFullTank: false,
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      expect(result.numberOfLegs).toBe(1);
+      expect(result.legPrices).toHaveLength(1);
+    });
+
+    it("should handle booking with all discounts exceeding subtotal", async () => {
+      const input: BookingCalculationInput = {
+        bookingType: "AIRPORT_PICKUP",
+        legs: createLegs(1),
+        car: mockCar,
+        includeSecurityDetail: false,
+        requiresFullTank: false,
+        referralDiscountAmount: new Decimal(999999),
+        userCreditsBalance: new Decimal(999999),
+        creditsToUse: new Decimal(999999),
+      };
+
+      const result = await service.calculateBookingCost(input);
+
+      // Subtotal should be 0, not negative
+      expect(result.subtotalAfterDiscounts.gte(new Decimal(0))).toBe(true);
+      // VAT on 0 should be 0
+      expect(result.vatAmount.equals(new Decimal(0))).toBe(true);
+      // Total should be 0
+      expect(result.totalAmount.equals(new Decimal(0))).toBe(true);
+    });
+  });
+});

--- a/src/modules/booking/booking-calculation.service.ts
+++ b/src/modules/booking/booking-calculation.service.ts
@@ -9,9 +9,7 @@ import type {
   LegPrice,
 } from "./booking-calculation.interface";
 import type { GeneratedLeg } from "./booking.interface";
-
-/** Maximum number of legs eligible for fuel upgrade */
-const MAX_LEGS_FOR_FUEL_UPGRADE = 2;
+import { MAX_LEGS_FOR_FUEL_UPGRADE } from "./booking.const";
 
 /**
  * Service for calculating booking financials.

--- a/src/modules/booking/booking-calculation.service.ts
+++ b/src/modules/booking/booking-calculation.service.ts
@@ -196,7 +196,7 @@ export class BookingCalculationService {
    * Fuel upgrade applies only if:
    * 1. Car pricing doesn't include fuel
    * 2. Customer requests full tank
-   * 3. Booking has 2 or fewer legs
+   * 3. Booking has at least 1 leg and no more than 2 legs
    *
    * @param car - Car pricing information
    * @param requiresFullTank - Whether customer requests full tank
@@ -211,6 +211,7 @@ export class BookingCalculationService {
     const isEligible =
       !car.pricingIncludesFuel &&
       requiresFullTank &&
+      numberOfLegs > 0 &&
       numberOfLegs <= MAX_LEGS_FOR_FUEL_UPGRADE &&
       car.fuelUpgradeRate !== null &&
       car.fuelUpgradeRate > 0;
@@ -254,7 +255,8 @@ export class BookingCalculationService {
     userBalance: Decimal,
     remainingSubtotal: Decimal,
   ): Decimal {
-    if (creditsToUse.lte(0)) {
+    // Early return if no credits requested or no balance available
+    if (creditsToUse.lte(0) || userBalance.lte(0)) {
       return new Decimal(0);
     }
 

--- a/src/modules/booking/booking-calculation.service.ts
+++ b/src/modules/booking/booking-calculation.service.ts
@@ -1,0 +1,267 @@
+import { Injectable } from "@nestjs/common";
+import type { BookingType } from "@prisma/client";
+import { Decimal } from "@prisma/client/runtime/library";
+import { RatesService } from "../rates/rates.service";
+import type {
+  BookingCalculationInput,
+  BookingFinancials,
+  CarPricing,
+  LegPrice,
+} from "./booking-calculation.interface";
+import type { GeneratedLeg } from "./booking.interface";
+
+/** Maximum number of legs eligible for fuel upgrade */
+const MAX_LEGS_FOR_FUEL_UPGRADE = 2;
+
+/**
+ * Service for calculating booking financials.
+ *
+ * Handles the complete financial breakdown including:
+ * - Leg pricing based on booking type
+ * - Add-ons (security detail, fuel upgrade)
+ * - Platform fees
+ * - Discounts (referral, credits)
+ * - VAT
+ * - Fleet owner commission and payout
+ */
+@Injectable()
+export class BookingCalculationService {
+  constructor(private readonly ratesService: RatesService) {}
+
+  /**
+   * Calculate complete booking cost breakdown.
+   *
+   * @param input - Booking calculation parameters
+   * @returns Complete financial breakdown
+   */
+  async calculateBookingCost(input: BookingCalculationInput): Promise<BookingFinancials> {
+    const {
+      bookingType,
+      legs,
+      car,
+      includeSecurityDetail,
+      requiresFullTank,
+      userCreditsBalance,
+      creditsToUse,
+      referralDiscountAmount,
+    } = input;
+
+    // Get current platform rates
+    const rates = await this.ratesService.getRates();
+
+    // 1. Calculate leg prices
+    const legPrices = this.calculateLegPrices(legs, bookingType, car);
+    const numberOfLegs = legs.length;
+    const netTotal = legPrices.reduce((sum, leg) => sum.add(leg.price), new Decimal(0));
+
+    // 2. Calculate add-ons
+    const securityDetailCost = includeSecurityDetail
+      ? rates.securityDetailRate.mul(numberOfLegs)
+      : new Decimal(0);
+
+    const fuelUpgradeCost = this.calculateFuelUpgradeCost(car, requiresFullTank, numberOfLegs);
+
+    const netTotalWithAddons = netTotal.add(securityDetailCost).add(fuelUpgradeCost);
+
+    // 3. Calculate platform fee (on netTotal + fuelUpgrade, excludes security)
+    const platformFeeBase = netTotal.add(fuelUpgradeCost);
+    const platformCustomerServiceFeeRatePercent = rates.platformCustomerServiceFeeRatePercent;
+    const platformCustomerServiceFeeAmount = platformFeeBase
+      .mul(platformCustomerServiceFeeRatePercent)
+      .div(100);
+
+    // 4. Calculate subtotal before discounts
+    const subtotalBeforeDiscounts = netTotalWithAddons.add(platformCustomerServiceFeeAmount);
+
+    // 5. Apply referral discount (capped at subtotal)
+    const effectiveReferralDiscount = this.applyDiscount(
+      referralDiscountAmount ?? new Decimal(0),
+      subtotalBeforeDiscounts,
+    );
+
+    const afterReferral = subtotalBeforeDiscounts.sub(effectiveReferralDiscount);
+
+    // 6. Apply credits (capped at remaining subtotal and user's balance)
+    const effectiveCredits = this.calculateEffectiveCredits(
+      creditsToUse ?? new Decimal(0),
+      userCreditsBalance ?? new Decimal(0),
+      afterReferral,
+    );
+
+    const subtotalAfterDiscounts = afterReferral.sub(effectiveCredits);
+
+    // 7. Calculate VAT on subtotal after discounts
+    const vatRatePercent = rates.vatRatePercent;
+    const vatAmount = subtotalAfterDiscounts.mul(vatRatePercent).div(100);
+
+    // 8. Calculate total customer pays
+    const totalAmount = subtotalAfterDiscounts.add(vatAmount);
+
+    // 9. Calculate fleet owner commission and payout
+    const platformFleetOwnerCommissionRatePercent = rates.platformFleetOwnerCommissionRatePercent;
+    const platformFleetOwnerCommissionAmount = platformFeeBase
+      .mul(platformFleetOwnerCommissionRatePercent)
+      .div(100);
+
+    // Fleet owner gets: netTotal + securityDetail - commission
+    // (fuel upgrade goes to refueling, not fleet owner)
+    const fleetOwnerPayoutAmountNet = netTotal
+      .add(securityDetailCost)
+      .sub(platformFleetOwnerCommissionAmount);
+
+    return {
+      // Leg pricing
+      legPrices,
+      numberOfLegs,
+      netTotal,
+
+      // Add-ons
+      securityDetailCost,
+      fuelUpgradeCost,
+      netTotalWithAddons,
+
+      // Platform fee
+      platformFeeBase,
+      platformCustomerServiceFeeRatePercent,
+      platformCustomerServiceFeeAmount,
+
+      // Subtotals
+      subtotalBeforeDiscounts,
+      referralDiscountAmount: effectiveReferralDiscount,
+      creditsUsed: effectiveCredits,
+      subtotalAfterDiscounts,
+
+      // VAT
+      vatRatePercent,
+      vatAmount,
+
+      // Total
+      totalAmount,
+
+      // Fleet owner
+      platformFleetOwnerCommissionRatePercent,
+      platformFleetOwnerCommissionAmount,
+      fleetOwnerPayoutAmountNet,
+    };
+  }
+
+  /**
+   * Calculate price for each leg based on booking type.
+   *
+   * @param legs - Generated booking legs
+   * @param bookingType - Type of booking (DAY, NIGHT, FULL_DAY, AIRPORT_PICKUP)
+   * @param car - Car pricing information
+   * @returns Array of leg prices
+   */
+  private calculateLegPrices(
+    legs: GeneratedLeg[],
+    bookingType: BookingType,
+    car: CarPricing,
+  ): LegPrice[] {
+    const ratePerLeg = this.getRateForBookingType(bookingType, car);
+
+    return legs.map((leg) => ({
+      legDate: leg.legDate,
+      price: new Decimal(ratePerLeg),
+    }));
+  }
+
+  /**
+   * Get the appropriate rate for a booking type.
+   *
+   * @param bookingType - Type of booking
+   * @param car - Car pricing information
+   * @returns Rate per leg as a number
+   */
+  private getRateForBookingType(bookingType: BookingType, car: CarPricing): number {
+    switch (bookingType) {
+      case "DAY":
+        return car.dayRate;
+      case "NIGHT":
+        return car.nightRate;
+      case "FULL_DAY":
+        return car.fullDayRate;
+      case "AIRPORT_PICKUP":
+        return car.airportPickupRate;
+      default: {
+        const exhaustiveCheck: never = bookingType;
+        throw new Error(`Unknown booking type: ${exhaustiveCheck}`);
+      }
+    }
+  }
+
+  /**
+   * Calculate fuel upgrade cost.
+   *
+   * Fuel upgrade applies only if:
+   * 1. Car pricing doesn't include fuel
+   * 2. Customer requests full tank
+   * 3. Booking has 2 or fewer legs
+   *
+   * @param car - Car pricing information
+   * @param requiresFullTank - Whether customer requests full tank
+   * @param numberOfLegs - Number of legs in booking
+   * @returns Fuel upgrade cost (0 if not applicable)
+   */
+  private calculateFuelUpgradeCost(
+    car: CarPricing,
+    requiresFullTank: boolean,
+    numberOfLegs: number,
+  ): Decimal {
+    const isEligible =
+      !car.pricingIncludesFuel &&
+      requiresFullTank &&
+      numberOfLegs <= MAX_LEGS_FOR_FUEL_UPGRADE &&
+      car.fuelUpgradeRate !== null &&
+      car.fuelUpgradeRate > 0;
+
+    if (!isEligible) {
+      return new Decimal(0);
+    }
+
+    return new Decimal(car.fuelUpgradeRate);
+  }
+
+  /**
+   * Apply a discount capped at the available amount.
+   *
+   * @param discount - Requested discount amount
+   * @param availableAmount - Maximum amount that can be discounted
+   * @returns Effective discount (min of discount and available)
+   */
+  private applyDiscount(discount: Decimal, availableAmount: Decimal): Decimal {
+    if (discount.lte(0)) {
+      return new Decimal(0);
+    }
+    return Decimal.min(discount, availableAmount);
+  }
+
+  /**
+   * Calculate effective credits to use.
+   *
+   * Credits are capped at:
+   * 1. The requested amount
+   * 2. The user's available balance
+   * 3. The remaining subtotal (can't go negative)
+   *
+   * @param creditsToUse - Requested credits to use
+   * @param userBalance - User's available credit balance
+   * @param remainingSubtotal - Remaining amount after other discounts
+   * @returns Effective credits to apply
+   */
+  private calculateEffectiveCredits(
+    creditsToUse: Decimal,
+    userBalance: Decimal,
+    remainingSubtotal: Decimal,
+  ): Decimal {
+    if (creditsToUse.lte(0)) {
+      return new Decimal(0);
+    }
+
+    // Cap at user's balance
+    const cappedAtBalance = Decimal.min(creditsToUse, userBalance);
+
+    // Cap at remaining subtotal (can't go negative)
+    return Decimal.min(cappedAtBalance, remainingSubtotal);
+  }
+}

--- a/src/modules/booking/booking-calculation.service.ts
+++ b/src/modules/booking/booking-calculation.service.ts
@@ -96,13 +96,16 @@ export class BookingCalculationService {
     const totalAmount = subtotalAfterDiscounts.add(vatAmount);
 
     // 9. Calculate fleet owner commission and payout
+    // Commission is calculated on netTotal only (the rental earnings the fleet owner receives).
+    // Fuel upgrade is excluded because it goes to refueling, not the fleet owner.
+    // Security detail is excluded because it's a pass-through cost.
     const platformFleetOwnerCommissionRatePercent = rates.platformFleetOwnerCommissionRatePercent;
-    const platformFleetOwnerCommissionAmount = platformFeeBase
+    const platformFleetOwnerCommissionAmount = netTotal
       .mul(platformFleetOwnerCommissionRatePercent)
       .div(100);
 
     // Fleet owner gets: netTotal + securityDetail - commission
-    // (fuel upgrade goes to refueling, not fleet owner)
+    // (fuel upgrade goes to refueling, not fleet owner; security is pass-through)
     const fleetOwnerPayoutAmountNet = netTotal
       .add(securityDetailCost)
       .sub(platformFleetOwnerCommissionAmount);

--- a/src/modules/booking/booking.const.ts
+++ b/src/modules/booking/booking.const.ts
@@ -33,3 +33,6 @@ export const NIGHT_END_HOUR = 5; // 5 AM
 export const FULL_DAY_DURATION_HOURS = 24;
 export const AIRPORT_PICKUP_BUFFER_MINUTES = 40;
 export const AIRPORT_PICKUP_DRIVE_TIME_MULTIPLIER = 1.2;
+
+/** Maximum number of legs eligible for fuel upgrade */
+export const MAX_LEGS_FOR_FUEL_UPGRADE = 2;

--- a/src/modules/booking/booking.module.ts
+++ b/src/modules/booking/booking.module.ts
@@ -1,12 +1,24 @@
 import { Module } from "@nestjs/common";
 import { NotificationModule } from "../notification/notification.module";
+import { RatesModule } from "../rates/rates.module";
+import { BookingCalculationService } from "./booking-calculation.service";
 import { BookingConfirmationService } from "./booking-confirmation.service";
 import { BookingLegService } from "./booking-leg.service";
 import { BookingValidationService } from "./booking-validation.service";
 
 @Module({
-  imports: [NotificationModule],
-  providers: [BookingConfirmationService, BookingLegService, BookingValidationService],
-  exports: [BookingConfirmationService, BookingLegService, BookingValidationService],
+  imports: [NotificationModule, RatesModule],
+  providers: [
+    BookingConfirmationService,
+    BookingLegService,
+    BookingValidationService,
+    BookingCalculationService,
+  ],
+  exports: [
+    BookingConfirmationService,
+    BookingLegService,
+    BookingValidationService,
+    BookingCalculationService,
+  ],
 })
 export class BookingModule {}


### PR DESCRIPTION
- Add BookingCalculationInput and BookingFinancials interfaces
- Add CarPricing and LegPrice interfaces for type safety
- Implement calculateBookingCost method with full financial breakdown:
  - Leg pricing based on booking type (DAY, NIGHT, FULL_DAY, AIRPORT_PICKUP)
  - Security detail add-on (rate × number of legs)
  - Fuel upgrade add-on (conditional on fuel policy and leg count)
  - Platform customer service fee (on net + fuel, excludes security)
  - Referral discount (capped at subtotal)
  - Credits usage (capped at balance and remaining subtotal)
  - VAT calculation on subtotal after discounts
  - Fleet owner commission and payout calculation
- Add comprehensive unit tests (33 test cases)
- Register service in BookingModule with RatesModule dependency

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements centralized booking cost calculation with platform rate integration and exposes results for both customer pricing and fleet payouts.
> 
> - New `BookingCalculationService` computes leg pricing by booking type, add-ons (security per leg, conditional fuel upgrade capped by `MAX_LEGS_FOR_FUEL_UPGRADE`), platform fee on `netTotal + fuelUpgrade`, discounts (referral capped at subtotal, credits capped by balance and remaining subtotal), VAT on post-discount subtotal, and fleet owner commission/payout (commission on `netTotal` only)
> - Added type-safe interfaces: `BookingCalculationInput`, `BookingFinancials`, `CarPricing`, `LegPrice`
> - Introduced `MAX_LEGS_FOR_FUEL_UPGRADE` in `booking.const.ts`
> - Registered service and `RatesModule` dependency in `BookingModule`
> - Comprehensive unit tests in `booking-calculation.service.spec.ts` covering core flows and edge cases
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63f358582939b00814e1e988c48b17d754e6ae97. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->