### PR TITLE
fix(auth): fix Better Auth endpoint routing and refactor tests

### DIFF
--- a/src/config/env.config.ts
+++ b/src/config/env.config.ts
@@ -67,8 +67,8 @@ export const envSchema = z.object({
   GOOGLE_DISTANCE_MATRIX_API_KEY: z.string().min(1, "GOOGLE_DISTANCE_MATRIX_API_KEY is required"),
 
   // Auth configuration (optional - only required when AuthModule is used)
-  SESSION_SECRET: z.string().min(32, "SESSION_SECRET must be at least 32 characters").optional(),
-  AUTH_BASE_URL: z.url("AUTH_BASE_URL must be a valid URL").optional(),
+  SESSION_SECRET: z.string().min(32, "SESSION_SECRET must be at least 32 characters"),
+  AUTH_BASE_URL: z.url("AUTH_BASE_URL must be a valid URL"),
   TRUSTED_ORIGINS: z
     .string()
     .min(1, "TRUSTED_ORIGINS is required")
@@ -82,8 +82,7 @@ export const envSchema = z.object({
       z
         .array(z.url("Each TRUSTED_ORIGIN must be a valid URL"))
         .min(1, "At least one valid TRUSTED_ORIGIN is required"),
-    )
-    .optional(),
+    ),
 });
 
 export type EnvConfig = z.infer<typeof envSchema>;

--- a/src/modules/auth/auth-email.service.ts
+++ b/src/modules/auth/auth-email.service.ts
@@ -1,4 +1,6 @@
 import { Injectable, Logger } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import type { EnvConfig } from "../../config/env.config";
 import { maskEmail } from "../../shared/helper";
 import { renderAuthOTPEmail } from "../../templates/emails";
 import { EmailService } from "../notification/email.service";
@@ -7,10 +9,22 @@ import { EmailService } from "../notification/email.service";
 export class AuthEmailService {
   private readonly logger = new Logger(AuthEmailService.name);
 
-  constructor(private readonly emailService: EmailService) {}
+  constructor(
+    private readonly emailService: EmailService,
+    private readonly configService: ConfigService<EnvConfig>,
+  ) {}
 
   async sendOTPEmail(email: string, otp: string): Promise<void> {
-    const maskedEmail = maskEmail(email);
+    const nodeEnv = this.configService.get("NODE_ENV", { infer: true });
+    console.log({ nodeEnv });
+    const isDev = nodeEnv === "development";
+    const maskedEmail = isDev ? email : maskEmail(email);
+
+    if (nodeEnv === "development") {
+      this.logger.log(`Dev OTP for ${maskedEmail}: ${otp}`);
+      return;
+    }
+
     this.logger.log(`Sending OTP email to ${maskedEmail}`);
 
     const html = await renderAuthOTPEmail({ otp });

--- a/src/modules/auth/auth-email.service.ts
+++ b/src/modules/auth/auth-email.service.ts
@@ -16,11 +16,10 @@ export class AuthEmailService {
 
   async sendOTPEmail(email: string, otp: string): Promise<void> {
     const nodeEnv = this.configService.get("NODE_ENV", { infer: true });
-    console.log({ nodeEnv });
-    const isDev = nodeEnv === "development";
-    const maskedEmail = isDev ? email : maskEmail(email);
+    const isDevelopment = nodeEnv === "development";
+    const maskedEmail = isDevelopment ? email : maskEmail(email);
 
-    if (nodeEnv === "development") {
+    if (isDevelopment) {
       this.logger.log(`Dev OTP for ${maskedEmail}: ${otp}`);
       return;
     }

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -40,14 +40,6 @@ export class AuthService implements OnModuleInit {
     const trustedOrigins = this.configService.get("TRUSTED_ORIGINS", { infer: true });
     const nodeEnv = this.configService.get("NODE_ENV", { infer: true });
 
-    if (!sessionSecret || !authBaseUrl || !trustedOrigins?.length) {
-      this.logger.warn(
-        "Auth configuration incomplete. AuthService will not be initialized. " +
-          "Set SESSION_SECRET, AUTH_BASE_URL, and TRUSTED_ORIGINS to enable auth.",
-      );
-      return;
-    }
-
     this.trustedOrigins = trustedOrigins;
 
     this._auth = createAuth({
@@ -70,11 +62,6 @@ export class AuthService implements OnModuleInit {
   }
 
   get auth(): Auth {
-    if (!this._auth) {
-      throw new Error(
-        "Auth service not initialized. Ensure SESSION_SECRET, AUTH_BASE_URL, and TRUSTED_ORIGINS are configured.",
-      );
-    }
     return this._auth;
   }
 
@@ -103,7 +90,6 @@ export class AuthService implements OnModuleInit {
     clientType,
     referer,
   }: ValidateRoleForClientParams): boolean {
-    // Mobile app: only user role allowed
     if (clientType === MOBILE) {
       return role === USER;
     }

--- a/test/bookings.e2e-spec.ts
+++ b/test/bookings.e2e-spec.ts
@@ -162,9 +162,7 @@ describe("Bookings E2E Tests", () => {
       it("should create a booking for guest user", async () => {
         const payload = createGuestBookingPayload(testCarId);
 
-        const response = await request(app.getHttpServer())
-          .post("/api/bookings")
-          .send(payload);
+        const response = await request(app.getHttpServer()).post("/api/bookings").send(payload);
 
         expect(response.status).toBe(HttpStatus.CREATED);
         expect(response.body).toHaveProperty("bookingId");
@@ -175,9 +173,7 @@ describe("Bookings E2E Tests", () => {
         const payload = createValidBookingPayload(testCarId);
         // Not authenticated and no guest fields
 
-        const response = await request(app.getHttpServer())
-          .post("/api/bookings")
-          .send(payload);
+        const response = await request(app.getHttpServer()).post("/api/bookings").send(payload);
 
         expect(response.status).toBe(HttpStatus.BAD_REQUEST);
       });
@@ -188,9 +184,7 @@ describe("Bookings E2E Tests", () => {
           guestEmail: "not-an-email",
         };
 
-        const response = await request(app.getHttpServer())
-          .post("/api/bookings")
-          .send(payload);
+        const response = await request(app.getHttpServer()).post("/api/bookings").send(payload);
 
         expect(response.status).toBe(HttpStatus.BAD_REQUEST);
         expect(response.body.message).toContain("Validation");
@@ -202,9 +196,7 @@ describe("Bookings E2E Tests", () => {
           guestPhone: "123", // Too short
         };
 
-        const response = await request(app.getHttpServer())
-          .post("/api/bookings")
-          .send(payload);
+        const response = await request(app.getHttpServer()).post("/api/bookings").send(payload);
 
         expect(response.status).toBe(HttpStatus.BAD_REQUEST);
         expect(response.body.message).toContain("Validation");

--- a/test/payments.e2e-spec.ts
+++ b/test/payments.e2e-spec.ts
@@ -18,7 +18,6 @@ describe("Payments E2E Tests", () => {
   let flutterwaveService: FlutterwaveService;
   let factory: TestDataFactory;
 
-  // Test data
   let testUserId: string;
   let testUserCookie: string;
   let otherUserCookie: string;


### PR DESCRIPTION
- Fix Better Auth 404 by normalizing AUTH_BASE_URL (strip path, use basePath)
- Register Better Auth handler as Express middleware in main.ts
- Make auth env vars required (SESSION_SECRET, AUTH_BASE_URL, TRUSTED_ORIGINS)
- Add dev mode OTP logging (skip email sending in development)
- Refactor auth service tests to use shared baseConfig
- Remove redundant auth initialization guard (now enforced at startup)

Fixes auth endpoint returning 404 when AUTH_BASE_URL includes path segment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication initialization assumptions and OTP delivery behavior, so misconfigured environments or unexpected `NODE_ENV` values could break login flows; otherwise changes are localized and well-covered by tests.
> 
> **Overview**
> Auth configuration is tightened by making `SESSION_SECRET`, `AUTH_BASE_URL`, and `TRUSTED_ORIGINS` required environment variables (no longer optional), shifting failure to startup validation instead of runtime.
> 
> `AuthService` no longer conditionally initializes or guards access to `auth`, assuming config is always present, and `AuthEmailService` now **logs OTPs and skips sending emails in `development`**.
> 
> Auth unit tests are refactored to use a shared typed `baseConfig` and updated `ConfigService<EnvConfig>` mocks; a small amount of E2E test code is also reformatted (no behavioral change).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8a47da63c82fdd76160dcccac854b38a56aeacc. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->