### PR TITLE
feat(booking): add BookingController with optional auth guard

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,7 +11,7 @@ sonar.exclusions=**/node_modules/**,**/dist/**,**/coverage/**,src/config/**,src/
 sonar.tests=src
 sonar.test.inclusions=**/*.spec.ts,**/*.test.ts
 # Coverage settings
-sonar.coverage.exclusions=**/*.spec.ts,**/*.test.ts,**/*.module.ts,**/main.ts,**/*.interface.ts,**/*.dto.ts,**/types.ts,**/*.fixtures.ts
+sonar.coverage.exclusions=**/*.spec.ts,**/*.test.ts,**/*.module.ts,**/main.ts,**/*.interface.ts,**/*.dto.ts,**/types.ts,**/*.fixtures.ts,**/*.decorators.ts
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
 
 # Language

--- a/src/modules/auth/auth.config.ts
+++ b/src/modules/auth/auth.config.ts
@@ -309,11 +309,15 @@ export function createAuth(options: AuthConfigOptions) {
       },
     },
     advanced: {
-      cookiePrefix: "", // Web app handles __Host- prefix
+      // Use __Host- prefix in production for enhanced security (prevents subdomain attacks)
+      // In development, use no prefix since __Host- requires HTTPS
+      cookiePrefix: secureCookies ? "__Host-" : "",
       defaultCookieAttributes: {
         httpOnly: true,
         secure: secureCookies,
         sameSite: "lax",
+        // __Host- cookies require path to be "/"
+        ...(secureCookies && { path: "/" }),
       },
     },
   });

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -4,13 +4,14 @@ import { NotificationModule } from "../notification/notification.module";
 import { AuthController } from "./auth.controller";
 import { AuthService } from "./auth.service";
 import { AuthEmailService } from "./auth-email.service";
+import { OptionalSessionGuard } from "./guards/optional-session.guard";
 import { RoleGuard } from "./guards/role.guard";
 import { SessionGuard } from "./guards/session.guard";
 
 @Module({
   imports: [DatabaseModule, NotificationModule],
   controllers: [AuthController],
-  providers: [AuthService, AuthEmailService, SessionGuard, RoleGuard],
-  exports: [AuthService, SessionGuard, RoleGuard],
+  providers: [AuthService, AuthEmailService, SessionGuard, OptionalSessionGuard, RoleGuard],
+  exports: [AuthService, SessionGuard, OptionalSessionGuard, RoleGuard],
 })
 export class AuthModule {}

--- a/src/modules/auth/guards/optional-session.guard.spec.ts
+++ b/src/modules/auth/guards/optional-session.guard.spec.ts
@@ -1,0 +1,147 @@
+import { ExecutionContext } from "@nestjs/common";
+import { Test, TestingModule } from "@nestjs/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthService } from "../auth.service";
+import type { RoleName } from "../auth.types";
+import { OptionalSessionGuard } from "./optional-session.guard";
+import { AUTH_SESSION_KEY } from "./session.guard";
+
+describe("OptionalSessionGuard", () => {
+  let guard: OptionalSessionGuard;
+  let mockGetSession: ReturnType<typeof vi.fn>;
+  let mockGetUserRoles: ReturnType<typeof vi.fn>;
+
+  const mockSession = {
+    user: {
+      id: "user-123",
+      email: "test@example.com",
+      name: "Test User",
+      emailVerified: true,
+      image: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    session: {
+      id: "session-123",
+      userId: "user-123",
+      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      token: "token-123",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ipAddress: "127.0.0.1",
+      userAgent: "test-agent",
+    },
+  };
+
+  const mockRoles: RoleName[] = ["user"];
+
+  const createMockAuthService = (isInitialized: boolean) => {
+    mockGetSession = vi.fn();
+    mockGetUserRoles = vi.fn().mockResolvedValue(mockRoles);
+    return {
+      isInitialized,
+      auth: {
+        api: {
+          getSession: mockGetSession,
+        },
+      },
+      getUserRoles: mockGetUserRoles,
+    };
+  };
+
+  const createMockExecutionContext = (headers: Record<string, string> = {}) => {
+    const mockRequest = { headers, [AUTH_SESSION_KEY]: undefined };
+    return {
+      switchToHttp: () => ({
+        getRequest: () => mockRequest,
+      }),
+      getRequest: () => mockRequest,
+    } as unknown as ExecutionContext & { getRequest: () => typeof mockRequest };
+  };
+
+  const setupTestModule = async (isInitialized: boolean) => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OptionalSessionGuard,
+        { provide: AuthService, useValue: createMockAuthService(isInitialized) },
+      ],
+    }).compile();
+
+    guard = module.get<OptionalSessionGuard>(OptionalSessionGuard);
+  };
+
+  describe("when auth is initialized", () => {
+    beforeEach(async () => {
+      await setupTestModule(true);
+    });
+
+    it("should be defined", () => {
+      expect(guard).toBeDefined();
+    });
+
+    it("should return true and attach session with roles when valid session exists", async () => {
+      mockGetSession.mockResolvedValueOnce(mockSession);
+      const context = createMockExecutionContext({ cookie: "session=token-123" });
+
+      const result = await guard.canActivate(context);
+
+      expect(result).toBe(true);
+      expect(mockGetUserRoles).toHaveBeenCalledWith("user-123");
+      expect(context.getRequest()[AUTH_SESSION_KEY]).toEqual({
+        user: { ...mockSession.user, roles: mockRoles },
+        session: mockSession.session,
+      });
+    });
+
+    it("should return true without session when no session found (guest request)", async () => {
+      mockGetSession.mockResolvedValueOnce(null);
+      const context = createMockExecutionContext();
+
+      const result = await guard.canActivate(context);
+
+      expect(result).toBe(true);
+      expect(mockGetUserRoles).not.toHaveBeenCalled();
+      expect(context.getRequest()[AUTH_SESSION_KEY]).toBeUndefined();
+    });
+
+    it("should return true when session validation throws (treat as guest)", async () => {
+      mockGetSession.mockRejectedValueOnce(new Error("Session expired"));
+      const context = createMockExecutionContext({ cookie: "session=expired" });
+
+      const result = await guard.canActivate(context);
+
+      expect(result).toBe(true);
+      expect(context.getRequest()[AUTH_SESSION_KEY]).toBeUndefined();
+    });
+
+    it("should pass headers to getSession", async () => {
+      mockGetSession.mockResolvedValueOnce(mockSession);
+      const context = createMockExecutionContext({
+        cookie: "session=token-123",
+        authorization: "Bearer some-token",
+      });
+
+      await guard.canActivate(context);
+
+      expect(mockGetSession).toHaveBeenCalledWith({
+        headers: expect.any(Headers),
+      });
+    });
+  });
+
+  describe("when auth is not initialized", () => {
+    beforeEach(async () => {
+      await setupTestModule(false);
+    });
+
+    it("should return true and allow request through (guest mode)", async () => {
+      const context = createMockExecutionContext();
+
+      const result = await guard.canActivate(context);
+
+      expect(result).toBe(true);
+      expect(mockGetSession).not.toHaveBeenCalled();
+      expect(context.getRequest()[AUTH_SESSION_KEY]).toBeUndefined();
+    });
+  });
+});

--- a/src/modules/auth/guards/optional-session.guard.spec.ts
+++ b/src/modules/auth/guards/optional-session.guard.spec.ts
@@ -1,4 +1,4 @@
-import { ExecutionContext } from "@nestjs/common";
+import { ExecutionContext, UnauthorizedException } from "@nestjs/common";
 import { Test, TestingModule } from "@nestjs/testing";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AuthService } from "../auth.service";
@@ -79,52 +79,141 @@ describe("OptionalSessionGuard", () => {
       expect(guard).toBeDefined();
     });
 
-    it("should return true and attach session with roles when valid session exists", async () => {
-      mockGetSession.mockResolvedValueOnce(mockSession);
-      const context = createMockExecutionContext({ cookie: "session=token-123" });
+    describe("without auth credentials (intentional guest)", () => {
+      it("should allow through as guest when no credentials provided", async () => {
+        const context = createMockExecutionContext(); // No headers
 
-      const result = await guard.canActivate(context);
+        const result = await guard.canActivate(context);
 
-      expect(result).toBe(true);
-      expect(mockGetUserRoles).toHaveBeenCalledWith("user-123");
-      expect(context.getRequest()[AUTH_SESSION_KEY]).toEqual({
-        user: { ...mockSession.user, roles: mockRoles },
-        session: mockSession.session,
+        expect(result).toBe(true);
+        expect(mockGetSession).not.toHaveBeenCalled(); // No need to call getSession
+        expect(mockGetUserRoles).not.toHaveBeenCalled();
+        expect(context.getRequest()[AUTH_SESSION_KEY]).toBeUndefined();
+      });
+
+      it("should allow through as guest when only non-auth headers provided", async () => {
+        const context = createMockExecutionContext({
+          "content-type": "application/json",
+          "accept": "application/json",
+        });
+
+        const result = await guard.canActivate(context);
+
+        expect(result).toBe(true);
+        expect(mockGetSession).not.toHaveBeenCalled();
+        expect(context.getRequest()[AUTH_SESSION_KEY]).toBeUndefined();
       });
     });
 
-    it("should return true without session when no session found (guest request)", async () => {
-      mockGetSession.mockResolvedValueOnce(null);
-      const context = createMockExecutionContext();
+    describe("with auth credentials", () => {
+      it("should attach session with roles when valid session exists (cookie auth - dev)", async () => {
+        mockGetSession.mockResolvedValueOnce(mockSession);
+        const context = createMockExecutionContext({
+          cookie: "session_token=token-123",
+        });
 
-      const result = await guard.canActivate(context);
+        const result = await guard.canActivate(context);
 
-      expect(result).toBe(true);
-      expect(mockGetUserRoles).not.toHaveBeenCalled();
-      expect(context.getRequest()[AUTH_SESSION_KEY]).toBeUndefined();
-    });
-
-    it("should return true when session validation throws (treat as guest)", async () => {
-      mockGetSession.mockRejectedValueOnce(new Error("Session expired"));
-      const context = createMockExecutionContext({ cookie: "session=expired" });
-
-      const result = await guard.canActivate(context);
-
-      expect(result).toBe(true);
-      expect(context.getRequest()[AUTH_SESSION_KEY]).toBeUndefined();
-    });
-
-    it("should pass headers to getSession", async () => {
-      mockGetSession.mockResolvedValueOnce(mockSession);
-      const context = createMockExecutionContext({
-        cookie: "session=token-123",
-        authorization: "Bearer some-token",
+        expect(result).toBe(true);
+        expect(mockGetSession).toHaveBeenCalled();
+        expect(mockGetUserRoles).toHaveBeenCalledWith("user-123");
+        expect(context.getRequest()[AUTH_SESSION_KEY]).toEqual({
+          user: { ...mockSession.user, roles: mockRoles },
+          session: mockSession.session,
+        });
       });
 
-      await guard.canActivate(context);
+      it("should attach session with roles when valid session exists (cookie auth - prod with __Host- prefix)", async () => {
+        mockGetSession.mockResolvedValueOnce(mockSession);
+        const context = createMockExecutionContext({
+          cookie: "__Host-session_token=token-123",
+        });
 
-      expect(mockGetSession).toHaveBeenCalledWith({
-        headers: expect.any(Headers),
+        const result = await guard.canActivate(context);
+
+        expect(result).toBe(true);
+        expect(mockGetSession).toHaveBeenCalled();
+        expect(mockGetUserRoles).toHaveBeenCalledWith("user-123");
+        expect(context.getRequest()[AUTH_SESSION_KEY]).toEqual({
+          user: { ...mockSession.user, roles: mockRoles },
+          session: mockSession.session,
+        });
+      });
+
+      it("should attach session with roles when valid session exists (bearer token)", async () => {
+        mockGetSession.mockResolvedValueOnce(mockSession);
+        const context = createMockExecutionContext({
+          authorization: "Bearer some-token",
+        });
+
+        const result = await guard.canActivate(context);
+
+        expect(result).toBe(true);
+        expect(mockGetSession).toHaveBeenCalled();
+        expect(mockGetUserRoles).toHaveBeenCalledWith("user-123");
+        expect(context.getRequest()[AUTH_SESSION_KEY]).toEqual({
+          user: { ...mockSession.user, roles: mockRoles },
+          session: mockSession.session,
+        });
+      });
+
+      it("should throw UnauthorizedException when credentials provided but session is null", async () => {
+        // User has a cookie but session is expired/invalid (getSession returns null)
+        mockGetSession.mockResolvedValueOnce(null);
+        const context = createMockExecutionContext({
+          cookie: "session_token=expired-token",
+        });
+
+        await expect(guard.canActivate(context)).rejects.toThrow(UnauthorizedException);
+        await expect(guard.canActivate(context)).rejects.toThrow(
+          "Your session has expired or is invalid",
+        );
+
+        expect(mockGetSession).toHaveBeenCalled();
+        expect(mockGetUserRoles).not.toHaveBeenCalled();
+      });
+
+      it("should propagate error when getSession throws", async () => {
+        // Network error or auth service error
+        mockGetSession.mockRejectedValueOnce(new Error("Auth service unavailable"));
+        const context = createMockExecutionContext({
+          authorization: "Bearer some-token",
+        });
+
+        await expect(guard.canActivate(context)).rejects.toThrow("Auth service unavailable");
+
+        expect(mockGetSession).toHaveBeenCalled();
+        expect(context.getRequest()[AUTH_SESSION_KEY]).toBeUndefined();
+      });
+
+      it("should propagate error when getUserRoles fails (not silently downgrade to guest)", async () => {
+        // Scenario: User has valid session, but getUserRoles fails (e.g., transient DB error)
+        // Expected: Error propagates instead of silently treating user as guest
+        mockGetSession.mockResolvedValueOnce(mockSession);
+        mockGetUserRoles.mockRejectedValueOnce(new Error("Database connection failed"));
+        const context = createMockExecutionContext({
+          cookie: "session_token=token-123",
+        });
+
+        await expect(guard.canActivate(context)).rejects.toThrow("Database connection failed");
+
+        expect(mockGetSession).toHaveBeenCalled();
+        expect(mockGetUserRoles).toHaveBeenCalledWith("user-123");
+        expect(context.getRequest()[AUTH_SESSION_KEY]).toBeUndefined();
+      });
+
+      it("should pass headers to getSession", async () => {
+        mockGetSession.mockResolvedValueOnce(mockSession);
+        const context = createMockExecutionContext({
+          cookie: "session_token=token-123",
+          authorization: "Bearer some-token",
+        });
+
+        await guard.canActivate(context);
+
+        expect(mockGetSession).toHaveBeenCalledWith({
+          headers: expect.any(Headers),
+        });
       });
     });
   });
@@ -134,8 +223,10 @@ describe("OptionalSessionGuard", () => {
       await setupTestModule(false);
     });
 
-    it("should return true and allow request through (guest mode)", async () => {
-      const context = createMockExecutionContext();
+    it("should allow through as guest when auth service not initialized", async () => {
+      const context = createMockExecutionContext({
+        cookie: "session_token=token-123",
+      });
 
       const result = await guard.canActivate(context);
 

--- a/src/modules/auth/guards/optional-session.guard.ts
+++ b/src/modules/auth/guards/optional-session.guard.ts
@@ -1,5 +1,11 @@
 import type { IncomingHttpHeaders } from "node:http";
-import { CanActivate, ExecutionContext, Injectable, Logger } from "@nestjs/common";
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  Logger,
+  UnauthorizedException,
+} from "@nestjs/common";
 import type { Request } from "express";
 import { AuthService } from "../auth.service";
 import { AUTH_SESSION_KEY, type AuthSession } from "./session.guard";
@@ -17,14 +23,48 @@ function toHeaders(incomingHeaders: IncomingHttpHeaders): Headers {
 }
 
 /**
+ * Checks if the request contains any authentication credentials.
+ * Returns true if Authorization header or session cookie is present.
+ */
+function hasAuthCredentials(request: Request): boolean {
+  // Check for Authorization header (Bearer token)
+  if (request.headers.authorization) {
+    return true;
+  }
+
+  // Check for session cookie
+  // Better Auth uses session_token cookie with optional __Host- prefix:
+  // - Production (HTTPS): __Host-session_token
+  // - Development (HTTP): session_token
+  const cookieHeader = request.headers.cookie;
+  if (cookieHeader) {
+    const hasSessionCookie =
+      cookieHeader.includes("session_token") || // Matches both "session_token" and "__Host-session_token"
+      cookieHeader.includes("session_data"); // Matches both "session_data" and "__Host-session_data"
+    if (hasSessionCookie) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
  * Guard that optionally validates user session via Better Auth.
  *
- * Unlike SessionGuard, this guard does NOT throw when no session is present.
- * It allows both authenticated and unauthenticated (guest) requests through.
+ * Unlike SessionGuard, this guard allows guest (unauthenticated) requests through,
+ * but ONLY when no auth credentials are provided. If credentials are provided
+ * but invalid/expired, it throws UnauthorizedException to prevent silent downgrade.
  *
- * - If valid session exists: attaches session to request, @CurrentUser returns user
- * - If no session: allows request through, @CurrentUser returns null
- * - If auth service not initialized: allows request through (logs warning)
+ * Behavior:
+ * - No auth credentials: allows through as guest, @CurrentUser returns null
+ * - Valid session: attaches session to request, @CurrentUser returns user
+ * - Credentials provided but invalid/expired: throws UnauthorizedException
+ * - Auth service not initialized: allows through as guest (logs warning)
+ *
+ * This prevents the dangerous scenario where a user thinks they're logged in
+ * (has a cookie) but their session expired, causing their booking to be created
+ * as a guest without account association, referral benefits, or history visibility.
  *
  * Usage:
  * ```typescript
@@ -34,7 +74,7 @@ function toHeaders(incomingHeaders: IncomingHttpHeaders): Headers {
  *   @Body() dto: CreateBookingDto,
  *   @CurrentUser() user: AuthSession['user'] | null,
  * ) {
- *   // user is null for guest bookings
+ *   // user is null for intentional guest bookings (no credentials provided)
  * }
  * ```
  */
@@ -54,32 +94,39 @@ export class OptionalSessionGuard implements CanActivate {
     }
 
     const request = context.switchToHttp().getRequest<Request>();
+    const credentialsProvided = hasAuthCredentials(request);
 
-    try {
-      const session = await this.authService.auth.api.getSession({
-        headers: toHeaders(request.headers),
-      });
-
-      if (!session) {
-        // No session - allow through as guest (don't throw)
-        return true;
-      }
-
-      // Fetch user roles from database
-      const roles = await this.authService.getUserRoles(session.user.id);
-
-      // Attach session with roles to request for use by @CurrentUser decorator
-      const authSession: AuthSession = {
-        user: { ...session.user, roles },
-        session: session.session,
-      };
-      (request as Request & { [AUTH_SESSION_KEY]: AuthSession })[AUTH_SESSION_KEY] = authSession;
-    } catch (error) {
-      // If session validation fails (e.g., expired token), treat as guest
-      this.logger.debug("Session validation failed, treating as guest request", {
-        error: error instanceof Error ? error.message : String(error),
-      });
+    // If no auth credentials provided, this is an intentional guest request
+    if (!credentialsProvided) {
+      return true;
     }
+
+    // Auth credentials were provided - user intends to be authenticated
+    // If validation fails, we should NOT silently downgrade to guest
+    const session = await this.authService.auth.api.getSession({
+      headers: toHeaders(request.headers),
+    });
+
+    if (!session) {
+      // User provided credentials but session is invalid/expired
+      // Don't silently downgrade to guest - inform them to re-authenticate
+      throw new UnauthorizedException(
+        "Your session has expired or is invalid. Please log in again.",
+      );
+    }
+
+    // Fetch user roles from database
+    // NOTE: If this fails, we let the error propagate rather than silently
+    // downgrading an authenticated user to guest mode (which would cause loss
+    // of referral discounts and booking history visibility)
+    const roles = await this.authService.getUserRoles(session.user.id);
+
+    // Attach session with roles to request for use by @CurrentUser decorator
+    const authSession: AuthSession = {
+      user: { ...session.user, roles },
+      session: session.session,
+    };
+    (request as Request & { [AUTH_SESSION_KEY]: AuthSession })[AUTH_SESSION_KEY] = authSession;
 
     return true;
   }

--- a/src/modules/auth/guards/optional-session.guard.ts
+++ b/src/modules/auth/guards/optional-session.guard.ts
@@ -1,0 +1,86 @@
+import type { IncomingHttpHeaders } from "node:http";
+import { CanActivate, ExecutionContext, Injectable, Logger } from "@nestjs/common";
+import type { Request } from "express";
+import { AuthService } from "../auth.service";
+import { AUTH_SESSION_KEY, type AuthSession } from "./session.guard";
+
+/**
+ * Converts Express IncomingHttpHeaders to a Headers object.
+ */
+function toHeaders(incomingHeaders: IncomingHttpHeaders): Headers {
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(incomingHeaders)) {
+    if (value === undefined) continue;
+    headers.set(key, Array.isArray(value) ? value.join(", ") : value);
+  }
+  return headers;
+}
+
+/**
+ * Guard that optionally validates user session via Better Auth.
+ *
+ * Unlike SessionGuard, this guard does NOT throw when no session is present.
+ * It allows both authenticated and unauthenticated (guest) requests through.
+ *
+ * - If valid session exists: attaches session to request, @CurrentUser returns user
+ * - If no session: allows request through, @CurrentUser returns null
+ * - If auth service not initialized: allows request through (logs warning)
+ *
+ * Usage:
+ * ```typescript
+ * @UseGuards(OptionalSessionGuard)
+ * @Post('bookings')
+ * createBooking(
+ *   @Body() dto: CreateBookingDto,
+ *   @CurrentUser() user: AuthSession['user'] | null,
+ * ) {
+ *   // user is null for guest bookings
+ * }
+ * ```
+ */
+@Injectable()
+export class OptionalSessionGuard implements CanActivate {
+  private readonly logger = new Logger(OptionalSessionGuard.name);
+
+  constructor(private readonly authService: AuthService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    // If auth service is not initialized, allow request through (guest mode)
+    if (!this.authService.isInitialized) {
+      this.logger.warn(
+        "Authentication service not initialized. All requests will be treated as guest requests.",
+      );
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest<Request>();
+
+    try {
+      const session = await this.authService.auth.api.getSession({
+        headers: toHeaders(request.headers),
+      });
+
+      if (!session) {
+        // No session - allow through as guest (don't throw)
+        return true;
+      }
+
+      // Fetch user roles from database
+      const roles = await this.authService.getUserRoles(session.user.id);
+
+      // Attach session with roles to request for use by @CurrentUser decorator
+      const authSession: AuthSession = {
+        user: { ...session.user, roles },
+        session: session.session,
+      };
+      (request as Request & { [AUTH_SESSION_KEY]: AuthSession })[AUTH_SESSION_KEY] = authSession;
+    } catch (error) {
+      // If session validation fails (e.g., expired token), treat as guest
+      this.logger.debug("Session validation failed, treating as guest request", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    return true;
+  }
+}

--- a/src/modules/booking/booking-calculation.service.spec.ts
+++ b/src/modules/booking/booking-calculation.service.spec.ts
@@ -2,9 +2,9 @@ import { Test, type TestingModule } from "@nestjs/testing";
 import { Decimal } from "@prisma/client/runtime/library";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { RatesService } from "../rates/rates.service";
+import type { GeneratedLeg } from "./booking.interface";
 import type { BookingCalculationInput, CarPricing } from "./booking-calculation.interface";
 import { BookingCalculationService } from "./booking-calculation.service";
-import type { GeneratedLeg } from "./booking.interface";
 
 describe("BookingCalculationService", () => {
   let service: BookingCalculationService;

--- a/src/modules/booking/booking-calculation.service.ts
+++ b/src/modules/booking/booking-calculation.service.ts
@@ -2,14 +2,14 @@ import { Injectable } from "@nestjs/common";
 import type { BookingType } from "@prisma/client";
 import { Decimal } from "@prisma/client/runtime/library";
 import { RatesService } from "../rates/rates.service";
+import { MAX_LEGS_FOR_FUEL_UPGRADE } from "./booking.const";
+import type { GeneratedLeg } from "./booking.interface";
 import type {
   BookingCalculationInput,
   BookingFinancials,
   CarPricing,
   LegPrice,
 } from "./booking-calculation.interface";
-import type { GeneratedLeg } from "./booking.interface";
-import { MAX_LEGS_FOR_FUEL_UPGRADE } from "./booking.const";
 
 /**
  * Service for calculating booking financials.

--- a/src/modules/booking/booking-confirmation.service.spec.ts
+++ b/src/modules/booking/booking-confirmation.service.spec.ts
@@ -423,7 +423,10 @@ describe("BookingConfirmationService", () => {
 
       vi.mocked(databaseService.booking.updateMany).mockResolvedValueOnce({ count: 1 });
       vi.mocked(databaseService.booking.findUnique).mockResolvedValueOnce(mockBooking);
-      vi.mocked(databaseService.car.update).mockResolvedValueOnce({ ...mockBooking.car, status: Status.BOOKED });
+      vi.mocked(databaseService.car.update).mockResolvedValueOnce({
+        ...mockBooking.car,
+        status: Status.BOOKED,
+      });
       vi.mocked(notificationQueue.add).mockResolvedValue(createMockJob());
 
       await service.confirmFromPayment(mockPayment);

--- a/src/modules/booking/booking-confirmation.service.ts
+++ b/src/modules/booking/booking-confirmation.service.ts
@@ -1,6 +1,6 @@
 import { InjectQueue } from "@nestjs/bullmq";
 import { Injectable, Logger } from "@nestjs/common";
-import { BookingStatus, PaymentStatus, Status, type Payment } from "@prisma/client";
+import { BookingStatus, type Payment, PaymentStatus, Status } from "@prisma/client";
 import { Queue } from "bullmq";
 import { NOTIFICATIONS_QUEUE } from "../../config/constants";
 import { normaliseBookingDetails } from "../../shared/helper";
@@ -12,7 +12,7 @@ import {
   FLEET_OWNER_RECIPIENT_TYPE,
   SEND_NOTIFICATION_JOB_NAME,
 } from "../notification/notification.const";
-import { NotificationType, type NotificationJobData } from "../notification/notification.interface";
+import { type NotificationJobData, NotificationType } from "../notification/notification.interface";
 
 /**
  * Service for confirming bookings after successful payment.

--- a/src/modules/booking/booking-creation.service.spec.ts
+++ b/src/modules/booking/booking-creation.service.spec.ts
@@ -876,14 +876,12 @@ describe("BookingCreationService", () => {
 
     it("should not apply referral discount when user has already used it (preliminary check)", async () => {
       // User was referred but already used their one-time discount
-      vi.mocked(databaseService.user.findUnique).mockResolvedValue({
-        id: "user-123",
-        email: "user@example.com",
-        name: "Test User",
-        phoneNumber: "08012345678",
-        referredByUserId: "referrer-123",
-        referralDiscountUsed: true, // ✅ Already used!
-      });
+      vi.mocked(databaseService.user.findUnique).mockResolvedValue(
+        createUser({
+          referredByUserId: "referrer-123",
+          referralDiscountUsed: true, // ✅ Already used!
+        }),
+      );
       vi.mocked(validationService.validateDates).mockReturnValue(undefined);
       vi.mocked(validationService.checkCarAvailability).mockResolvedValue(undefined);
       vi.mocked(validationService.validatePriceMatch).mockReturnValue(undefined);

--- a/src/modules/booking/booking-creation.service.spec.ts
+++ b/src/modules/booking/booking-creation.service.spec.ts
@@ -2,7 +2,8 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { BookingStatus, PaymentStatus } from "@prisma/client";
 import { Decimal } from "@prisma/client/runtime/library";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createBookingFinancials, createCar } from "../../shared/helper.fixtures";
+import { createBookingFinancials, createCar, createUser } from "../../shared/helper.fixtures";
+import type { AuthSession } from "../auth/guards/session.guard";
 import { DatabaseService } from "../database/database.service";
 import {
   FlightAlreadyLandedException,
@@ -21,7 +22,6 @@ import {
   PaymentIntentFailedException,
   ReferralDiscountNoLongerAvailableException,
 } from "./booking.error";
-import type { BookingCreationInput } from "./booking.interface";
 import { BookingCalculationService } from "./booking-calculation.service";
 import { BookingCreationService } from "./booking-creation.service";
 import { BookingLegService } from "./booking-leg.service";
@@ -58,14 +58,17 @@ const createGuestBookingInput = (
   return { ...base, ...overrides } as CreateGuestBookingDto;
 };
 
-// Helper to create user context
-const createUserContext = (): BookingCreationInput["user"] => ({
+// Helper to create session user context (AuthSession["user"] type from Better Auth)
+const createSessionUser = (overrides: Partial<AuthSession["user"]> = {}): AuthSession["user"] => ({
   id: "user-123",
   email: "user@example.com",
   name: "Test User",
-  phoneNumber: "08012345678",
-  referredByUserId: null,
-  referralDiscountUsed: false,
+  emailVerified: true,
+  image: null,
+  createdAt: new Date("2024-01-01T00:00:00Z"),
+  updatedAt: new Date("2024-01-01T00:00:00Z"),
+  roles: ["user"],
+  ...overrides,
 });
 
 describe("BookingCreationService", () => {
@@ -92,6 +95,7 @@ describe("BookingCreationService", () => {
           provide: DatabaseService,
           useValue: {
             car: { findUnique: vi.fn() },
+            user: { findUnique: vi.fn(), update: vi.fn() },
             booking: { create: vi.fn(), update: vi.fn() },
             flight: { upsert: vi.fn() },
             referralProgramConfig: { findMany: vi.fn(), findFirst: vi.fn() },
@@ -168,6 +172,7 @@ describe("BookingCreationService", () => {
       vi.mocked(validationService.validatePriceMatch).mockReturnValue(undefined);
 
       vi.mocked(databaseService.car.findUnique).mockResolvedValue(createCar());
+      vi.mocked(databaseService.user.findUnique).mockResolvedValue(createUser());
 
       vi.mocked(legService.generateLegs).mockReturnValue([
         {
@@ -219,16 +224,13 @@ describe("BookingCreationService", () => {
       setupSuccessfulMocks();
 
       const booking = createBookingInput();
-      const user = createUserContext();
+      const user = createSessionUser();
 
-      const result = await service.createBooking({ booking, user });
+      const result = await service.createBooking(booking, user);
 
       expect(result).toEqual({
         bookingId: "booking-123",
-        bookingReference: expect.stringMatching(/^BK-/),
         checkoutUrl: "https://checkout.flutterwave.com/pay/abc123",
-        totalAmount: "56437.5",
-        status: BookingStatus.PENDING,
       });
 
       expect(validationService.validateDates).toHaveBeenCalledWith({
@@ -252,14 +254,11 @@ describe("BookingCreationService", () => {
 
       const booking = createGuestBookingInput();
 
-      const result = await service.createBooking({ booking, user: null });
+      const result = await service.createBooking(booking, null);
 
       expect(result).toEqual({
         bookingId: "booking-123",
-        bookingReference: expect.stringMatching(/^BK-/),
         checkoutUrl: "https://checkout.flutterwave.com/pay/abc123",
-        totalAmount: "56437.5",
-        status: BookingStatus.PENDING,
       });
 
       expect(validationService.validateGuestEmail).toHaveBeenCalledWith(booking);
@@ -273,9 +272,9 @@ describe("BookingCreationService", () => {
       });
 
       const booking = createBookingInput();
-      const user = createUserContext();
+      const user = createSessionUser();
 
-      await expect(service.createBooking({ booking, user })).rejects.toThrow(
+      await expect(service.createBooking(booking, user)).rejects.toThrow(
         BookingValidationException,
       );
 
@@ -283,17 +282,16 @@ describe("BookingCreationService", () => {
     });
 
     it("should throw CarNotAvailableException when car is not available", async () => {
+      vi.mocked(databaseService.user.findUnique).mockResolvedValue(createUser());
       vi.mocked(validationService.validateDates).mockReturnValue(undefined);
       vi.mocked(validationService.checkCarAvailability).mockRejectedValue(
         new CarNotAvailableException("car-123", "Car is not available for the selected dates"),
       );
 
       const booking = createBookingInput();
-      const user = createUserContext();
+      const user = createSessionUser();
 
-      await expect(service.createBooking({ booking, user })).rejects.toThrow(
-        CarNotAvailableException,
-      );
+      await expect(service.createBooking(booking, user)).rejects.toThrow(CarNotAvailableException);
 
       expect(databaseService.car.findUnique).not.toHaveBeenCalled();
     });
@@ -309,7 +307,7 @@ describe("BookingCreationService", () => {
 
       const booking = createGuestBookingInput();
 
-      await expect(service.createBooking({ booking, user: null })).rejects.toThrow(
+      await expect(service.createBooking(booking, null)).rejects.toThrow(
         BookingValidationException,
       );
     });
@@ -335,23 +333,25 @@ describe("BookingCreationService", () => {
       const booking = createBookingInput();
 
       // Pass user: null with a non-guest booking
-      await expect(service.createBooking({ booking, user: null })).rejects.toThrow(
+      await expect(service.createBooking(booking, null)).rejects.toThrow(
         BookingValidationException,
       );
     });
 
     it("should throw CarNotFoundException when car does not exist", async () => {
+      vi.mocked(databaseService.user.findUnique).mockResolvedValue(createUser());
       vi.mocked(validationService.validateDates).mockReturnValue(undefined);
       vi.mocked(validationService.checkCarAvailability).mockResolvedValue(undefined);
       vi.mocked(databaseService.car.findUnique).mockResolvedValue(null);
 
       const booking = createBookingInput();
-      const user = createUserContext();
+      const user = createSessionUser();
 
-      await expect(service.createBooking({ booking, user })).rejects.toThrow(CarNotFoundException);
+      await expect(service.createBooking(booking, user)).rejects.toThrow(CarNotFoundException);
     });
 
     it("should throw BookingValidationException when price does not match", async () => {
+      vi.mocked(databaseService.user.findUnique).mockResolvedValue(createUser());
       vi.mocked(validationService.validateDates).mockReturnValue(undefined);
       vi.mocked(validationService.checkCarAvailability).mockResolvedValue(undefined);
       vi.mocked(databaseService.car.findUnique).mockResolvedValue(createCar());
@@ -373,9 +373,9 @@ describe("BookingCreationService", () => {
       });
 
       const booking = createBookingInput({ clientTotalAmount: "10000" });
-      const user = createUserContext();
+      const user = createSessionUser();
 
-      await expect(service.createBooking({ booking, user })).rejects.toThrow(
+      await expect(service.createBooking(booking, user)).rejects.toThrow(
         BookingValidationException,
       );
     });
@@ -389,9 +389,9 @@ describe("BookingCreationService", () => {
       );
 
       const booking = createBookingInput();
-      const user = createUserContext();
+      const user = createSessionUser();
 
-      await expect(service.createBooking({ booking, user })).rejects.toThrow(
+      await expect(service.createBooking(booking, user)).rejects.toThrow(
         PaymentIntentFailedException,
       );
 
@@ -403,6 +403,7 @@ describe("BookingCreationService", () => {
     });
 
     it("should throw BookingCreationFailedException when numberOfLegs is zero", async () => {
+      vi.mocked(databaseService.user.findUnique).mockResolvedValue(createUser());
       vi.mocked(validationService.validateDates).mockReturnValue(undefined);
       vi.mocked(validationService.checkCarAvailability).mockResolvedValue(undefined);
       vi.mocked(validationService.validatePriceMatch).mockReturnValue(undefined);
@@ -418,9 +419,9 @@ describe("BookingCreationService", () => {
       );
 
       const booking = createBookingInput();
-      const user = createUserContext();
+      const user = createSessionUser();
 
-      await expect(service.createBooking({ booking, user })).rejects.toThrow(
+      await expect(service.createBooking(booking, user)).rejects.toThrow(
         BookingCreationFailedException,
       );
 
@@ -431,6 +432,7 @@ describe("BookingCreationService", () => {
 
   describe("createBooking - Airport Pickup", () => {
     it("should validate flight for airport pickup bookings", async () => {
+      vi.mocked(databaseService.user.findUnique).mockResolvedValue(createUser());
       // Validation methods now return void
       vi.mocked(validationService.validateDates).mockReturnValue(undefined);
       vi.mocked(validationService.checkCarAvailability).mockResolvedValue(undefined);
@@ -508,9 +510,9 @@ describe("BookingCreationService", () => {
         sameLocation: false as const,
         dropOffAddress: "Victoria Island, Lagos",
       });
-      const user = createUserContext();
+      const user = createSessionUser();
 
-      const result = await service.createBooking({ booking, user });
+      const result = await service.createBooking(booking, user);
 
       expect(result.bookingId).toBe("booking-123");
       expect(flightAwareService.validateFlight).toHaveBeenCalledWith("BA74", "2025-02-01");
@@ -520,6 +522,7 @@ describe("BookingCreationService", () => {
     });
 
     it("should throw FlightNotFoundException when flight is not found", async () => {
+      vi.mocked(databaseService.user.findUnique).mockResolvedValue(createUser());
       vi.mocked(validationService.validateDates).mockReturnValue(undefined);
       vi.mocked(validationService.checkCarAvailability).mockResolvedValue(undefined);
 
@@ -534,14 +537,13 @@ describe("BookingCreationService", () => {
         sameLocation: false as const,
         dropOffAddress: "Victoria Island, Lagos",
       });
-      const user = createUserContext();
+      const user = createSessionUser();
 
-      await expect(service.createBooking({ booking, user })).rejects.toThrow(
-        FlightNotFoundException,
-      );
+      await expect(service.createBooking(booking, user)).rejects.toThrow(FlightNotFoundException);
     });
 
     it("should throw FlightAlreadyLandedException when flight has already landed", async () => {
+      vi.mocked(databaseService.user.findUnique).mockResolvedValue(createUser());
       vi.mocked(validationService.validateDates).mockReturnValue(undefined);
       vi.mocked(validationService.checkCarAvailability).mockResolvedValue(undefined);
 
@@ -556,9 +558,9 @@ describe("BookingCreationService", () => {
         sameLocation: false as const,
         dropOffAddress: "Victoria Island, Lagos",
       });
-      const user = createUserContext();
+      const user = createSessionUser();
 
-      await expect(service.createBooking({ booking, user })).rejects.toThrow(
+      await expect(service.createBooking(booking, user)).rejects.toThrow(
         FlightAlreadyLandedException,
       );
     });
@@ -566,6 +568,13 @@ describe("BookingCreationService", () => {
 
   describe("createBooking - Referral Handling", () => {
     it("should apply referral discount for eligible users", async () => {
+      // Mock user in database with referral info (fetched for preliminary check)
+      vi.mocked(databaseService.user.findUnique).mockResolvedValue(
+        createUser({
+          referredByUserId: "referrer-123", // User was referred
+          referralDiscountUsed: false, // Discount not yet used
+        }),
+      );
       vi.mocked(validationService.validateDates).mockReturnValue(undefined);
       vi.mocked(validationService.checkCarAvailability).mockResolvedValue(undefined);
       vi.mocked(validationService.validatePriceMatch).mockReturnValue(undefined);
@@ -632,16 +641,10 @@ describe("BookingCreationService", () => {
       });
 
       const booking = createBookingInput();
-      const user: BookingCreationInput["user"] = {
-        id: "user-123",
-        email: "user@example.com",
-        name: "Test User",
-        phoneNumber: "08012345678",
-        referredByUserId: "referrer-123", // User was referred
-        referralDiscountUsed: false, // Discount not yet used
-      };
+      // Session user only has Better Auth fields, not referral info
+      const sessionUser = createSessionUser();
 
-      const result = await service.createBooking({ booking, user });
+      const result = await service.createBooking(booking, sessionUser);
 
       expect(result.bookingId).toBe("booking-123");
 
@@ -654,6 +657,13 @@ describe("BookingCreationService", () => {
     });
 
     it("should mark referralDiscountUsed=true within the transaction to prevent race conditions", async () => {
+      // Mock user in database with referral info
+      vi.mocked(databaseService.user.findUnique).mockResolvedValue(
+        createUser({
+          referredByUserId: "referrer-123",
+          referralDiscountUsed: false,
+        }),
+      );
       vi.mocked(validationService.validateDates).mockReturnValue(undefined);
       vi.mocked(validationService.checkCarAvailability).mockResolvedValue(undefined);
       vi.mocked(validationService.validatePriceMatch).mockReturnValue(undefined);
@@ -722,16 +732,10 @@ describe("BookingCreationService", () => {
       });
 
       const booking = createBookingInput();
-      const user: BookingCreationInput["user"] = {
-        id: "user-123",
-        email: "user@example.com",
-        name: "Test User",
-        phoneNumber: "08012345678",
-        referredByUserId: "referrer-123",
-        referralDiscountUsed: false,
-      };
+      // Session user only has Better Auth fields
+      const sessionUser = createSessionUser();
 
-      await service.createBooking({ booking, user });
+      await service.createBooking(booking, sessionUser);
 
       // Verify that user.referralDiscountUsed was set to true WITHIN the transaction
       // This prevents the race condition where concurrent bookings could all receive the discount
@@ -742,6 +746,13 @@ describe("BookingCreationService", () => {
     });
 
     it("should throw ReferralDiscountNoLongerAvailableException when discount was already used (race condition)", async () => {
+      // Mock user in database - preliminary check shows eligible
+      vi.mocked(databaseService.user.findUnique).mockResolvedValue(
+        createUser({
+          referredByUserId: "referrer-123",
+          referralDiscountUsed: false,
+        }),
+      );
       vi.mocked(validationService.validateDates).mockReturnValue(undefined);
       vi.mocked(validationService.checkCarAvailability).mockResolvedValue(undefined);
       vi.mocked(validationService.validatePriceMatch).mockReturnValue(undefined);
@@ -756,7 +767,7 @@ describe("BookingCreationService", () => {
         },
       ]);
 
-      // Preliminary check: user appears eligible (from request context)
+      // Preliminary check: user appears eligible (from initial DB query)
       vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
         { key: "REFERRAL_ENABLED", value: true, updatedAt: new Date(), updatedBy: null },
         { key: "REFERRAL_DISCOUNT_AMOUNT", value: "5000", updatedAt: new Date(), updatedBy: null },
@@ -791,17 +802,11 @@ describe("BookingCreationService", () => {
       });
 
       const booking = createBookingInput();
-      const user: BookingCreationInput["user"] = {
-        id: "user-123",
-        email: "user@example.com",
-        name: "Test User",
-        phoneNumber: "08012345678",
-        referredByUserId: "referrer-123",
-        referralDiscountUsed: false, // Preliminary check says eligible
-      };
+      // Session user only has Better Auth fields
+      const sessionUser = createSessionUser();
 
       // Should throw because fresh DB query shows discount was already used
-      await expect(service.createBooking({ booking, user })).rejects.toThrow(
+      await expect(service.createBooking(booking, sessionUser)).rejects.toThrow(
         ReferralDiscountNoLongerAvailableException,
       );
     });
@@ -859,7 +864,7 @@ describe("BookingCreationService", () => {
 
       const booking = createGuestBookingInput();
 
-      await service.createBooking({ booking, user: null });
+      await service.createBooking(booking, null);
 
       // Verify no referral discount was passed
       expect(calculationService.calculateBookingCost).toHaveBeenCalledWith(

--- a/src/modules/booking/booking-creation.service.ts
+++ b/src/modules/booking/booking-creation.service.ts
@@ -481,11 +481,11 @@ export class BookingCreationService {
         select: { phoneNumber: true, email: true, name: true },
       });
 
-      return {
-        email: sessionUser.email ?? user.email,
-        name: sessionUser.name ?? user.name,
-        phoneNumber: user?.phoneNumber ?? undefined,
-      };
+      if (!user) {
+        throw new BookingCreationFailedException("User not found for session");
+      }
+
+      return user;
     }
 
     const guestBooking = booking as CreateGuestBookingDto;

--- a/src/modules/booking/booking-leg.service.spec.ts
+++ b/src/modules/booking/booking-leg.service.spec.ts
@@ -1,8 +1,8 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { beforeEach, describe, expect, it } from "vitest";
-import { BookingLegService } from "./booking-leg.service";
-import { LegGenerationInput } from "./booking.interface";
 import { AIRPORT_PICKUP_BUFFER_MINUTES } from "./booking.const";
+import { LegGenerationInput } from "./booking.interface";
+import { BookingLegService } from "./booking-leg.service";
 
 describe("BookingLegService", () => {
   let service: BookingLegService;

--- a/src/modules/booking/booking-leg.service.ts
+++ b/src/modules/booking/booking-leg.service.ts
@@ -1,5 +1,5 @@
-import { Injectable } from "@nestjs/common";
 import { UTCDate } from "@date-fns/utc";
+import { Injectable } from "@nestjs/common";
 import { addDays, addHours, eachDayOfInterval, setHours, setMinutes, setSeconds } from "date-fns";
 import {
   AIRPORT_PICKUP_BUFFER_MINUTES,

--- a/src/modules/booking/booking.controller.spec.ts
+++ b/src/modules/booking/booking.controller.spec.ts
@@ -1,0 +1,282 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthService } from "../auth/auth.service";
+import { OptionalSessionGuard } from "../auth/guards/optional-session.guard";
+import { BookingController } from "./booking.controller";
+import { BookingValidationException } from "./booking.error";
+import { BookingCreationService } from "./booking-creation.service";
+import {
+  type CreateBookingDto,
+  type CreateBookingInput,
+  type CreateGuestBookingDto,
+  createBookingSchema,
+  createGuestBookingSchema,
+} from "./dto/create-booking.dto";
+import { BookingZodValidationPipe } from "./pipes/zod-validation.pipe";
+
+/**
+ * Helper function to validate booking input (simulates the decorator behavior)
+ */
+function validateBookingInput(
+  rawBody: unknown,
+  isAuthenticated: boolean,
+): CreateBookingInput {
+  const schema = isAuthenticated ? createBookingSchema : createGuestBookingSchema;
+  const pipe = new BookingZodValidationPipe(schema);
+  return pipe.transform(rawBody);
+}
+
+describe("BookingController", () => {
+  let controller: BookingController;
+  let bookingCreationService: BookingCreationService;
+
+  const mockCreateBookingResponse = {
+    bookingId: "booking-123",
+    checkoutUrl: "https://checkout.flutterwave.com/pay/abc123",
+  };
+
+  const mockSessionUser = {
+    id: "user-123",
+    email: "user@example.com",
+    name: "Test User",
+    emailVerified: true,
+    image: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    roles: ["user" as const],
+  };
+
+  const createValidBookingDto = (): CreateBookingDto => ({
+    carId: "car-123",
+    startDate: new Date("2025-02-01T09:00:00Z"),
+    endDate: new Date("2025-02-01T21:00:00Z"),
+    pickupAddress: "123 Main St, Lagos",
+    bookingType: "DAY",
+    pickupTime: "9:00 AM",
+    sameLocation: true,
+    includeSecurityDetail: false,
+    requiresFullTank: false,
+    useCredits: 0,
+  });
+
+  const createValidGuestBookingDto = (): CreateGuestBookingDto => ({
+    ...createValidBookingDto(),
+    guestEmail: "guest@example.com",
+    guestName: "Guest User",
+    guestPhone: "08098765432",
+  });
+
+  beforeEach(async () => {
+    const mockBookingCreationService = {
+      createBooking: vi.fn().mockResolvedValue(mockCreateBookingResponse),
+    };
+
+    const mockAuthService = {
+      isInitialized: true,
+      auth: {
+        api: {
+          getSession: vi.fn().mockResolvedValue(null),
+        },
+      },
+      getUserRoles: vi.fn().mockResolvedValue(["user"]),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [BookingController],
+      providers: [
+        { provide: BookingCreationService, useValue: mockBookingCreationService },
+        { provide: AuthService, useValue: mockAuthService },
+        OptionalSessionGuard,
+      ],
+    }).compile();
+
+    controller = module.get<BookingController>(BookingController);
+    bookingCreationService = module.get<BookingCreationService>(BookingCreationService);
+  });
+
+  it("should be defined", () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe("createBooking", () => {
+    describe("authenticated user", () => {
+      it("should create a booking for authenticated user", async () => {
+        const dto = createValidBookingDto();
+        const validatedDto = validateBookingInput(dto, true);
+
+        const result = await controller.createBooking(validatedDto, mockSessionUser);
+
+        expect(result).toEqual(mockCreateBookingResponse);
+        expect(bookingCreationService.createBooking).toHaveBeenCalledWith(
+          expect.objectContaining({
+            carId: "car-123",
+            bookingType: "DAY",
+          }),
+          {
+            id: "user-123",
+            email: "user@example.com",
+            name: "Test User",
+            emailVerified: true,
+            image: null,
+            roles: ["user"],
+            createdAt: expect.any(Date),
+            updatedAt: expect.any(Date),
+          },
+        );
+      });
+
+      it("should throw BookingValidationException for invalid booking data", async () => {
+        const invalidDto = {
+          carId: "", // Invalid - empty
+          startDate: new Date("2025-02-01"),
+          endDate: new Date("2025-02-01"),
+          pickupAddress: "123 Main St",
+          bookingType: "DAY",
+          // Missing pickupTime (required for DAY)
+          sameLocation: true,
+        };
+
+        // Validation should throw before reaching controller
+        expect(() => validateBookingInput(invalidDto, true)).toThrow(BookingValidationException);
+      });
+
+      it("should validate pickupTime is required for DAY bookings", async () => {
+        const dto = {
+          ...createValidBookingDto(),
+          pickupTime: undefined, // Missing
+        };
+
+        // Validation should throw before reaching controller
+        expect(() => validateBookingInput(dto, true)).toThrow(BookingValidationException);
+      });
+
+      it("should validate flightNumber is required for AIRPORT_PICKUP bookings", async () => {
+        const dto = {
+          ...createValidBookingDto(),
+          bookingType: "AIRPORT_PICKUP" as const,
+          pickupTime: undefined,
+          sameLocation: false,
+          dropOffAddress: "456 Drop Off St",
+          // Missing flightNumber
+        };
+
+        // Validation should throw before reaching controller
+        expect(() => validateBookingInput(dto, true)).toThrow(BookingValidationException);
+      });
+    });
+
+    describe("guest user", () => {
+      it("should create a booking for guest user", async () => {
+        const dto = createValidGuestBookingDto();
+        const validatedDto = validateBookingInput(dto, false);
+
+        const result = await controller.createBooking(validatedDto, null);
+
+        expect(result).toEqual(mockCreateBookingResponse);
+        expect(bookingCreationService.createBooking).toHaveBeenCalledWith(
+          expect.objectContaining({
+            carId: "car-123",
+            guestEmail: "guest@example.com",
+            guestName: "Guest User",
+            guestPhone: "08098765432",
+          }),
+          null,
+        );
+      });
+
+      it("should throw BookingValidationException if guest fields are missing", async () => {
+        const dto = createValidBookingDto(); // Missing guest fields
+
+        // Validation should throw before reaching controller
+        expect(() => validateBookingInput(dto, false)).toThrow(BookingValidationException);
+      });
+
+      it("should validate guest email format", async () => {
+        const dto = {
+          ...createValidGuestBookingDto(),
+          guestEmail: "invalid-email", // Invalid format
+        };
+
+        // Validation should throw before reaching controller
+        expect(() => validateBookingInput(dto, false)).toThrow(BookingValidationException);
+      });
+
+      it("should validate guest name minimum length", async () => {
+        const dto = {
+          ...createValidGuestBookingDto(),
+          guestName: "A", // Too short
+        };
+
+        // Validation should throw before reaching controller
+        expect(() => validateBookingInput(dto, false)).toThrow(BookingValidationException);
+      });
+
+      it("should validate guest phone minimum length", async () => {
+        const dto = {
+          ...createValidGuestBookingDto(),
+          guestPhone: "123", // Too short
+        };
+
+        // Validation should throw before reaching controller
+        expect(() => validateBookingInput(dto, false)).toThrow(BookingValidationException);
+      });
+    });
+
+    describe("validation", () => {
+      it("should validate end date is after start date", async () => {
+        const dto = {
+          ...createValidBookingDto(),
+          startDate: new Date("2025-02-02"),
+          endDate: new Date("2025-02-01"), // Before start
+        };
+
+        // Validation should throw before reaching controller
+        expect(() => validateBookingInput(dto, true)).toThrow(BookingValidationException);
+      });
+
+      it("should validate dropOffAddress is required when sameLocation is false", async () => {
+        const dto = {
+          ...createValidBookingDto(),
+          sameLocation: false,
+          // Missing dropOffAddress
+        };
+
+        // Validation should throw before reaching controller
+        expect(() => validateBookingInput(dto, true)).toThrow(BookingValidationException);
+      });
+
+      it("should accept booking with different drop-off location", async () => {
+        const dto = {
+          ...createValidBookingDto(),
+          sameLocation: false as const,
+          dropOffAddress: "456 Other St, Lagos",
+        };
+        const validatedDto = validateBookingInput(dto, true);
+
+        const result = await controller.createBooking(validatedDto, mockSessionUser);
+
+        expect(result).toEqual(mockCreateBookingResponse);
+        expect(bookingCreationService.createBooking).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sameLocation: false,
+            dropOffAddress: "456 Other St, Lagos",
+          }),
+          expect.any(Object),
+        );
+      });
+
+      it("should validate AIRPORT_PICKUP requires sameLocation=false", async () => {
+        const dto = {
+          ...createValidBookingDto(),
+          bookingType: "AIRPORT_PICKUP" as const,
+          pickupTime: undefined,
+          sameLocation: true, // Invalid for AIRPORT_PICKUP
+          flightNumber: "BA74",
+        };
+
+        // Validation should throw before reaching controller
+        expect(() => validateBookingInput(dto, true)).toThrow(BookingValidationException);
+      });
+    });
+  });
+});

--- a/src/modules/booking/booking.controller.ts
+++ b/src/modules/booking/booking.controller.ts
@@ -1,0 +1,42 @@
+import { Controller, HttpCode, HttpStatus, Post, UseGuards } from "@nestjs/common";
+import { CurrentUser } from "../auth/decorators/current-user.decorator";
+import { OptionalSessionGuard } from "../auth/guards/optional-session.guard";
+import type { AuthSession } from "../auth/guards/session.guard";
+import type { CreateBookingResponse } from "./booking.interface";
+import { BookingCreationService } from "./booking-creation.service";
+import { ValidatedBookingBody } from "./decorators/validated-booking-body.decorator";
+import type { CreateBookingInput } from "./dto/create-booking.dto";
+
+/**
+ * Controller for booking-related API endpoints.
+ *
+ * Supports both authenticated users and guest bookings on the same endpoint.
+ * The OptionalSessionGuard makes the session optional - if a valid session exists,
+ * the user is attached to the request; otherwise, the request proceeds as a guest.
+ */
+@Controller("api/bookings")
+export class BookingController {
+  constructor(private readonly bookingCreationService: BookingCreationService) {}
+
+  /**
+   * Create a new booking.
+   *
+   * Supports both authenticated users and guests:
+   * - Authenticated users: session is validated, user info from profile
+   * - Guests: no session required, must provide guestEmail, guestName, guestPhone
+   *
+   * The @ValidatedBookingBody decorator automatically selects the correct schema
+   * (createBookingSchema vs createGuestBookingSchema) based on authentication status.
+   *
+   * @returns Booking ID and checkout URL for payment
+   */
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @UseGuards(OptionalSessionGuard)
+  async createBooking(
+    @ValidatedBookingBody() booking: CreateBookingInput,
+    @CurrentUser() sessionUser: AuthSession["user"] | null,
+  ): Promise<CreateBookingResponse> {
+    return this.bookingCreationService.createBooking(booking, sessionUser);
+  }
+}

--- a/src/modules/booking/booking.interface.ts
+++ b/src/modules/booking/booking.interface.ts
@@ -1,4 +1,4 @@
-import type { BookingStatus, BookingType, Prisma } from "@prisma/client";
+import type { BookingType, Prisma } from "@prisma/client";
 import type { Decimal } from "@prisma/client/runtime/library";
 import type { CarPricing } from "./booking-calculation.interface";
 import type { CreateBookingInput } from "./dto/create-booking.dto";
@@ -74,10 +74,7 @@ export interface CustomerDetails {
 
 export interface CreateBookingResponse {
   bookingId: string;
-  bookingReference: string;
   checkoutUrl: string;
-  totalAmount: string;
-  status: BookingStatus;
 }
 
 export type BookingApiResponse = Prisma.BookingGetPayload<{

--- a/src/modules/booking/booking.interface.ts
+++ b/src/modules/booking/booking.interface.ts
@@ -1,26 +1,6 @@
 import type { BookingType, Prisma } from "@prisma/client";
 import type { Decimal } from "@prisma/client/runtime/library";
 import type { CarPricing } from "./booking-calculation.interface";
-import type { CreateBookingInput } from "./dto/create-booking.dto";
-
-/**
- * Input for booking creation with optional user context.
- */
-export interface BookingCreationInput {
-  /** Booking details from the request */
-  booking: CreateBookingInput;
-  /** Authenticated user info (null for guest bookings) */
-  user: {
-    id: string;
-    email: string;
-    name: string | null;
-    phoneNumber: string | null;
-    /** User's referrer ID (if they signed up via referral) */
-    referredByUserId: string | null;
-    /** Whether the user has used their referral discount */
-    referralDiscountUsed: boolean;
-  } | null;
-}
 
 /**
  * Car data with pricing for booking creation.

--- a/src/modules/booking/booking.module.ts
+++ b/src/modules/booking/booking.module.ts
@@ -1,9 +1,11 @@
 import { Module } from "@nestjs/common";
+import { AuthModule } from "../auth/auth.module";
 import { FlightAwareModule } from "../flightaware/flightaware.module";
 import { FlutterwaveModule } from "../flutterwave/flutterwave.module";
 import { MapsModule } from "../maps/maps.module";
 import { NotificationModule } from "../notification/notification.module";
 import { RatesModule } from "../rates/rates.module";
+import { BookingController } from "./booking.controller";
 import { BookingCalculationService } from "./booking-calculation.service";
 import { BookingConfirmationService } from "./booking-confirmation.service";
 import { BookingCreationService } from "./booking-creation.service";
@@ -11,7 +13,15 @@ import { BookingLegService } from "./booking-leg.service";
 import { BookingValidationService } from "./booking-validation.service";
 
 @Module({
-  imports: [NotificationModule, RatesModule, FlutterwaveModule, FlightAwareModule, MapsModule],
+  imports: [
+    AuthModule,
+    NotificationModule,
+    RatesModule,
+    FlutterwaveModule,
+    FlightAwareModule,
+    MapsModule,
+  ],
+  controllers: [BookingController],
   providers: [
     BookingConfirmationService,
     BookingLegService,

--- a/src/modules/booking/decorators/validated-booking-body.decorator.ts
+++ b/src/modules/booking/decorators/validated-booking-body.decorator.ts
@@ -1,0 +1,48 @@
+import { createParamDecorator, type ExecutionContext } from "@nestjs/common";
+import type { Request } from "express";
+import { AUTH_SESSION_KEY, type AuthSession } from "../../auth/guards/session.guard";
+import {
+  type CreateBookingInput,
+  createBookingSchema,
+  createGuestBookingSchema,
+} from "../dto/create-booking.dto";
+import { BookingZodValidationPipe } from "../pipes/zod-validation.pipe";
+
+// Extend Express Request type to include custom properties from guards
+interface RequestWithAuthSession extends Request {
+  [AUTH_SESSION_KEY]?: AuthSession;
+}
+
+// Reuse pipe instances to avoid creating new objects on every request
+const authenticatedPipe = new BookingZodValidationPipe(createBookingSchema);
+const guestPipe = new BookingZodValidationPipe(createGuestBookingSchema);
+
+/**
+ * Custom parameter decorator that validates booking input with the appropriate schema
+ * based on authentication status.
+ *
+ * Usage:
+ * ```typescript
+ * @Post()
+ * @UseGuards(OptionalSessionGuard)
+ * async createBooking(
+ *   @ValidatedBookingBody() booking: CreateBookingInput,
+ *   @CurrentUser() user: AuthSession["user"] | null,
+ * ) { ... }
+ * ```
+ */
+export const ValidatedBookingBody = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext): CreateBookingInput => {
+    const request = ctx.switchToHttp().getRequest<RequestWithAuthSession>();
+
+    // Check if user is authenticated (attached by OptionalSessionGuard via AUTH_SESSION_KEY)
+    const authSession = request[AUTH_SESSION_KEY];
+    const isAuthenticated = authSession !== null && authSession !== undefined;
+
+    // Select appropriate pipe based on authentication status
+    const pipe = isAuthenticated ? authenticatedPipe : guestPipe;
+
+    // Validate and transform
+    return pipe.transform(request.body);
+  },
+);

--- a/src/modules/booking/pipes/zod-validation.pipe.ts
+++ b/src/modules/booking/pipes/zod-validation.pipe.ts
@@ -1,0 +1,29 @@
+import { PipeTransform } from "@nestjs/common";
+import type { z } from "zod";
+import { BookingValidationException } from "../booking.error";
+
+/**
+ * Zod validation pipe for booking endpoints.
+ *
+ * Transforms Zod validation errors into BookingValidationException
+ * with RFC 7807 Problem Details format.
+ */
+export class BookingZodValidationPipe<T> implements PipeTransform<unknown, T> {
+  constructor(private readonly schema: z.ZodType<T>) {}
+
+  transform(value: unknown): T {
+    const result = this.schema.safeParse(value);
+
+    if (!result.success) {
+      const errors = result.error.issues.map((issue) => ({
+        field: issue.path.join("."),
+        code: issue.code,
+        message: issue.message,
+      }));
+
+      throw new BookingValidationException(errors);
+    }
+
+    return result.data;
+  }
+}

--- a/test/bookings.e2e-spec.ts
+++ b/test/bookings.e2e-spec.ts
@@ -1,0 +1,298 @@
+import { HttpStatus, type INestApplication } from "@nestjs/common";
+import { HttpAdapterHost } from "@nestjs/core";
+import { Test, type TestingModule } from "@nestjs/testing";
+import request from "supertest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppModule } from "../src/app.module";
+import { GlobalExceptionFilter } from "../src/common/filters/global-exception.filter";
+import { AuthEmailService } from "../src/modules/auth/auth-email.service";
+import { DatabaseService } from "../src/modules/database/database.service";
+import { FlutterwaveService } from "../src/modules/flutterwave/flutterwave.service";
+import { MapsService } from "../src/modules/maps/maps.service";
+import { TestDataFactory, uniqueEmail } from "./helpers";
+
+describe("Bookings E2E Tests", () => {
+  let app: INestApplication;
+  let databaseService: DatabaseService;
+  let flutterwaveService: FlutterwaveService;
+  let mapsService: MapsService;
+  let factory: TestDataFactory;
+
+  // Test data
+  let testUserCookie: string;
+  let testCarId: string;
+
+  beforeAll(async () => {
+    const mockSendOTPEmail = vi.fn().mockResolvedValue(undefined);
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(AuthEmailService)
+      .useValue({ sendOTPEmail: mockSendOTPEmail })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+
+    const httpAdapterHost = app.get(HttpAdapterHost);
+    app.useGlobalFilters(new GlobalExceptionFilter(httpAdapterHost));
+
+    databaseService = app.get(DatabaseService);
+    flutterwaveService = app.get(FlutterwaveService);
+    mapsService = app.get(MapsService);
+    factory = new TestDataFactory(databaseService, app);
+
+    await app.init();
+
+    // Create platform rates required for booking calculations
+    await factory.createPlatformRates();
+
+    // Create test user
+    const testEmail = uniqueEmail("booking-test-user");
+    const testResult = await factory.authenticateAndGetUser(testEmail, "user");
+    testUserCookie = testResult.cookie;
+
+    // Create fleet owner and car
+    const fleetOwner = await factory.createFleetOwner();
+    const car = await factory.createCar(fleetOwner.id);
+    testCarId = car.id;
+  });
+
+  beforeEach(async () => {
+    await factory.clearRateLimits();
+    vi.restoreAllMocks();
+
+    // Mock payment intent creation for all booking tests
+    vi.spyOn(flutterwaveService, "createPaymentIntent").mockResolvedValue({
+      paymentIntentId: "flw_pi_123",
+      checkoutUrl: "https://checkout.flutterwave.com/pay/abc123",
+    });
+
+    // Mock maps service for any airport-related calculations
+    vi.spyOn(mapsService, "calculateAirportTripDuration").mockResolvedValue({
+      durationMinutes: 45,
+      distanceMeters: 25000,
+    });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe("POST /api/bookings", () => {
+    const createValidBookingPayload = (carId: string) => ({
+      carId,
+      startDate: new Date(Date.now() + 86400000 * 2).toISOString(), // 2 days from now
+      endDate: new Date(Date.now() + 86400000 * 2 + 43200000).toISOString(), // 2 days + 12 hours
+      pickupAddress: "123 Main St, Lagos",
+      bookingType: "DAY",
+      pickupTime: "9:00 AM",
+      sameLocation: true,
+      includeSecurityDetail: false,
+      requiresFullTank: false,
+      useCredits: 0,
+      // Note: clientTotalAmount is optional - omitting it skips price validation
+    });
+
+    const createGuestBookingPayload = (carId: string) => ({
+      ...createValidBookingPayload(carId),
+      guestEmail: "guest@example.com",
+      guestName: "Guest User",
+      guestPhone: "08012345678",
+    });
+
+    describe("Authenticated User Bookings", () => {
+      it("should create a booking for authenticated user", async () => {
+        const payload = createValidBookingPayload(testCarId);
+
+        const response = await request(app.getHttpServer())
+          .post("/api/bookings")
+          .set("Cookie", testUserCookie)
+          .send(payload);
+
+        expect(response.status).toBe(HttpStatus.CREATED);
+        expect(response.body).toHaveProperty("bookingId");
+        expect(response.body).toHaveProperty("checkoutUrl");
+        expect(response.body.checkoutUrl).toContain("checkout.flutterwave.com");
+      });
+
+      it("should return 400 for invalid booking type", async () => {
+        const payload = {
+          ...createValidBookingPayload(testCarId),
+          bookingType: "INVALID_TYPE",
+        };
+
+        const response = await request(app.getHttpServer())
+          .post("/api/bookings")
+          .set("Cookie", testUserCookie)
+          .send(payload);
+
+        expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+        expect(response.body.message).toContain("Validation");
+      });
+
+      it("should return 400 for missing required fields", async () => {
+        const payload = {
+          carId: testCarId,
+          // Missing required fields
+        };
+
+        const response = await request(app.getHttpServer())
+          .post("/api/bookings")
+          .set("Cookie", testUserCookie)
+          .send(payload);
+
+        expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+        expect(response.body.message).toContain("Validation");
+      });
+
+      it("should return 404 for non-existent car", async () => {
+        const payload = createValidBookingPayload("non-existent-car-id");
+
+        const response = await request(app.getHttpServer())
+          .post("/api/bookings")
+          .set("Cookie", testUserCookie)
+          .send(payload);
+
+        expect(response.status).toBe(HttpStatus.NOT_FOUND);
+      });
+    });
+
+    describe("Guest Bookings", () => {
+      it("should create a booking for guest user", async () => {
+        const payload = createGuestBookingPayload(testCarId);
+
+        const response = await request(app.getHttpServer())
+          .post("/api/bookings")
+          .send(payload);
+
+        expect(response.status).toBe(HttpStatus.CREATED);
+        expect(response.body).toHaveProperty("bookingId");
+        expect(response.body).toHaveProperty("checkoutUrl");
+      });
+
+      it("should return 400 when guest fields are missing without authentication", async () => {
+        const payload = createValidBookingPayload(testCarId);
+        // Not authenticated and no guest fields
+
+        const response = await request(app.getHttpServer())
+          .post("/api/bookings")
+          .send(payload);
+
+        expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+      });
+
+      it("should return 400 for invalid guest email", async () => {
+        const payload = {
+          ...createGuestBookingPayload(testCarId),
+          guestEmail: "not-an-email",
+        };
+
+        const response = await request(app.getHttpServer())
+          .post("/api/bookings")
+          .send(payload);
+
+        expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+        expect(response.body.message).toContain("Validation");
+      });
+
+      it("should return 400 for invalid guest phone", async () => {
+        const payload = {
+          ...createGuestBookingPayload(testCarId),
+          guestPhone: "123", // Too short
+        };
+
+        const response = await request(app.getHttpServer())
+          .post("/api/bookings")
+          .send(payload);
+
+        expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+        expect(response.body.message).toContain("Validation");
+      });
+    });
+
+    describe("Validation", () => {
+      it("should reject booking with end date before start date", async () => {
+        const now = Date.now();
+        const payload = {
+          ...createValidBookingPayload(testCarId),
+          startDate: new Date(now + 86400000 * 3).toISOString(),
+          endDate: new Date(now + 86400000 * 2).toISOString(), // Before start
+        };
+
+        const response = await request(app.getHttpServer())
+          .post("/api/bookings")
+          .set("Cookie", testUserCookie)
+          .send(payload);
+
+        expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+      });
+
+      it("should reject booking with dates in the past", async () => {
+        const payload = {
+          ...createValidBookingPayload(testCarId),
+          startDate: new Date(Date.now() - 86400000).toISOString(), // Yesterday
+          endDate: new Date().toISOString(),
+        };
+
+        const response = await request(app.getHttpServer())
+          .post("/api/bookings")
+          .set("Cookie", testUserCookie)
+          .send(payload);
+
+        expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+      });
+
+      it("should require hoursBooked for HOURLY booking type", async () => {
+        const payload = {
+          ...createValidBookingPayload(testCarId),
+          bookingType: "HOURLY",
+          // Missing hoursBooked
+        };
+
+        const response = await request(app.getHttpServer())
+          .post("/api/bookings")
+          .set("Cookie", testUserCookie)
+          .send(payload);
+
+        expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+      });
+    });
+
+    describe("Payment Integration", () => {
+      it("should return valid checkout URL on success", async () => {
+        const mockCheckoutUrl = "https://checkout.flutterwave.com/pay/unique123";
+        vi.spyOn(flutterwaveService, "createPaymentIntent").mockResolvedValueOnce({
+          paymentIntentId: "flw_pi_unique",
+          checkoutUrl: mockCheckoutUrl,
+        });
+
+        const payload = createValidBookingPayload(testCarId);
+
+        const response = await request(app.getHttpServer())
+          .post("/api/bookings")
+          .set("Cookie", testUserCookie)
+          .send(payload);
+
+        expect(response.status).toBe(HttpStatus.CREATED);
+        expect(response.body.checkoutUrl).toBe(mockCheckoutUrl);
+      });
+
+      it("should handle payment intent creation failure gracefully", async () => {
+        vi.spyOn(flutterwaveService, "createPaymentIntent").mockRejectedValueOnce(
+          new Error("Payment provider unavailable"),
+        );
+
+        const payload = createValidBookingPayload(testCarId);
+
+        const response = await request(app.getHttpServer())
+          .post("/api/bookings")
+          .set("Cookie", testUserCookie)
+          .send(payload);
+
+        // Should return appropriate error status
+        expect(response.status).toBeGreaterThanOrEqual(HttpStatus.BAD_REQUEST);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Implement PR 15b: BookingController + Auth Guards

- Add OptionalSessionGuard that allows both authenticated and guest requests
- Create BookingController with POST /api/bookings endpoint
- Add ValidatedBookingBody decorator for schema-based validation
- Add BookingZodValidationPipe for RFC 7807 error formatting
- Simplify CreateBookingResponse to return only bookingId and checkoutUrl
- Update BookingCreationService to accept (booking, sessionUser) params
- Update test fixtures to use createUser() and createSessionUser() helpers
- Add createPlatformRates() helper for e2e test setup
- Add e2e tests for booking creation flow

The same endpoint supports both authenticated users and guests:
- Authenticated: session validated, user info from profile
- Guests: must provide guestEmail, guestName, guestPhone

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches booking creation flow and session/guest handling, including referral eligibility checks and request validation, so subtle behavior changes could affect who can book and what price/discount is applied.
> 
> **Overview**
> Adds a new `POST /api/bookings` endpoint that supports *both authenticated and guest bookings* using `OptionalSessionGuard` plus a `@ValidatedBookingBody` decorator that selects the correct Zod schema and maps validation errors to `BookingValidationException` via `BookingZodValidationPipe`.
> 
> Refactors `BookingCreationService.createBooking` to accept `(booking, sessionUser)` and to fetch missing user fields (phone + referral status) from the DB instead of relying on request-provided user context; referral discount is now prechecked via DB lookup and still transaction-verified, and `CreateBookingResponse` is simplified to return only `bookingId` and `checkoutUrl`.
> 
> Hardens auth cookie handling by using `__Host-` prefix + required cookie attributes when `secureCookies` is enabled, and wires `OptionalSessionGuard` into `AuthModule`/`BookingModule`. Adds unit tests for the new guard/controller and new e2e coverage for booking creation, plus minor test fixture updates (e.g., platform rates seeding, car approval status) and Sonar coverage exclusions for `*.decorators.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a58ce6509bed083949a3ce44e29c2e39c8e4298. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->