### PR TITLE
feat: add Pino instrumentation for trace correlation

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/auto-instrumentations-node": "^0.69.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.211.0",
+    "@opentelemetry/instrumentation-pino": "^0.57.0",
     "@opentelemetry/resources": "^2.5.0",
     "@opentelemetry/sdk-node": "^0.211.0",
     "@opentelemetry/semantic-conventions": "^1.39.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@opentelemetry/exporter-trace-otlp-http':
         specifier: ^0.211.0
         version: 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-pino':
+        specifier: ^0.57.0
+        version: 0.57.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources':
         specifier: ^2.5.0
         version: 2.5.0(@opentelemetry/api@1.9.0)

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -1,5 +1,6 @@
 import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { PinoInstrumentation } from "@opentelemetry/instrumentation-pino";
 import { resourceFromAttributes } from "@opentelemetry/resources";
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
@@ -48,6 +49,13 @@ const sdk = new NodeSDK({
       // Disable fs instrumentation (too noisy for most apps)
       "@opentelemetry/instrumentation-fs": {
         enabled: false,
+      },
+    }),
+    new PinoInstrumentation({
+      logKeys: {
+        traceId: "trace_id",
+        spanId: "span_id",
+        traceFlags: "trace_flags",
       },
     }),
   ],


### PR DESCRIPTION
Add @opentelemetry/instrumentation-pino to inject trace_id, span_id, and trace_flags into Pino structured logs. This enables correlation between distributed traces and log entries for improved observability.

The instrumentation automatically enriches all Pino log output with OpenTelemetry trace context when tracing is active.