### PR TITLE
feat(security): add Helmet middleware for HTTP security headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "better-auth": "^1.4.18",
     "bullmq": "^5.63.0",
     "date-fns": "^4.1.0",
+    "helmet": "^8.1.0",
     "ioredis": "^5.7.0",
     "nestjs-pino": "^4.5.0",
     "pino-http": "^11.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      helmet:
+        specifier: ^8.1.0
+        version: 8.1.0
       ioredis:
         specifier: ^5.7.0
         version: 5.8.2
@@ -3204,6 +3207,10 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  helmet@8.1.0:
+    resolution: {integrity: sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==}
+    engines: {node: '>=18.0.0'}
 
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
@@ -7969,6 +7976,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  helmet@8.1.0: {}
 
   help-me@5.0.0: {}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { HttpAdapterHost, NestFactory } from "@nestjs/core";
 import type { NestExpressApplication } from "@nestjs/platform-express";
+import type { NextFunction, Request, Response } from "express";
 import helmet from "helmet";
 import { Logger as PinoLogger } from "nestjs-pino";
 import { AppModule } from "./app.module";
@@ -26,6 +27,15 @@ async function bootstrap() {
 
     // Security headers
     app.use(helmet());
+
+    // Bull Board requires inline scripts and styles - apply relaxed CSP
+    app.use("/queues", (_req: Request, res: Response, next: NextFunction) => {
+      res.setHeader(
+        "Content-Security-Policy",
+        "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self'; font-src 'self' data:",
+      );
+      next();
+    });
 
     const configService = app.get(ConfigService<EnvConfig>);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { HttpAdapterHost, NestFactory } from "@nestjs/core";
 import type { NestExpressApplication } from "@nestjs/platform-express";
+import helmet from "helmet";
 import { Logger as PinoLogger } from "nestjs-pino";
 import { AppModule } from "./app.module";
 import { GlobalExceptionFilter } from "./common/filters/global-exception.filter";
@@ -22,6 +23,9 @@ async function bootstrap() {
     // Use Pino logger for all application logging
     // biome-ignore lint/correctness/useHookAtTopLevel: <nestjs hook, not react>
     app.useLogger(app.get(PinoLogger));
+
+    // Security headers
+    app.use(helmet());
 
     const configService = app.get(ConfigService<EnvConfig>);
 


### PR DESCRIPTION
Add helmet package to set secure HTTP headers, including Content-Security-Policy, Strict-Transport-Security, X-Frame-Options, and other protections against common web vulnerabilities.

Use a simple middleware for /queues that overwrites the CSP header with a relaxed policy allowing 'unsafe-inline' for scripts and styles, because calling helmet() with default options applies a restrictive Content-Security-Policy (default-src 'self', no inline scripts/styles) globally. This breaks the Bull Board queue monitoring dashboard served at /queues, which relies on inline scripts and styles to render its React-based UI. This is a well-known incompatibility between Helmet's default CSP and Bull Board. The CSP needs to be relaxed or disabled for the /queues route.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global HTTP response headers and CSP behavior, which can break browsers/embeds or any endpoints relying on inline assets if the policy is too strict or overridden unexpectedly.
> 
> **Overview**
> Adds the `helmet` dependency and enables Helmet middleware in `src/main.ts` to apply standard HTTP security headers across the NestJS app.
> 
> Introduces a route-specific middleware for `/queues` that overrides `Content-Security-Policy` with a relaxed policy (allowing inline scripts/styles) to keep the Bull Board UI functional under the new security headers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 821303442eeaa5df689a2ad73cc737e2870ac391. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->