### PR TITLE
chore: clean up E2E tests and add SENDER_NAME env variable

### DIFF
--- a/.env.e2e
+++ b/.env.e2e
@@ -27,3 +27,4 @@ HMAC_KEY=flutterwave-webhook-comparison-e2e
 
 FLIGHTAWARE_API_KEY=flightaware-api-key
 GOOGLE_DISTANCE_MATRIX_API_KEY=google-mapa-api-key
+SENDER_NAME=Yomide

--- a/src/config/env.config.ts
+++ b/src/config/env.config.ts
@@ -83,6 +83,7 @@ export const envSchema = z.object({
         .array(z.url("Each TRUSTED_ORIGIN must be a valid URL"))
         .min(1, "At least one valid TRUSTED_ORIGIN is required"),
     ),
+  SENDER_NAME: z.string().min(2, "SENDER_NAME is required"),
 });
 
 export type EnvConfig = z.infer<typeof envSchema>;

--- a/src/modules/booking/booking.interface.ts
+++ b/src/modules/booking/booking.interface.ts
@@ -1,4 +1,4 @@
-import type { BookingType, Prisma } from "@prisma/client";
+import type { BookingType } from "@prisma/client";
 import type { Decimal } from "@prisma/client/runtime/library";
 import type { CarPricing } from "./booking-calculation.interface";
 
@@ -57,52 +57,7 @@ export interface CreateBookingResponse {
   checkoutUrl: string;
 }
 
-export type BookingApiResponse = Prisma.BookingGetPayload<{
-  include: {
-    car: {
-      select: {
-        id: true;
-        make: true;
-        model: true;
-        year: true;
-        plateNumber: true;
-        primaryImageUrl: true;
-      };
-    };
-    user: {
-      select: {
-        id: true;
-        name: true;
-        email: true;
-      };
-    };
-    legs: true;
-  };
-}>;
-
-/**
- * Booking financial breakdown for display (all amounts as strings for Decimal precision)
- */
-export interface BookingFinancialsResponse {
-  netTotal: string;
-  securityDetailCost: string;
-  fuelUpgradeCost: string;
-  netTotalWithAddons: string;
-  platformCustomerServiceFeeRatePercent: string;
-  platformCustomerServiceFeeAmount: string;
-  subtotalBeforeDiscounts: string;
-  referralDiscountAmount: string;
-  creditsUsed: string;
-  subtotalAfterDiscounts: string;
-  vatRatePercent: string;
-  vatAmount: string;
-  totalAmount: string;
-  numberOfLegs: number;
-  legPrices: Array<{
-    legDate: string;
-    price: string;
-  }>;
-}
+// export type Booking = Prisma.BookingGetPayload<null>;
 
 /**
  * Booking availability check result

--- a/src/modules/notification/email.service.ts
+++ b/src/modules/notification/email.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { Resend } from "resend";
+import { EnvConfig } from "src/config/env.config";
 import { EmailNotificationData } from "./notification.interface";
 
 @Injectable()
@@ -9,11 +10,11 @@ export class EmailService {
   private readonly resend: Resend;
   private readonly from: string;
 
-  constructor(private readonly configService: ConfigService) {
-    const apiKey = this.configService.get<string>("RESEND_API_KEY");
-    const appName = this.configService.get<string>("APP_NAME");
-    const fromEmail = this.configService.get<string>("RESEND_FROM_EMAIL");
-    const senderName = this.configService.get<string>("SENDER_NAME");
+  constructor(private readonly configService: ConfigService<EnvConfig>) {
+    const apiKey = this.configService.get("RESEND_API_KEY", { infer: true });
+    const appName = this.configService.get("APP_NAME", { infer: true });
+    const fromEmail = this.configService.get("RESEND_FROM_EMAIL", { infer: true });
+    const senderName = this.configService.get("SENDER_NAME", { infer: true });
 
     this.resend = new Resend(apiKey);
     this.from = `${senderName} from ${appName} <${fromEmail}>`;

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -326,7 +326,8 @@ export class TestDataFactory {
         currency: options.currency ?? "NGN",
         status: (options.status ?? "PROCESSING") as PayoutTransactionStatus,
         payoutProviderReference:
-          options.payoutProviderReference ?? `payout-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+          options.payoutProviderReference ??
+          `payout-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
       },
       select: { id: true },
     });

--- a/test/jobs.e2e-spec.ts
+++ b/test/jobs.e2e-spec.ts
@@ -14,7 +14,9 @@ describe("Jobs E2E Tests", () => {
       imports: [AppModule],
     }).compile();
 
-    app = moduleFixture.createNestApplication();
+    app = moduleFixture.createNestApplication({
+      logger: false,
+    });
 
     // Register global exception filter (same as in main.ts)
     const httpAdapterHost = app.get(HttpAdapterHost);

--- a/test/payments.e2e-spec.ts
+++ b/test/payments.e2e-spec.ts
@@ -35,7 +35,9 @@ describe("Payments E2E Tests", () => {
       .useValue({ sendOTPEmail: mockSendOTPEmail })
       .compile();
 
-    app = moduleFixture.createNestApplication();
+    app = moduleFixture.createNestApplication({
+      logger: false,
+    });
 
     const httpAdapterHost = app.get(HttpAdapterHost);
     app.useGlobalFilters(new GlobalExceptionFilter(httpAdapterHost));


### PR DESCRIPTION
- Suppress logger output in E2E tests for cleaner test runs
- Remove debug logging and unnecessary comments from test files
- Add SENDER_NAME to required environment variables
- Clean up test helpers and reduce test boilerplate
- Simplify booking interface and email service code

Reduces test noise and improves maintainability.