### PR TITLE
feat(docker): add entrypoint script for automatic database migrations

### DIFF
--- a/.env.e2e
+++ b/.env.e2e
@@ -1,3 +1,5 @@
+NODE_ENV=test
+
 RESEND_API_KEY=test-api-key
 RESEND_FROM_EMAIL=test@example.com
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,6 @@ RUN pnpm install --offline --frozen-lockfile
 # Build the NestJS app (prisma generate runs as part of the build script)
 RUN pnpm build
 
-# Copy prisma CLI before pruning (it's a devDependency needed for migrations)
-RUN cp -R node_modules/prisma /tmp/prisma_cli && \
-    cp -R node_modules/.bin/prisma /tmp/prisma_bin
-
 # Prune dev dependencies for a tiny final image
 RUN pnpm prune --prod --ignore-scripts && cp -R node_modules /tmp/node_modules_prod
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -e
 
-# Run database migrations using prisma CLI installed during Docker build
-# Version matches @prisma/client (6.19.0) and avoids runtime npm registry access
+# Run database migrations using prisma CLI copied from builder
+# Exact version match with @prisma/client is guaranteed
 node_modules/.bin/prisma migrate deploy
 
 # Start the app

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+# Run database migrations using prisma CLI installed during Docker build
+# Version matches @prisma/client (6.19.0) and avoids runtime npm registry access
+node_modules/.bin/prisma migrate deploy
+
+# Start the app
+exec node dist/main

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -e
 
-# Run database migrations using prisma CLI copied from builder
-# Exact version match with @prisma/client is guaranteed
+# Run database migrations using prisma CLI installed during Docker build
+# Version matches @prisma/client (6.19.0) and avoids runtime npm registry access
 node_modules/.bin/prisma migrate deploy
 
 # Start the app

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
         version: 6.0.1(@nestjs/common@11.1.8(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.8)
       '@nestjs/terminus':
         specifier: ^11.0.0
-        version: 11.0.0(@grpc/grpc-js@1.14.1)(@grpc/proto-loader@0.8.0)(@nestjs/common@11.1.8(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.8)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(reflect-metadata@0.1.14)(rxjs@7.8.2)
+        version: 11.0.0(@grpc/grpc-js@1.14.1)(@grpc/proto-loader@0.8.0)(@nestjs/common@11.1.8(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.8)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(reflect-metadata@0.1.14)(rxjs@7.8.2)
       '@nestjs/throttler':
         specifier: ^6.4.0
         version: 6.4.0(@nestjs/common@11.1.8(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.8)(reflect-metadata@0.1.14)
@@ -67,7 +67,7 @@ importers:
         version: 1.39.0
       '@prisma/client':
         specifier: ^6.19.0
-        version: 6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3)
+        version: 6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3)
       '@react-email/components':
         specifier: ^0.3.3
         version: 0.3.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -79,7 +79,7 @@ importers:
         version: 1.13.2
       better-auth:
         specifier: ^1.4.18
-        version: 1.4.18(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.2.4)
+        version: 1.4.18(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.2.4)
       bullmq:
         specifier: ^5.63.0
         version: 5.63.0
@@ -185,7 +185,7 @@ importers:
         version: 13.1.3
       prisma:
         specifier: ^6.19.0
-        version: 6.19.0(magicast@0.3.5)(typescript@5.9.3)
+        version: 6.19.2(magicast@0.3.5)(typescript@5.9.3)
       supertest:
         specifier: ^7.1.4
         version: 7.1.4
@@ -1520,8 +1520,8 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
-  '@prisma/client@6.19.0':
-    resolution: {integrity: sha512-QXFT+N/bva/QI2qoXmjBzL7D6aliPffIwP+81AdTGq0FXDoLxLkWivGMawG8iM5B9BKfxLIXxfWWAF6wbuJU6g==}
+  '@prisma/client@6.19.2':
+    resolution: {integrity: sha512-gR2EMvfK/aTxsuooaDA32D8v+us/8AAet+C3J1cc04SW35FPdZYgLF+iN4NDLUgAaUGTKdAB0CYenu1TAgGdMg==}
     engines: {node: '>=18.18'}
     peerDependencies:
       prisma: '*'
@@ -1532,23 +1532,23 @@ packages:
       typescript:
         optional: true
 
-  '@prisma/config@6.19.0':
-    resolution: {integrity: sha512-zwCayme+NzI/WfrvFEtkFhhOaZb/hI+X8TTjzjJ252VbPxAl2hWHK5NMczmnG9sXck2lsXrxIZuK524E25UNmg==}
+  '@prisma/config@6.19.2':
+    resolution: {integrity: sha512-kadBGDl+aUswv/zZMk9Mx0C8UZs1kjao8H9/JpI4Wh4SHZaM7zkTwiKn/iFLfRg+XtOAo/Z/c6pAYhijKl0nzQ==}
 
-  '@prisma/debug@6.19.0':
-    resolution: {integrity: sha512-8hAdGG7JmxrzFcTzXZajlQCidX0XNkMJkpqtfbLV54wC6LSSX6Vni25W/G+nAANwLnZ2TmwkfIuWetA7jJxJFA==}
+  '@prisma/debug@6.19.2':
+    resolution: {integrity: sha512-lFnEZsLdFLmEVCVNdskLDCL8Uup41GDfU0LUfquw+ercJC8ODTuL0WNKgOKmYxCJVvFwf0OuZBzW99DuWmoH2A==}
 
-  '@prisma/engines-version@6.19.0-26.2ba551f319ab1df4bc874a89965d8b3641056773':
-    resolution: {integrity: sha512-gV7uOBQfAFlWDvPJdQxMT1aSRur3a0EkU/6cfbAC5isV67tKDWUrPauyaHNpB+wN1ebM4A9jn/f4gH+3iHSYSQ==}
+  '@prisma/engines-version@7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7':
+    resolution: {integrity: sha512-03bgb1VD5gvuumNf+7fVGBzfpJPjmqV423l/WxsWk2cNQ42JD0/SsFBPhN6z8iAvdHs07/7ei77SKu7aZfq8bA==}
 
-  '@prisma/engines@6.19.0':
-    resolution: {integrity: sha512-pMRJ+1S6NVdXoB8QJAPIGpKZevFjxhKt0paCkRDTZiczKb7F4yTgRP8M4JdVkpQwmaD4EoJf6qA+p61godDokw==}
+  '@prisma/engines@6.19.2':
+    resolution: {integrity: sha512-TTkJ8r+uk/uqczX40wb+ODG0E0icVsMgwCTyTHXehaEfb0uo80M9g1aW1tEJrxmFHeOZFXdI2sTA1j1AgcHi4A==}
 
-  '@prisma/fetch-engine@6.19.0':
-    resolution: {integrity: sha512-OOx2Lda0DGrZ1rodADT06ZGqHzr7HY7LNMaFE2Vp8dp146uJld58sRuasdX0OiwpHgl8SqDTUKHNUyzEq7pDdQ==}
+  '@prisma/fetch-engine@6.19.2':
+    resolution: {integrity: sha512-h4Ff4Pho+SR1S8XerMCC12X//oY2bG3Iug/fUnudfcXEUnIeRiBdXHFdGlGOgQ3HqKgosTEhkZMvGM9tWtYC+Q==}
 
-  '@prisma/get-platform@6.19.0':
-    resolution: {integrity: sha512-ym85WDO2yDhC3fIXHWYpG3kVMBA49cL1XD2GCsCF8xbwoy2OkDQY44gEbAt2X46IQ4Apq9H6g0Ex1iFfPqEkHA==}
+  '@prisma/get-platform@6.19.2':
+    resolution: {integrity: sha512-PGLr06JUSTqIvztJtAzIxOwtWKtJm5WwOG6xpsgD37Rc84FpfUBGLKz65YpJBGtkRQGXTYEFie7pYALocC3MtA==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -2270,6 +2270,10 @@ packages:
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
+
+  aws-ssl-profiles@1.1.2:
+    resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
+    engines: {node: '>= 6.0.0'}
 
   axios@1.13.2:
     resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
@@ -3131,6 +3135,9 @@ packages:
     resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
     engines: {node: '>=14'}
 
+  generate-function@2.3.1:
+    resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -3337,6 +3344,9 @@ packages:
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
+  is-property@1.0.2:
+    resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
+
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
@@ -3522,6 +3532,10 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru.min@1.1.4:
+    resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
+    engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
+
   luxon@3.7.2:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
     engines: {node: '>=12'}
@@ -3671,6 +3685,14 @@ packages:
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  mysql2@3.15.3:
+    resolution: {integrity: sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==}
+    engines: {node: '>= 8.0'}
+
+  named-placeholders@1.1.6:
+    resolution: {integrity: sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==}
+    engines: {node: '>=8.0.0'}
 
   nan@2.23.1:
     resolution: {integrity: sha512-r7bBUGKzlqk8oPBDYxt6Z0aEdF1G1rwlMcLk8LCOMbOzf0mG+JUfUzG4fIMWwHWP0iyaLWEQZJmtB7nOHEm/qw==}
@@ -3897,8 +3919,8 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  prisma@6.19.0:
-    resolution: {integrity: sha512-F3eX7K+tWpkbhl3l4+VkFtrwJlLXbAM+f9jolgoUZbFcm1DgHZ4cq9AgVEgUym2au5Ad/TDLN8lg83D+M10ycw==}
+  prisma@6.19.2:
+    resolution: {integrity: sha512-XTKeKxtQElcq3U9/jHyxSPgiRgeYDKxWTPOf6NkXA0dNj5j40MfEsZkMbyNpwDWCUv7YBFUl7I2VK/6ALbmhEg==}
     engines: {node: '>=18.18'}
     hasBin: true
     peerDependencies:
@@ -4150,6 +4172,9 @@ packages:
     resolution: {integrity: sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==}
     engines: {node: '>= 18'}
 
+  seq-queue@0.0.5:
+    resolution: {integrity: sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==}
+
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
 
@@ -4233,6 +4258,10 @@ packages:
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+
+  sqlstring@2.3.3:
+    resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
+    engines: {node: '>= 0.6'}
 
   ssh-remote-port-forward@1.0.4:
     resolution: {integrity: sha512-x0LV1eVDwjf1gmG7TTnfqIzf+3VPRz7vrNIjX6oYLbeCrf/PeVY6hkT68Mg+q02qXxQhrLjB0jfgvhevoCRmLQ==}
@@ -5415,7 +5444,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@nestjs/terminus@11.0.0(@grpc/grpc-js@1.14.1)(@grpc/proto-loader@0.8.0)(@nestjs/common@11.1.8(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.8)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(reflect-metadata@0.1.14)(rxjs@7.8.2)':
+  '@nestjs/terminus@11.0.0(@grpc/grpc-js@1.14.1)(@grpc/proto-loader@0.8.0)(@nestjs/common@11.1.8(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.8)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(reflect-metadata@0.1.14)(rxjs@7.8.2)':
     dependencies:
       '@nestjs/common': 11.1.8(reflect-metadata@0.1.14)(rxjs@7.8.2)
       '@nestjs/core': 11.1.8(@nestjs/common@11.1.8(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.8)(reflect-metadata@0.1.14)(rxjs@7.8.2)
@@ -5426,7 +5455,7 @@ snapshots:
     optionalDependencies:
       '@grpc/grpc-js': 1.14.1
       '@grpc/proto-loader': 0.8.0
-      '@prisma/client': 6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3)
+      '@prisma/client': 6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3)
 
   '@nestjs/testing@11.1.8(@nestjs/common@11.1.8(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.8)(@nestjs/platform-express@11.1.8)':
     dependencies:
@@ -6237,12 +6266,12 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3)':
+  '@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3)':
     optionalDependencies:
-      prisma: 6.19.0(magicast@0.3.5)(typescript@5.9.3)
+      prisma: 6.19.2(magicast@0.3.5)(typescript@5.9.3)
       typescript: 5.9.3
 
-  '@prisma/config@6.19.0(magicast@0.3.5)':
+  '@prisma/config@6.19.2(magicast@0.3.5)':
     dependencies:
       c12: 3.1.0(magicast@0.3.5)
       deepmerge-ts: 7.1.5
@@ -6251,26 +6280,26 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@prisma/debug@6.19.0': {}
+  '@prisma/debug@6.19.2': {}
 
-  '@prisma/engines-version@6.19.0-26.2ba551f319ab1df4bc874a89965d8b3641056773': {}
+  '@prisma/engines-version@7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7': {}
 
-  '@prisma/engines@6.19.0':
+  '@prisma/engines@6.19.2':
     dependencies:
-      '@prisma/debug': 6.19.0
-      '@prisma/engines-version': 6.19.0-26.2ba551f319ab1df4bc874a89965d8b3641056773
-      '@prisma/fetch-engine': 6.19.0
-      '@prisma/get-platform': 6.19.0
+      '@prisma/debug': 6.19.2
+      '@prisma/engines-version': 7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7
+      '@prisma/fetch-engine': 6.19.2
+      '@prisma/get-platform': 6.19.2
 
-  '@prisma/fetch-engine@6.19.0':
+  '@prisma/fetch-engine@6.19.2':
     dependencies:
-      '@prisma/debug': 6.19.0
-      '@prisma/engines-version': 6.19.0-26.2ba551f319ab1df4bc874a89965d8b3641056773
-      '@prisma/get-platform': 6.19.0
+      '@prisma/debug': 6.19.2
+      '@prisma/engines-version': 7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7
+      '@prisma/get-platform': 6.19.2
 
-  '@prisma/get-platform@6.19.0':
+  '@prisma/get-platform@6.19.2':
     dependencies:
-      '@prisma/debug': 6.19.0
+      '@prisma/debug': 6.19.2
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -7024,6 +7053,9 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
+  aws-ssl-profiles@1.1.2:
+    optional: true
+
   axios@1.13.2:
     dependencies:
       follow-redirects: 1.15.11
@@ -7081,7 +7113,7 @@ snapshots:
     dependencies:
       tweetnacl: 0.14.5
 
-  better-auth@1.4.18(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.2.4):
+  better-auth@1.4.18(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.2.4):
     dependencies:
       '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.1.12))(jose@6.1.3)(kysely@0.28.10)(nanostores@1.1.0)
       '@better-auth/telemetry': 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.1.12))(jose@6.1.3)(kysely@0.28.10)(nanostores@1.1.0))
@@ -7096,8 +7128,9 @@ snapshots:
       nanostores: 1.1.0
       zod: 4.3.6
     optionalDependencies:
-      '@prisma/client': 6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3)
-      prisma: 6.19.0(magicast@0.3.5)(typescript@5.9.3)
+      '@prisma/client': 6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3)
+      mysql2: 3.15.3
+      prisma: 6.19.2(magicast@0.3.5)(typescript@5.9.3)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       vitest: 3.2.4(@types/node@20.19.24)(@vitest/ui@3.2.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.1)
@@ -7895,6 +7928,11 @@ snapshots:
       - encoding
       - supports-color
 
+  generate-function@2.3.1:
+    dependencies:
+      is-property: 1.0.2
+    optional: true
+
   get-caller-file@2.0.5: {}
 
   get-intrinsic@1.3.0:
@@ -8142,6 +8180,9 @@ snapshots:
 
   is-promise@4.0.0: {}
 
+  is-property@1.0.2:
+    optional: true
+
   is-stream@2.0.1: {}
 
   is-unicode-supported@0.1.0: {}
@@ -8308,6 +8349,9 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru.min@1.1.4:
+    optional: true
+
   luxon@3.7.2: {}
 
   magic-string@0.30.21:
@@ -8432,6 +8476,24 @@ snapshots:
   mute-stream@1.0.0: {}
 
   mute-stream@2.0.0: {}
+
+  mysql2@3.15.3:
+    dependencies:
+      aws-ssl-profiles: 1.1.2
+      denque: 2.1.0
+      generate-function: 2.3.1
+      iconv-lite: 0.7.0
+      long: 5.3.2
+      lru.min: 1.1.4
+      named-placeholders: 1.1.6
+      seq-queue: 0.0.5
+      sqlstring: 2.3.3
+    optional: true
+
+  named-placeholders@1.1.6:
+    dependencies:
+      lru.min: 1.1.4
+    optional: true
 
   nan@2.23.1:
     optional: true
@@ -8661,10 +8723,10 @@ snapshots:
 
   prettier@3.6.2: {}
 
-  prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3):
+  prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3):
     dependencies:
-      '@prisma/config': 6.19.0(magicast@0.3.5)
-      '@prisma/engines': 6.19.0
+      '@prisma/config': 6.19.2(magicast@0.3.5)
+      '@prisma/engines': 6.19.2
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -8963,6 +9025,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  seq-queue@0.0.5:
+    optional: true
+
   serialize-javascript@6.0.2:
     dependencies:
       randombytes: 2.1.0
@@ -9055,6 +9120,9 @@ snapshots:
   split-ca@1.0.1: {}
 
   split2@4.2.0: {}
+
+  sqlstring@2.3.3:
+    optional: true
 
   ssh-remote-port-forward@1.0.4:
     dependencies:

--- a/prisma/migrations/20260206000000_add_missing_schema_elements/migration.sql
+++ b/prisma/migrations/20260206000000_add_missing_schema_elements/migration.sql
@@ -147,9 +147,7 @@ CREATE TABLE "rateLimit" (
 -- CreateIndex Flight
 CREATE UNIQUE INDEX "Flight_alertId_key" ON "Flight"("alertId");
 CREATE UNIQUE INDEX "Flight_flightNumber_flightDate_key" ON "Flight"("flightNumber", "flightDate");
-CREATE INDEX "Flight_flightNumber_flightDate_idx" ON "Flight"("flightNumber", "flightDate");
 CREATE INDEX "Flight_status_idx" ON "Flight"("status");
-CREATE INDEX "Flight_alertId_idx" ON "Flight"("alertId");
 CREATE INDEX "Flight_destinationCodeIATA_flightDate_idx" ON "Flight"("destinationCodeIATA", "flightDate");
 CREATE INDEX "Flight_scheduledArrival_idx" ON "Flight"("scheduledArrival");
 
@@ -177,7 +175,6 @@ CREATE INDEX "Car_serviceTier_vehicleType_idx" ON "Car"("serviceTier", "vehicleT
 -- CreateIndex Session
 CREATE UNIQUE INDEX "session_token_key" ON "session"("token");
 CREATE INDEX "session_userId_idx" ON "session"("userId");
-CREATE INDEX "session_token_idx" ON "session"("token");
 
 -- CreateIndex Verification
 CREATE INDEX "verification_identifier_idx" ON "verification"("identifier");

--- a/prisma/migrations/20260206000000_add_missing_schema_elements/migration.sql
+++ b/prisma/migrations/20260206000000_add_missing_schema_elements/migration.sql
@@ -1,0 +1,209 @@
+-- CreateEnum
+CREATE TYPE "VehicleType" AS ENUM ('SEDAN', 'SUV', 'LUXURY_SEDAN', 'LUXURY_SUV', 'VAN', 'CROSSOVER');
+
+-- CreateEnum
+CREATE TYPE "ServiceTier" AS ENUM ('STANDARD', 'EXECUTIVE', 'LUXURY', 'ULTRA_LUXURY');
+
+-- CreateEnum
+CREATE TYPE "FlightStatus" AS ENUM ('SCHEDULED', 'DEPARTED', 'EN_ROUTE', 'LANDED', 'CANCELLED', 'DIVERTED', 'UNKNOWN');
+
+-- CreateEnum
+CREATE TYPE "FlightDataSource" AS ENUM ('FLIGHTAWARE', 'MANUAL', 'CACHED');
+
+-- AlterEnum (add AIRPORT_PICKUP to BookingType)
+ALTER TYPE "BookingType" ADD VALUE 'AIRPORT_PICKUP';
+
+-- AlterEnum (add LASDRI to DocumentType)
+ALTER TYPE "DocumentType" ADD VALUE 'LASDRI';
+
+-- AlterEnum (add REFUND_ERROR to PaymentAttemptStatus)
+ALTER TYPE "PaymentAttemptStatus" ADD VALUE 'REFUND_ERROR';
+
+-- AlterTable Car (add missing columns)
+ALTER TABLE "Car" ADD COLUMN "airportPickupRate" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "Car" ADD COLUMN "vehicleType" "VehicleType" NOT NULL DEFAULT 'SEDAN';
+ALTER TABLE "Car" ADD COLUMN "serviceTier" "ServiceTier" NOT NULL DEFAULT 'STANDARD';
+ALTER TABLE "Car" ADD COLUMN "passengerCapacity" INTEGER NOT NULL DEFAULT 4;
+
+-- AlterTable User (add missing columns)
+ALTER TABLE "User" ADD COLUMN "emailVerified" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "User" ADD COLUMN "image" TEXT;
+ALTER TABLE "User" ADD COLUMN "isOwnerDriver" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable Flight
+CREATE TABLE "Flight" (
+    "id" TEXT NOT NULL,
+    "flightNumber" TEXT NOT NULL,
+    "flightDate" DATE NOT NULL,
+    "faFlightId" TEXT,
+    "originCode" TEXT NOT NULL,
+    "originCodeIATA" TEXT,
+    "originName" TEXT,
+    "originCity" TEXT,
+    "destinationCode" TEXT NOT NULL,
+    "destinationCodeIATA" TEXT,
+    "destinationName" TEXT,
+    "destinationCity" TEXT,
+    "scheduledDeparture" TIMESTAMP(3),
+    "scheduledArrival" TIMESTAMP(3) NOT NULL,
+    "estimatedDeparture" TIMESTAMP(3),
+    "estimatedArrival" TIMESTAMP(3),
+    "actualDeparture" TIMESTAMP(3),
+    "actualArrival" TIMESTAMP(3),
+    "status" "FlightStatus" NOT NULL DEFAULT 'SCHEDULED',
+    "delayMinutes" INTEGER,
+    "aircraftType" TEXT,
+    "registration" TEXT,
+    "departureGate" TEXT,
+    "arrivalGate" TEXT,
+    "alertId" TEXT,
+    "alertEnabled" BOOLEAN NOT NULL DEFAULT false,
+    "alertCreatedAt" TIMESTAMP(3),
+    "alertDisabledAt" TIMESTAMP(3),
+    "lastUpdated" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "dataSource" "FlightDataSource" NOT NULL DEFAULT 'FLIGHTAWARE',
+    "isLive" BOOLEAN NOT NULL DEFAULT false,
+
+    CONSTRAINT "Flight_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable FlightStatusEvent
+CREATE TABLE "FlightStatusEvent" (
+    "id" TEXT NOT NULL,
+    "flightId" TEXT NOT NULL,
+    "eventType" TEXT NOT NULL,
+    "eventTime" TIMESTAMP(3) NOT NULL,
+    "eventData" JSONB NOT NULL,
+    "oldStatus" "FlightStatus",
+    "newStatus" "FlightStatus",
+    "delayChange" INTEGER,
+    "processed" BOOLEAN NOT NULL DEFAULT false,
+    "notificationsSent" BOOLEAN NOT NULL DEFAULT false,
+    "notifiedUserIds" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "FlightStatusEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable Review
+CREATE TABLE "Review" (
+    "id" TEXT NOT NULL,
+    "bookingId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "overallRating" INTEGER NOT NULL,
+    "carRating" INTEGER NOT NULL,
+    "chauffeurRating" INTEGER NOT NULL,
+    "serviceRating" INTEGER NOT NULL,
+    "comment" TEXT,
+    "isVisible" BOOLEAN NOT NULL DEFAULT true,
+    "moderatedAt" TIMESTAMP(3),
+    "moderatedBy" TEXT,
+    "moderationNotes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Review_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable Session (better-auth)
+CREATE TABLE "session" (
+    "id" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "token" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "ipAddress" TEXT,
+    "userAgent" TEXT,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "session_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable Verification (better-auth)
+CREATE TABLE "verification" (
+    "id" TEXT NOT NULL,
+    "identifier" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "verification_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable RateLimit (better-auth)
+CREATE TABLE "rateLimit" (
+    "id" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "count" INTEGER NOT NULL,
+    "lastRequest" BIGINT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "rateLimit_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex Flight
+CREATE UNIQUE INDEX "Flight_alertId_key" ON "Flight"("alertId");
+CREATE UNIQUE INDEX "Flight_flightNumber_flightDate_key" ON "Flight"("flightNumber", "flightDate");
+CREATE INDEX "Flight_flightNumber_flightDate_idx" ON "Flight"("flightNumber", "flightDate");
+CREATE INDEX "Flight_status_idx" ON "Flight"("status");
+CREATE INDEX "Flight_alertId_idx" ON "Flight"("alertId");
+CREATE INDEX "Flight_destinationCodeIATA_flightDate_idx" ON "Flight"("destinationCodeIATA", "flightDate");
+CREATE INDEX "Flight_scheduledArrival_idx" ON "Flight"("scheduledArrival");
+
+-- CreateIndex FlightStatusEvent
+CREATE INDEX "FlightStatusEvent_flightId_eventTime_idx" ON "FlightStatusEvent"("flightId", "eventTime");
+CREATE INDEX "FlightStatusEvent_eventType_idx" ON "FlightStatusEvent"("eventType");
+CREATE INDEX "FlightStatusEvent_processed_idx" ON "FlightStatusEvent"("processed");
+
+-- CreateIndex Review
+CREATE UNIQUE INDEX "Review_bookingId_key" ON "Review"("bookingId");
+CREATE INDEX "Review_userId_idx" ON "Review"("userId");
+CREATE INDEX "Review_overallRating_idx" ON "Review"("overallRating");
+CREATE INDEX "Review_carRating_idx" ON "Review"("carRating");
+CREATE INDEX "Review_chauffeurRating_idx" ON "Review"("chauffeurRating");
+CREATE INDEX "Review_serviceRating_idx" ON "Review"("serviceRating");
+CREATE INDEX "Review_isVisible_idx" ON "Review"("isVisible");
+CREATE INDEX "Review_createdAt_idx" ON "Review"("createdAt");
+CREATE INDEX "Review_moderatedBy_idx" ON "Review"("moderatedBy");
+
+-- CreateIndex Car (new columns)
+CREATE INDEX "Car_vehicleType_idx" ON "Car"("vehicleType");
+CREATE INDEX "Car_serviceTier_idx" ON "Car"("serviceTier");
+CREATE INDEX "Car_serviceTier_vehicleType_idx" ON "Car"("serviceTier", "vehicleType");
+
+-- CreateIndex Session
+CREATE UNIQUE INDEX "session_token_key" ON "session"("token");
+CREATE INDEX "session_userId_idx" ON "session"("userId");
+CREATE INDEX "session_token_idx" ON "session"("token");
+
+-- CreateIndex Verification
+CREATE INDEX "verification_identifier_idx" ON "verification"("identifier");
+CREATE INDEX "verification_value_idx" ON "verification"("value");
+
+-- CreateIndex RateLimit
+CREATE UNIQUE INDEX "rateLimit_key_key" ON "rateLimit"("key");
+
+-- CreateIndex Booking (flightId)
+CREATE INDEX "Booking_flightId_idx" ON "Booking"("flightId");
+CREATE INDEX "Booking_deletedAt_idx" ON "Booking"("deletedAt");
+
+-- CreateIndex Payment (refundIdempotencyKey)
+ALTER TABLE "Payment" ADD COLUMN "refundIdempotencyKey" TEXT;
+CREATE UNIQUE INDEX "Payment_refundIdempotencyKey_key" ON "Payment"("refundIdempotencyKey");
+
+-- AddForeignKey Flight
+ALTER TABLE "FlightStatusEvent" ADD CONSTRAINT "FlightStatusEvent_flightId_fkey" FOREIGN KEY ("flightId") REFERENCES "Flight"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey Booking to Flight
+ALTER TABLE "Booking" ADD CONSTRAINT "Booking_flightId_fkey" FOREIGN KEY ("flightId") REFERENCES "Flight"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey Review
+ALTER TABLE "Review" ADD CONSTRAINT "Review_bookingId_fkey" FOREIGN KEY ("bookingId") REFERENCES "Booking"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Review" ADD CONSTRAINT "Review_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Review" ADD CONSTRAINT "Review_moderatedBy_fkey" FOREIGN KEY ("moderatedBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey Session
+ALTER TABLE "session" ADD CONSTRAINT "session_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,5 @@
 generator client {
-  provider              = "prisma-client-js"
-  skipDefaultValidation = true
+  provider = "prisma-client-js"
 }
 
 datasource db {
@@ -10,33 +9,33 @@ datasource db {
 }
 
 model Car {
-  id                 String             @id @default(cuid())
-  make               String
-  model              String
-  year               Int
-  createdAt          DateTime           @default(now())
-  updatedAt          DateTime           @updatedAt
-  color              String
-  ownerId            String
-  registrationNumber String
-  status             Status
-  approvalStatus     CarApprovalStatus  @default(PENDING)
-  approvalNotes      String?
-  hourlyRate         Int
-  dayRate            Int
-  nightRate          Int
-  fuelUpgradeRate    Int?
-  fullDayRate        Int
-  airportPickupRate  Int
-  pricingIncludesFuel Boolean           @default(false)
+  id                  String             @id @default(cuid())
+  make                String
+  model               String
+  year                Int
+  createdAt           DateTime           @default(now())
+  updatedAt           DateTime           @updatedAt
+  color               String
+  ownerId             String
+  registrationNumber  String
+  status              Status
+  approvalStatus      CarApprovalStatus  @default(PENDING)
+  approvalNotes       String?
+  hourlyRate          Int
+  dayRate             Int
+  nightRate           Int
+  fuelUpgradeRate     Int?
+  fullDayRate         Int
+  airportPickupRate   Int
+  pricingIncludesFuel Boolean            @default(false)
   // Vehicle categorization
-  vehicleType        VehicleType        @default(SEDAN)
-  serviceTier        ServiceTier        @default(STANDARD)
-  passengerCapacity  Int                @default(4)
-  bookings           Booking[]
-  owner              User               @relation(fields: [ownerId], references: [id], onDelete: Cascade)
-  documents          DocumentApproval[] @relation("CarDocuments")
-  images             VehicleImage[]
+  vehicleType         VehicleType        @default(SEDAN)
+  serviceTier         ServiceTier        @default(STANDARD)
+  passengerCapacity   Int                @default(4)
+  bookings            Booking[]
+  owner               User               @relation(fields: [ownerId], references: [id], onDelete: Cascade)
+  documents           DocumentApproval[] @relation("CarDocuments")
+  images              VehicleImage[]
 
   @@index([ownerId])
   @@index([ownerId, updatedAt])

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -32,8 +32,18 @@ import { StatusChangeModule } from "./modules/status-change/status-change.module
       useFactory: (configService: ConfigService<EnvConfig>) => {
         const nodeEnv = configService.get("NODE_ENV", { infer: true });
         const isDev = nodeEnv === "development";
+        const isTest = nodeEnv === "test";
         const otlpLogsEndpoint = process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT;
         const otlpHeaders = parseOtlpHeaders(process.env.OTEL_EXPORTER_OTLP_HEADERS);
+
+        // Disable logging in test environment
+        if (isTest) {
+          return {
+            pinoHttp: {
+              level: "silent",
+            },
+          };
+        }
 
         // Build transport targets array
         const targets = [];

--- a/test/seeder.ts
+++ b/test/seeder.ts
@@ -62,7 +62,8 @@ export async function resetAndSeedDb() {
           nightRate: 60000,
           fuelUpgradeRate: 10000,
           fullDayRate: 120000,
-          ownerId: fleetOwner.id,
+          airportPickupRate: 50000,
+          owner: { connect: { id: fleetOwner.id } },
         },
       });
 
@@ -80,7 +81,8 @@ export async function resetAndSeedDb() {
           nightRate: 65000,
           fuelUpgradeRate: 10000,
           fullDayRate: 130000,
-          ownerId: fleetOwner.id,
+          airportPickupRate: 55000,
+          owner: { connect: { id: fleetOwner.id } },
         },
       });
 


### PR DESCRIPTION
- Add entrypoint.sh to run Prisma migrations on container startup
- Update Dockerfile to copy and execute the entrypoint script
- Pin Prisma CLI version (^6.19.0) to match @prisma/client
- Fix test/seeder.ts Car creation to use relation connect syntax
- Format prisma/schema.prisma with consistent spacing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Automatically running migrations at startup and applying a large schema migration (new tables/enums/constraints) can cause deployment-time failures or data/locking issues if not coordinated with existing databases.
> 
> **Overview**
> Adds a production Docker entrypoint (`entrypoint.sh`) that runs `prisma migrate deploy` before starting the NestJS app, and updates the `Dockerfile` to include `pnpm-lock.yaml`, install a matching Prisma CLI in the runtime image, and switch the container `CMD` to the entrypoint.
> 
> Introduces a large Prisma migration to backfill missing schema elements (new enums, `Flight`/`FlightStatusEvent`/`Review` tables, better-auth tables, new columns/indexes/foreign keys, plus `Payment.refundIdempotencyKey` and extra `Car`/`User` fields) and bumps Prisma packages in the lockfile.
> 
> Improves test ergonomics by silencing `nestjs-pino` logging when `NODE_ENV=test`, updating the e2e `.env` with additional auth/provider variables, and adjusting the test DB seeder to set `Car.owner` via relation `connect` while providing `airportPickupRate`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd6f68fa80f7f6e02886f1c7dc8a6e6866c42583. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->