### PR TITLE
refactor(flightaware): replace fire-and-forget flight alert with BullMQ queue

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -5,6 +5,8 @@ export const STATUS_UPDATES_QUEUE = "status-updates-queue";
 export const REMINDERS_QUEUE = "reminders-queue";
 export const REFERRAL_QUEUE = "referral-queue";
 export const PAYOUTS_QUEUE = "payouts-queue";
+export const FLIGHT_ALERTS_QUEUE = "flight-alerts-queue";
+export const CREATE_FLIGHT_ALERT_JOB = "create-flight-alert";
 
 export const EVERY_HOUR = "0 * * * *";
 export const CONFIRMED_TO_ACTIVE = "confirmed-to-active";

--- a/src/modules/booking/booking-creation.service.spec.ts
+++ b/src/modules/booking/booking-creation.service.spec.ts
@@ -1,7 +1,9 @@
+import { getQueueToken } from "@nestjs/bullmq";
 import { Test, TestingModule } from "@nestjs/testing";
 import { BookingStatus, PaymentStatus } from "@prisma/client";
 import { Decimal } from "@prisma/client/runtime/library";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FLIGHT_ALERTS_QUEUE } from "../../config/constants";
 import { createBookingFinancials, createCar, createUser } from "../../shared/helper.fixtures";
 import type { AuthSession } from "../auth/guards/session.guard";
 import { DatabaseService } from "../database/database.service";
@@ -143,6 +145,12 @@ describe("BookingCreationService", () => {
           provide: MapsService,
           useValue: {
             calculateAirportTripDuration: vi.fn(),
+          },
+        },
+        {
+          provide: getQueueToken(FLIGHT_ALERTS_QUEUE),
+          useValue: {
+            add: vi.fn(),
           },
         },
       ],

--- a/src/modules/flightaware/flightaware-alert.interface.ts
+++ b/src/modules/flightaware/flightaware-alert.interface.ts
@@ -1,0 +1,6 @@
+export interface FlightAlertJobData {
+  flightId: string;
+  flightNumber: string;
+  flightDate: string; // ISO string (Dates are serialised in Redis)
+  destinationIATA?: string;
+}

--- a/src/modules/flightaware/flightaware-alert.processor.spec.ts
+++ b/src/modules/flightaware/flightaware-alert.processor.spec.ts
@@ -1,0 +1,122 @@
+import { Logger } from "@nestjs/common";
+import { Test, TestingModule } from "@nestjs/testing";
+import { Job } from "bullmq";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { CREATE_FLIGHT_ALERT_JOB } from "../../config/constants";
+import { FlightAwareService } from "./flightaware.service";
+import type { FlightAlertJobData } from "./flightaware-alert.interface";
+import { FlightAlertProcessor } from "./flightaware-alert.processor";
+
+describe("FlightAlertProcessor", () => {
+  let processor: FlightAlertProcessor;
+  let flightAwareService: FlightAwareService;
+
+  beforeAll(() => {
+    Logger.overrideLogger([]);
+  });
+
+  afterAll(() => {
+    Logger.overrideLogger(undefined);
+  });
+
+  const mockJobData: FlightAlertJobData = {
+    flightId: "flight-123",
+    flightNumber: "BA74",
+    flightDate: "2025-12-25T10:00:00.000Z",
+    destinationIATA: "LOS",
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FlightAlertProcessor,
+        {
+          provide: FlightAwareService,
+          useValue: {
+            getOrCreateFlightAlert: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    processor = module.get<FlightAlertProcessor>(FlightAlertProcessor);
+    flightAwareService = module.get<FlightAwareService>(FlightAwareService);
+  });
+
+  it("should be defined", () => {
+    expect(processor).toBeDefined();
+  });
+
+  describe("process", () => {
+    it("should call getOrCreateFlightAlert with correct params", async () => {
+      const job = {
+        id: "job-123",
+        name: CREATE_FLIGHT_ALERT_JOB,
+        data: mockJobData,
+      } as Job<FlightAlertJobData, void, string>;
+
+      vi.mocked(flightAwareService.getOrCreateFlightAlert).mockResolvedValue("alert-456");
+
+      const result = await processor.process(job);
+
+      expect(result).toEqual({ success: true });
+      expect(flightAwareService.getOrCreateFlightAlert).toHaveBeenCalledWith("flight-123", {
+        flightNumber: "BA74",
+        flightDate: new Date("2025-12-25T10:00:00.000Z"),
+        destinationIATA: "LOS",
+      });
+    });
+
+    it("should pass undefined destinationIATA when not provided", async () => {
+      const jobData: FlightAlertJobData = {
+        flightId: "flight-789",
+        flightNumber: "AA100",
+        flightDate: "2025-12-25T10:00:00.000Z",
+      };
+
+      const job = {
+        id: "job-456",
+        name: CREATE_FLIGHT_ALERT_JOB,
+        data: jobData,
+      } as Job<FlightAlertJobData, void, string>;
+
+      vi.mocked(flightAwareService.getOrCreateFlightAlert).mockResolvedValue("alert-789");
+
+      const result = await processor.process(job);
+
+      expect(result).toEqual({ success: true });
+      expect(flightAwareService.getOrCreateFlightAlert).toHaveBeenCalledWith("flight-789", {
+        flightNumber: "AA100",
+        flightDate: new Date("2025-12-25T10:00:00.000Z"),
+        destinationIATA: undefined,
+      });
+    });
+
+    it("should throw error for unknown job type", async () => {
+      const job = {
+        id: "job-123",
+        name: "unknown-job-type",
+        data: mockJobData,
+      } as Job<FlightAlertJobData, void, string>;
+
+      await expect(processor.process(job)).rejects.toThrow(
+        "Unknown flight alert job type: unknown-job-type",
+      );
+      expect(flightAwareService.getOrCreateFlightAlert).not.toHaveBeenCalled();
+    });
+
+    it("should re-throw errors to trigger retry mechanism", async () => {
+      const job = {
+        id: "job-123",
+        name: CREATE_FLIGHT_ALERT_JOB,
+        data: mockJobData,
+      } as Job<FlightAlertJobData, void, string>;
+
+      vi.mocked(flightAwareService.getOrCreateFlightAlert).mockRejectedValue(
+        new Error("FlightAware API rate limit exceeded"),
+      );
+
+      await expect(processor.process(job)).rejects.toThrow("FlightAware API rate limit exceeded");
+    });
+  });
+});

--- a/src/modules/flightaware/flightaware-alert.processor.ts
+++ b/src/modules/flightaware/flightaware-alert.processor.ts
@@ -1,0 +1,95 @@
+import { OnWorkerEvent, Processor, WorkerHost } from "@nestjs/bullmq";
+import { Logger } from "@nestjs/common";
+import { Job } from "bullmq";
+import { CREATE_FLIGHT_ALERT_JOB, FLIGHT_ALERTS_QUEUE } from "../../config/constants";
+import { FlightAwareService } from "./flightaware.service";
+import type { FlightAlertJobData } from "./flightaware-alert.interface";
+
+@Processor(FLIGHT_ALERTS_QUEUE)
+export class FlightAlertProcessor extends WorkerHost {
+  private readonly logger = new Logger(FlightAlertProcessor.name);
+
+  constructor(private readonly flightAwareService: FlightAwareService) {
+    super();
+  }
+
+  async process(job: Job<FlightAlertJobData, void, string>): Promise<{ success: boolean }> {
+    this.logger.log(`Processing flight alert job: ${job.name}`, {
+      jobId: job.id,
+      flightId: job.data.flightId,
+      flightNumber: job.data.flightNumber,
+    });
+
+    try {
+      if (job.name === CREATE_FLIGHT_ALERT_JOB) {
+        const alertId = await this.flightAwareService.getOrCreateFlightAlert(job.data.flightId, {
+          flightNumber: job.data.flightNumber,
+          flightDate: new Date(job.data.flightDate),
+          destinationIATA: job.data.destinationIATA,
+        });
+
+        this.logger.log("Flight alert created successfully", {
+          flightId: job.data.flightId,
+          alertId,
+        });
+
+        return { success: true };
+      }
+
+      throw new Error(`Unknown flight alert job type: ${job.name}`);
+    } catch (error) {
+      this.logger.error(`Failed to process ${job.name} job:`, {
+        jobId: job.id,
+        flightId: job.data.flightId,
+        flightNumber: job.data.flightNumber,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error; // Re-throw to trigger retry mechanism
+    }
+  }
+
+  @OnWorkerEvent("completed")
+  onCompleted(job: Job<FlightAlertJobData>): void {
+    const duration = job.finishedOn && job.processedOn ? job.finishedOn - job.processedOn : "N/A";
+    this.logger.log(`Job completed: ${job.name} [${job.id}] - Duration: ${duration}ms`, {
+      flightId: job.data.flightId,
+    });
+  }
+
+  @OnWorkerEvent("failed")
+  onFailed(job: Job<FlightAlertJobData> | undefined, error: Error): void {
+    if (!job) {
+      this.logger.error("Job failed with no job context", { error: error.message });
+      return;
+    }
+
+    this.logger.error(`Job failed: ${job.name} [${job.id}]`, {
+      flightId: job.data.flightId,
+      flightNumber: job.data.flightNumber,
+      error: error.message,
+      stack: error.stack,
+      attempts: job.attemptsMade,
+      maxAttempts: job.opts.attempts,
+    });
+  }
+
+  @OnWorkerEvent("active")
+  onActive(job: Job<FlightAlertJobData>): void {
+    this.logger.log(`Job started: ${job.name} [${job.id}] - Attempt ${job.attemptsMade + 1}`, {
+      flightId: job.data.flightId,
+    });
+  }
+
+  @OnWorkerEvent("stalled")
+  onStalled(jobId: string): void {
+    this.logger.warn(`Job stalled: ${jobId}`);
+  }
+
+  @OnWorkerEvent("progress")
+  onProgress(job: Job<FlightAlertJobData>, progress: number | object): void {
+    this.logger.debug(`Job progress: ${job.name} [${job.id}]`, {
+      flightId: job.data.flightId,
+      progress,
+    });
+  }
+}

--- a/src/modules/flightaware/flightaware.module.ts
+++ b/src/modules/flightaware/flightaware.module.ts
@@ -1,11 +1,35 @@
+import { BullMQAdapter } from "@bull-board/api/bullMQAdapter";
+import { BullBoardModule } from "@bull-board/nestjs";
+import { BullModule } from "@nestjs/bullmq";
 import { Module } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
+import { FLIGHT_ALERTS_QUEUE } from "../../config/constants";
 import { DatabaseModule } from "../database/database.module";
 import { FlightAwareService } from "./flightaware.service";
+import { FlightAlertProcessor } from "./flightaware-alert.processor";
 
 @Module({
-  imports: [ConfigModule, DatabaseModule],
-  providers: [FlightAwareService],
-  exports: [FlightAwareService],
+  imports: [
+    ConfigModule,
+    DatabaseModule,
+    BullModule.registerQueue({
+      name: FLIGHT_ALERTS_QUEUE,
+      defaultJobOptions: {
+        attempts: 3,
+        backoff: {
+          type: "exponential",
+          delay: 5000,
+        },
+        removeOnComplete: 100,
+        removeOnFail: 50,
+      },
+    }),
+    BullBoardModule.forFeature({
+      name: FLIGHT_ALERTS_QUEUE,
+      adapter: BullMQAdapter,
+    }),
+  ],
+  providers: [FlightAwareService, FlightAlertProcessor],
+  exports: [FlightAwareService, BullModule],
 })
 export class FlightAwareModule {}


### PR DESCRIPTION
## Summary

- Replace fire-and-forget promise pattern in `BookingCreationService.createFlightAlertAsync` with a BullMQ queue (`flight-alerts-queue`)
- Add `FlightAlertProcessor` that calls `getOrCreateFlightAlert` with automatic retries (3 attempts, exponential backoff at 5s)
- Register queue in `FlightAwareModule` with BullBoard for monitoring at `/queues`
- Use `jobId: flight-alert-{flightRecordId}` for deduplication

## Why

The previous fire-and-forget pattern silently dropped flight alerts if the FlightAware API was temporarily unavailable or the process restarted mid-execution. Since flight alerts involve an external API call + DB transaction for airport pickup bookings, failed alerts directly affect service quality with no recovery path.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new asynchronous job processing for FlightAware alert creation (queue/worker/retry semantics), which can change when and whether alerts are created if the queue or worker configuration is incorrect.
> 
> **Overview**
> **Flight alert creation for airport pickup bookings is refactored from an in-process fire-and-forget promise to a BullMQ-backed workflow.** `BookingCreationService` now enqueues a `CREATE_FLIGHT_ALERT_JOB` on a new `FLIGHT_ALERTS_QUEUE` (with a deterministic `jobId` for dedupe) and logs queueing failures without blocking booking creation.
> 
> **Adds queue infrastructure and processing.** Introduces `FlightAlertProcessor` to consume jobs and call `FlightAwareService.getOrCreateFlightAlert`, and wires the queue into `FlightAwareModule` with retry/backoff defaults plus BullBoard registration. Tests are updated/added to mock the queue in booking creation and to cover processor behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36980eebb69548ec7cc9d65a47b2c1ab3e9c4601. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->