### PR TITLE
chore(workflow): disable fly specific workflows

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -9,6 +9,7 @@ jobs:
   deploy:
     name: Deploy app
     runs-on: ubuntu-latest
+    if: false  # Temporarily disabled - remove this line to re-enable
     concurrency: deploy-group    # optional: ensure only one action runs at a time
     environment:
       name: production

--- a/.github/workflows/fly-validate.yml
+++ b/.github/workflows/fly-validate.yml
@@ -8,6 +8,7 @@ jobs:
   validate:
     name: Validate deployment config and build
     runs-on: ubuntu-latest
+    if: false  # Temporarily disabled - remove this line to re-enable
     steps:
       # Pin to v6.0.1 - check for updates with: gh api repos/actions/checkout/tags --jq '.[0].name'
       - uses: actions/checkout@v6.0.1


### PR DESCRIPTION
Disable fly.io specific workflow, migrating to private VPS architecture Dokploy+Hetzner

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this only disables CI workflows, but it removes automated deploy/validation safety nets until an alternative pipeline is in place.
> 
> **Overview**
> **Disables Fly.io CI/CD in GitHub Actions** by adding `if: false` to the `deploy` job in `fly-deploy.yml` and the `validate` job in `fly-validate.yml`, preventing these workflows from running on `main` pushes or PRs.
> 
> No other workflow logic is changed; re-enabling is a single-line removal in each job.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e001b679e4f3639f27261534581f3c9d9ed8ecf. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->