### PR TITLE
feat(referrals): expose referral endpoints with facade-based service split and lean e2e coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,5 +95,10 @@
   },
   "engines": {
     "node": ">=22.12.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "minimatch": "10.2.1"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  minimatch: 10.2.1
+
 importers:
 
   .:
@@ -2286,8 +2289,9 @@ packages:
       react-native-b4a:
         optional: true
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+  balanced-match@4.0.3:
+    resolution: {integrity: sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==}
+    engines: {node: 20 || >=22}
 
   bare-events@2.8.2:
     resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
@@ -2425,11 +2429,9 @@ packages:
     resolution: {integrity: sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==}
     engines: {node: '>=10'}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
-
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+  brace-expansion@5.0.2:
+    resolution: {integrity: sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2627,9 +2629,6 @@ packages:
   compress-commons@6.0.2:
     resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
     engines: {node: '>= 14'}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   concat-stream@2.0.0:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
@@ -3628,16 +3627,9 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
-
-  minimatch@5.1.6:
-    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
-    engines: {node: '>=10'}
-
-  minimatch@9.0.5:
-    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
-    engines: {node: '>=16 || 14 >=14.17'}
+  minimatch@10.2.1:
+    resolution: {integrity: sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==}
+    engines: {node: 20 || >=22}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -7070,7 +7062,7 @@ snapshots:
 
   b4a@1.7.3: {}
 
-  balanced-match@1.0.2: {}
+  balanced-match@4.0.3: {}
 
   bare-events@2.8.2: {}
 
@@ -7183,14 +7175,9 @@ snapshots:
       widest-line: 3.1.0
       wrap-ansi: 7.0.0
 
-  brace-expansion@1.1.12:
+  brace-expansion@5.0.2:
     dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@2.0.2:
-    dependencies:
-      balanced-match: 1.0.2
+      balanced-match: 4.0.3
 
   braces@3.0.3:
     dependencies:
@@ -7400,8 +7387,6 @@ snapshots:
       is-stream: 2.0.1
       normalize-path: 3.0.0
       readable-stream: 4.7.0
-
-  concat-map@0.0.1: {}
 
   concat-stream@2.0.0:
     dependencies:
@@ -7834,7 +7819,7 @@ snapshots:
 
   filelist@1.0.4:
     dependencies:
-      minimatch: 5.1.6
+      minimatch: 10.2.1
 
   fill-range@7.1.1:
     dependencies:
@@ -7869,7 +7854,7 @@ snapshots:
       deepmerge: 4.3.1
       fs-extra: 10.1.0
       memfs: 3.5.3
-      minimatch: 3.1.2
+      minimatch: 10.2.1
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
       semver: 7.7.3
@@ -7992,7 +7977,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
-      minimatch: 9.0.5
+      minimatch: 10.2.1
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
@@ -8427,17 +8412,9 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
-  minimatch@3.1.2:
+  minimatch@10.2.1:
     dependencies:
-      brace-expansion: 1.1.12
-
-  minimatch@5.1.6:
-    dependencies:
-      brace-expansion: 2.0.2
-
-  minimatch@9.0.5:
-    dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 5.0.2
 
   minimist@1.2.8: {}
 
@@ -8878,7 +8855,7 @@ snapshots:
 
   readdir-glob@1.1.3:
     dependencies:
-      minimatch: 5.1.6
+      minimatch: 10.2.1
 
   readdirp@3.6.0:
     dependencies:
@@ -9312,7 +9289,7 @@ snapshots:
     dependencies:
       '@istanbuljs/schema': 0.1.3
       glob: 10.4.5
-      minimatch: 9.0.5
+      minimatch: 10.2.1
 
   testcontainers@11.8.0:
     dependencies:

--- a/src/common/http/request.helper.spec.ts
+++ b/src/common/http/request.helper.spec.ts
@@ -1,24 +1,82 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { getRequestOrigin } from "./request.helper";
 
 describe("getRequestOrigin", () => {
-  it("uses x-forwarded-proto when present", () => {
-    const request = {
-      headers: { "x-forwarded-proto": "https" },
-      protocol: "http",
-      get: vi.fn().mockReturnValue("api.example.com"),
-    } as never;
-
-    expect(getRequestOrigin(request)).toBe("https://api.example.com");
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
-  it("falls back to request protocol when forwarded proto is absent", () => {
+  it("returns AUTH_BASE_URL when configured", () => {
+    vi.stubEnv("AUTH_BASE_URL", "https://auth.example.com");
+    vi.stubEnv("TRUSTED_ORIGINS", "https://app.example.com");
+
+    const request = {
+      headers: { "x-forwarded-proto": "http" },
+      protocol: "http",
+      get: vi.fn().mockReturnValue("evil.example.com"),
+      app: { get: vi.fn().mockReturnValue(false) },
+    };
+
+    expect(getRequestOrigin(request)).toBe("https://auth.example.com");
+  });
+
+  it("falls back to first TRUSTED_ORIGINS when AUTH_BASE_URL is absent", () => {
+    vi.stubEnv("AUTH_BASE_URL", "");
+    vi.stubEnv("TRUSTED_ORIGINS", "https://app.example.com,https://admin.example.com");
+
     const request = {
       headers: {},
       protocol: "http",
       get: vi.fn().mockReturnValue("localhost:3000"),
-    } as never;
+      app: { get: vi.fn().mockReturnValue(false) },
+    };
+
+    expect(getRequestOrigin(request)).toBe("https://app.example.com");
+  });
+
+  it("uses forwarded proto only when trust proxy is enabled", () => {
+    vi.stubEnv("AUTH_BASE_URL", "");
+    vi.stubEnv("TRUSTED_ORIGINS", "https://api.example.com");
+
+    const request = {
+      headers: { "x-forwarded-proto": "https" },
+      protocol: "http",
+      get: vi.fn().mockReturnValue("api.example.com"),
+      app: {
+        get: vi
+          .fn()
+          .mockImplementation((key: string) => (key === "trust proxy" ? true : undefined)),
+      },
+    };
+
+    expect(getRequestOrigin(request)).toBe("https://api.example.com");
+  });
+
+  it("ignores forwarded proto when trust proxy is disabled", () => {
+    vi.stubEnv("AUTH_BASE_URL", "");
+    vi.stubEnv("TRUSTED_ORIGINS", "");
+
+    const request = {
+      headers: { "x-forwarded-proto": "https" },
+      protocol: "http",
+      get: vi.fn().mockReturnValue("localhost:3000"),
+      app: { get: vi.fn().mockReturnValue(false) },
+    };
 
     expect(getRequestOrigin(request)).toBe("http://localhost:3000");
+  });
+
+  it("returns null for untrusted host when no configured origin is present", () => {
+    vi.stubEnv("AUTH_BASE_URL", "");
+    vi.stubEnv("TRUSTED_ORIGINS", "");
+
+    const request = {
+      headers: {},
+      protocol: "https",
+      get: vi.fn().mockReturnValue("evil.example.com"),
+      app: { get: vi.fn().mockReturnValue(false) },
+    };
+
+    expect(getRequestOrigin(request)).toBeNull();
   });
 });

--- a/src/common/http/request.helper.spec.ts
+++ b/src/common/http/request.helper.spec.ts
@@ -36,12 +36,12 @@ describe("getRequestOrigin", () => {
 
   it("uses forwarded proto only when trust proxy is enabled", () => {
     vi.stubEnv("AUTH_BASE_URL", "");
-    vi.stubEnv("TRUSTED_ORIGINS", "https://api.example.com");
+    vi.stubEnv("TRUSTED_ORIGINS", "");
 
     const request = {
       headers: { "x-forwarded-proto": "https" },
       protocol: "http",
-      get: vi.fn().mockReturnValue("api.example.com"),
+      get: vi.fn().mockReturnValue("localhost:3000"),
       app: {
         get: vi
           .fn()
@@ -49,7 +49,7 @@ describe("getRequestOrigin", () => {
       },
     };
 
-    expect(getRequestOrigin(request)).toBe("https://api.example.com");
+    expect(getRequestOrigin(request)).toBe("https://localhost:3000");
   });
 
   it("ignores forwarded proto when trust proxy is disabled", () => {

--- a/src/common/http/request.helper.spec.ts
+++ b/src/common/http/request.helper.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+import { getRequestOrigin } from "./request.helper";
+
+describe("getRequestOrigin", () => {
+  it("uses x-forwarded-proto when present", () => {
+    const request = {
+      headers: { "x-forwarded-proto": "https" },
+      protocol: "http",
+      get: vi.fn().mockReturnValue("api.example.com"),
+    } as never;
+
+    expect(getRequestOrigin(request)).toBe("https://api.example.com");
+  });
+
+  it("falls back to request protocol when forwarded proto is absent", () => {
+    const request = {
+      headers: {},
+      protocol: "http",
+      get: vi.fn().mockReturnValue("localhost:3000"),
+    } as never;
+
+    expect(getRequestOrigin(request)).toBe("http://localhost:3000");
+  });
+});

--- a/src/common/http/request.helper.ts
+++ b/src/common/http/request.helper.ts
@@ -1,0 +1,11 @@
+import type { Request } from "express";
+
+export function getRequestOrigin(request: Pick<Request, "headers" | "protocol" | "get">): string {
+  const forwardedProto = request.headers["x-forwarded-proto"];
+  const protocol =
+    typeof forwardedProto === "string" && forwardedProto.length > 0
+      ? forwardedProto.split(",")[0].trim()
+      : request.protocol;
+  const host = request.get("host");
+  return `${protocol}://${host}`;
+}

--- a/src/common/http/request.helper.ts
+++ b/src/common/http/request.helper.ts
@@ -1,11 +1,144 @@
 import type { Request } from "express";
 
-export function getRequestOrigin(request: Pick<Request, "headers" | "protocol" | "get">): string {
-  const forwardedProto = request.headers["x-forwarded-proto"];
-  const protocol =
-    typeof forwardedProto === "string" && forwardedProto.length > 0
-      ? forwardedProto.split(",")[0].trim()
-      : request.protocol;
-  const host = request.get("host");
-  return `${protocol}://${host}`;
+type RequestOriginRequest = Pick<Request, "headers" | "protocol" | "get"> & {
+  app?: Pick<Request["app"], "get">;
+};
+
+const ALLOWED_PROTOCOLS = new Set(["http", "https"]);
+const DEFAULT_ALLOWED_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1"]);
+
+function asAllowedOrigin(rawOrigin: string | undefined): string | null {
+  if (!rawOrigin || rawOrigin.trim().length === 0) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(rawOrigin.trim());
+    const protocol = parsed.protocol.replace(":", "").toLowerCase();
+
+    if (!ALLOWED_PROTOCOLS.has(protocol)) {
+      return null;
+    }
+
+    return `${protocol}://${parsed.host.toLowerCase()}`;
+  } catch {
+    return null;
+  }
+}
+
+function getConfiguredOrigins(): string[] {
+  const configuredAuthOrigin = asAllowedOrigin(process.env.AUTH_BASE_URL);
+  const configuredTrustedOrigins = (process.env.TRUSTED_ORIGINS ?? "")
+    .split(",")
+    .map((origin) => asAllowedOrigin(origin))
+    .filter((origin): origin is string => origin !== null);
+
+  return configuredAuthOrigin
+    ? [configuredAuthOrigin, ...configuredTrustedOrigins]
+    : configuredTrustedOrigins;
+}
+
+function getTrustedHostAllowlist(configuredOrigins: string[]): Set<string> {
+  const allowlist = new Set<string>();
+
+  for (const configuredOrigin of configuredOrigins) {
+    try {
+      const parsedOrigin = new URL(configuredOrigin);
+      allowlist.add(parsedOrigin.host.toLowerCase());
+      allowlist.add(parsedOrigin.hostname.toLowerCase());
+    } catch {
+      // Invalid entries are ignored by design.
+    }
+  }
+
+  for (const hostname of DEFAULT_ALLOWED_HOSTNAMES) {
+    allowlist.add(hostname);
+  }
+
+  return allowlist;
+}
+
+function isExpressTrustProxyEnabled(request: RequestOriginRequest): boolean {
+  const trustProxyValue = request.app?.get?.("trust proxy");
+
+  if (typeof trustProxyValue === "function") {
+    return true;
+  }
+
+  if (typeof trustProxyValue === "number") {
+    return trustProxyValue > 0;
+  }
+
+  if (typeof trustProxyValue === "string") {
+    const normalizedValue = trustProxyValue.trim().toLowerCase();
+    return normalizedValue.length > 0 && normalizedValue !== "0" && normalizedValue !== "false";
+  }
+
+  return Boolean(trustProxyValue);
+}
+
+function parseRequestHost(
+  request: RequestOriginRequest,
+): { host: string; hostname: string } | null {
+  const rawHost = request.get("host");
+
+  if (!rawHost || rawHost.trim().length === 0) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(`http://${rawHost.trim()}`);
+    return {
+      host: parsed.host.toLowerCase(),
+      hostname: parsed.hostname.toLowerCase(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function getValidatedProtocol(request: RequestOriginRequest): string | null {
+  const baseProtocol = request.protocol?.trim().toLowerCase();
+  const protocolFromRequest = ALLOWED_PROTOCOLS.has(baseProtocol) ? baseProtocol : null;
+
+  if (!isExpressTrustProxyEnabled(request)) {
+    return protocolFromRequest;
+  }
+
+  const forwardedProtoHeader = request.headers["x-forwarded-proto"];
+  const forwardedProto = Array.isArray(forwardedProtoHeader)
+    ? forwardedProtoHeader[0]
+    : forwardedProtoHeader;
+  const sanitizedForwardedProto = forwardedProto?.split(",")[0]?.trim().toLowerCase();
+
+  if (sanitizedForwardedProto && ALLOWED_PROTOCOLS.has(sanitizedForwardedProto)) {
+    return sanitizedForwardedProto;
+  }
+
+  return protocolFromRequest;
+}
+
+export function getRequestOrigin(request: RequestOriginRequest): string | null {
+  const configuredOrigins = getConfiguredOrigins();
+  if (configuredOrigins.length > 0) {
+    return configuredOrigins[0];
+  }
+
+  const protocol = getValidatedProtocol(request);
+  if (!protocol) {
+    return null;
+  }
+
+  const host = parseRequestHost(request);
+  if (!host) {
+    return null;
+  }
+
+  const trustedHosts = getTrustedHostAllowlist(configuredOrigins);
+  const isTrustedHost = trustedHosts.has(host.host) || trustedHosts.has(host.hostname);
+  if (!isTrustedHost) {
+    return null;
+  }
+
+  return `${protocol}://${host.host}`;
 }

--- a/src/common/throttling/throttling.helper.spec.ts
+++ b/src/common/throttling/throttling.helper.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { getRetryAfterSeconds, type ThrottleHitRecord } from "./throttling.helper";
+
+describe("getRetryAfterSeconds", () => {
+  it("converts timeToBlockExpire from milliseconds to seconds", () => {
+    const hit = { timeToBlockExpire: 3_600_000 } as unknown as ThrottleHitRecord;
+
+    expect(getRetryAfterSeconds(hit, 60)).toBe(3600);
+  });
+
+  it("falls back to timeToExpire when timeToBlockExpire is missing", () => {
+    const hit = { timeToExpire: 1250 } as unknown as ThrottleHitRecord;
+
+    expect(getRetryAfterSeconds(hit, 60)).toBe(2);
+  });
+
+  it("uses fallback seconds when throttler values are unavailable", () => {
+    const hit = {} as unknown as ThrottleHitRecord;
+
+    expect(getRetryAfterSeconds(hit, 3600)).toBe(3600);
+  });
+
+  it("returns at least one second", () => {
+    const hit = { timeToExpire: 0 } as unknown as ThrottleHitRecord;
+
+    expect(getRetryAfterSeconds(hit, 0)).toBe(1);
+  });
+});

--- a/src/common/throttling/throttling.helper.ts
+++ b/src/common/throttling/throttling.helper.ts
@@ -1,0 +1,62 @@
+import type { ThrottlerStorage } from "@nestjs/throttler";
+
+export interface HeaderWritable {
+  setHeader(name: string, value: string): void;
+}
+
+export interface HttpRequestLike {
+  ip?: string;
+  headers?: Record<string, string | string[] | undefined>;
+}
+
+export type ThrottleHitRecord = Awaited<ReturnType<ThrottlerStorage["increment"]>>;
+
+export function getClientIp(request: HttpRequestLike): string {
+  const forwardedFor = request.headers?.["x-forwarded-for"];
+  if (typeof forwardedFor === "string" && forwardedFor.length > 0) {
+    return forwardedFor.split(",")[0].trim();
+  }
+
+  const cfIp = request.headers?.["cf-connecting-ip"];
+  if (typeof cfIp === "string" && cfIp.length > 0) {
+    return cfIp.trim();
+  }
+
+  const realIp = request.headers?.["x-real-ip"];
+  if (typeof realIp === "string" && realIp.length > 0) {
+    return realIp.trim();
+  }
+
+  return request.ip || "unknown";
+}
+
+export function isThrottled(hit: ThrottleHitRecord, limit: number): boolean {
+  if (hit.isBlocked !== undefined) {
+    return hit.isBlocked;
+  }
+
+  return hit.totalHits > limit;
+}
+
+export function getRetryAfterSeconds(hit: ThrottleHitRecord, fallbackSeconds: number): number {
+  return Math.max(1, hit.timeToBlockExpire || hit.timeToExpire || fallbackSeconds);
+}
+
+export function setRateLimitHeaders(
+  response: HeaderWritable,
+  input: {
+    limit: number;
+    windowSeconds: number;
+    retryAfterSeconds: number;
+    remaining?: number;
+  },
+): void {
+  response.setHeader("Retry-After", String(input.retryAfterSeconds));
+  response.setHeader("RateLimit-Policy", `${input.limit};w=${input.windowSeconds}`);
+  response.setHeader("RateLimit-Limit", String(input.limit));
+  response.setHeader("RateLimit-Remaining", String(input.remaining ?? 0));
+}
+
+export function computeRetryAfterEpoch(ttlSeconds: number): number {
+  return Math.ceil(Date.now() / 1000) + ttlSeconds;
+}

--- a/src/modules/flightaware/dto/search-flight.dto.ts
+++ b/src/modules/flightaware/dto/search-flight.dto.ts
@@ -1,27 +1,13 @@
 import { z } from "zod";
-import { FLIGHT_NUMBER_REGEX } from "../flightaware.const";
+import { FLIGHT_NUMBER_REGEX, parseIsoDateOnlyToUtc } from "../flightaware.const";
 
-const ISO_DATE_ONLY_REGEX = /^(\d{4})-(\d{2})-(\d{2})$/;
 const ISO_DATETIME_WITH_TIMEZONE_REGEX =
   /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:\d{2})$/;
 
 const parseIsoDateToUtc = (value: string): Date | null => {
-  const dateOnlyMatch = ISO_DATE_ONLY_REGEX.exec(value);
-  if (dateOnlyMatch) {
-    const year = Number.parseInt(dateOnlyMatch[1], 10);
-    const month = Number.parseInt(dateOnlyMatch[2], 10);
-    const day = Number.parseInt(dateOnlyMatch[3], 10);
-    const date = new Date(Date.UTC(year, month - 1, day));
-
-    if (
-      date.getUTCFullYear() !== year ||
-      date.getUTCMonth() !== month - 1 ||
-      date.getUTCDate() !== day
-    ) {
-      return null;
-    }
-
-    return date;
+  const dateOnlyUtc = parseIsoDateOnlyToUtc(value);
+  if (dateOnlyUtc) {
+    return dateOnlyUtc;
   }
 
   if (!ISO_DATETIME_WITH_TIMEZONE_REGEX.test(value)) {

--- a/src/modules/flightaware/flightaware.const.spec.ts
+++ b/src/modules/flightaware/flightaware.const.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { ISO_DATE_ONLY_REGEX, parseIsoDateOnlyToUtc } from "./flightaware.const";
+
+describe("flightaware.const", () => {
+  describe("ISO_DATE_ONLY_REGEX", () => {
+    it("should match valid ISO date-only values", () => {
+      expect(ISO_DATE_ONLY_REGEX.test("2025-12-25")).toBe(true);
+    });
+
+    it("should not match non date-only values", () => {
+      expect(ISO_DATE_ONLY_REGEX.test("2025-12-25T00:00:00Z")).toBe(false);
+      expect(ISO_DATE_ONLY_REGEX.test("12/25/2025")).toBe(false);
+    });
+  });
+
+  describe("parseIsoDateOnlyToUtc", () => {
+    it("should parse a valid ISO date-only string as UTC midnight", () => {
+      const parsed = parseIsoDateOnlyToUtc("2025-12-25");
+
+      expect(parsed).not.toBeNull();
+      expect(parsed?.toISOString()).toBe("2025-12-25T00:00:00.000Z");
+    });
+
+    it("should return null for invalid calendar dates", () => {
+      expect(parseIsoDateOnlyToUtc("2025-02-31")).toBeNull();
+    });
+
+    it("should return null for non date-only values", () => {
+      expect(parseIsoDateOnlyToUtc("2025-12-25T00:00:00Z")).toBeNull();
+      expect(parseIsoDateOnlyToUtc("2025/12/25")).toBeNull();
+    });
+  });
+});

--- a/src/modules/flightaware/flightaware.const.ts
+++ b/src/modules/flightaware/flightaware.const.ts
@@ -3,6 +3,29 @@
  * Used as fallback when FlightAware doesn't find the flight with IATA code
  */
 export const FLIGHT_NUMBER_REGEX = /^[A-Z0-9]{2,3}\d{1,5}$/i;
+export const ISO_DATE_ONLY_REGEX = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+export const parseIsoDateOnlyToUtc = (value: string): Date | null => {
+  const dateOnlyMatch = ISO_DATE_ONLY_REGEX.exec(value);
+  if (!dateOnlyMatch) {
+    return null;
+  }
+
+  const year = Number.parseInt(dateOnlyMatch[1], 10);
+  const month = Number.parseInt(dateOnlyMatch[2], 10);
+  const day = Number.parseInt(dateOnlyMatch[3], 10);
+  const date = new Date(Date.UTC(year, month - 1, day));
+
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  return date;
+};
 
 export const IATA_TO_ICAO_MAP: Record<string, string> = {
   // International carriers

--- a/src/modules/job/job-throttler.guard.spec.ts
+++ b/src/modules/job/job-throttler.guard.spec.ts
@@ -1,0 +1,98 @@
+import type { ExecutionContext } from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { Test, type TestingModule } from "@nestjs/testing";
+import { ThrottlerStorage } from "@nestjs/throttler";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { JobRateLimitExceededException } from "./errors";
+import { JobThrottlerGuard } from "./job-throttler.guard";
+
+class TestableJobThrottlerGuard extends JobThrottlerGuard {
+  async callThrowThrottlingException(
+    context: ExecutionContext,
+    throttlerConfig?: { ttl: number },
+  ): Promise<void> {
+    return this.throwThrottlingException(context, throttlerConfig);
+  }
+}
+
+function createContext(jobType: string): ExecutionContext {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => ({ params: { jobType } }),
+    }),
+  } as unknown as ExecutionContext;
+}
+
+describe("JobThrottlerGuard", () => {
+  let guard: TestableJobThrottlerGuard;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        {
+          provide: TestableJobThrottlerGuard,
+          useClass: TestableJobThrottlerGuard,
+        },
+        {
+          provide: "THROTTLER:MODULE_OPTIONS",
+          useValue: [{ name: "manual-triggers", ttl: 3600, limit: 1 }],
+        },
+        {
+          provide: ThrottlerStorage,
+          useValue: { increment: vi.fn(), get: vi.fn() },
+        },
+        Reflector,
+      ],
+    }).compile();
+
+    guard = module.get<TestableJobThrottlerGuard>(TestableJobThrottlerGuard);
+  });
+
+  it("converts millisecond ttl to seconds for retryAfter", async () => {
+    const nowSeconds = Math.ceil(Date.now() / 1000);
+
+    await expect(
+      guard.callThrowThrottlingException(createContext("start-reminders"), { ttl: 3_600_000 }),
+    ).rejects.toThrow(JobRateLimitExceededException);
+
+    try {
+      await guard.callThrowThrottlingException(createContext("start-reminders"), {
+        ttl: 3_600_000,
+      });
+    } catch (error) {
+      const details = (error as JobRateLimitExceededException).getDetails();
+      const retryAfter = details?.retryAfter as number;
+
+      expect(retryAfter).toBeGreaterThanOrEqual(nowSeconds + 3300);
+      expect(retryAfter).toBeLessThanOrEqual(nowSeconds + 3900);
+    }
+  });
+
+  it("keeps second-based ttl values unchanged", async () => {
+    const nowSeconds = Math.ceil(Date.now() / 1000);
+
+    try {
+      await guard.callThrowThrottlingException(createContext("start-reminders"), { ttl: 3600 });
+    } catch (error) {
+      const details = (error as JobRateLimitExceededException).getDetails();
+      const retryAfter = details?.retryAfter as number;
+
+      expect(retryAfter).toBeGreaterThanOrEqual(nowSeconds + 3300);
+      expect(retryAfter).toBeLessThanOrEqual(nowSeconds + 3900);
+    }
+  });
+
+  it("uses 1 hour fallback when ttl is missing", async () => {
+    const nowSeconds = Math.ceil(Date.now() / 1000);
+
+    try {
+      await guard.callThrowThrottlingException(createContext("start-reminders"));
+    } catch (error) {
+      const details = (error as JobRateLimitExceededException).getDetails();
+      const retryAfter = details?.retryAfter as number;
+
+      expect(retryAfter).toBeGreaterThanOrEqual(nowSeconds + 3300);
+      expect(retryAfter).toBeLessThanOrEqual(nowSeconds + 3900);
+    }
+  });
+});

--- a/src/modules/job/job-throttler.guard.ts
+++ b/src/modules/job/job-throttler.guard.ts
@@ -1,5 +1,6 @@
 import { ExecutionContext, Injectable } from "@nestjs/common";
 import { ThrottlerGuard } from "@nestjs/throttler";
+import { computeRetryAfterEpoch } from "../../common/throttling/throttling.helper";
 import { JobRateLimitExceededException } from "./errors";
 
 /**
@@ -51,7 +52,7 @@ export class JobThrottlerGuard extends ThrottlerGuard {
     // Calculate retryAfter: TTL seconds from now (when rate limit resets)
     // Default to 3600 seconds (1 hour) if not provided
     const ttlSeconds = throttlerConfig?.ttl || 3600;
-    const retryAfter = Math.ceil(Date.now() / 1000) + ttlSeconds;
+    const retryAfter = computeRetryAfterEpoch(ttlSeconds);
 
     throw new JobRateLimitExceededException(jobType, retryAfter);
   }

--- a/src/modules/job/job.service.spec.ts
+++ b/src/modules/job/job.service.spec.ts
@@ -1,4 +1,5 @@
 import { getQueueToken } from "@nestjs/bullmq";
+import { Logger } from "@nestjs/common";
 import { Test, TestingModule } from "@nestjs/testing";
 import { Queue } from "bullmq";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -49,9 +50,13 @@ describe("JobService", () => {
     service = module.get<JobService>(JobService);
     reminderQueue = module.get<Queue>(getQueueToken(REMINDERS_QUEUE));
     statusUpdateQueue = module.get<Queue>(getQueueToken(STATUS_UPDATES_QUEUE));
+
+    // Suppress logger noise for expected error-path tests
+    vi.spyOn(Logger.prototype, "error").mockImplementation(() => undefined);
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.useRealTimers();
   });
   it("should enqueue start booking leg reminders", async () => {

--- a/src/modules/payment/payment.service.spec.ts
+++ b/src/modules/payment/payment.service.spec.ts
@@ -1,4 +1,5 @@
 import { getQueueToken } from "@nestjs/bullmq";
+import { Logger } from "@nestjs/common";
 import { Test, TestingModule } from "@nestjs/testing";
 import { PayoutTransactionStatus } from "@prisma/client";
 import { Decimal } from "@prisma/client/runtime/library";
@@ -69,6 +70,9 @@ describe("PaymentService", () => {
           callback(databaseService),
       ),
     });
+
+    // Suppress logger noise for expected error-path tests
+    vi.spyOn(Logger.prototype, "error").mockImplementation(() => undefined);
   });
   it("should use a deterministic reference derived from payout transaction id", async () => {
     const booking = createBooking({

--- a/src/modules/referral/dto/referral.dto.ts
+++ b/src/modules/referral/dto/referral.dto.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+const referralCodePattern = /^[A-Z0-9]{8}$/;
+
+export const referralCodeParamSchema = z
+  .string()
+  .trim()
+  .length(8, "Referral code must be exactly 8 characters")
+  .transform((value) => value.toUpperCase())
+  .refine((value) => referralCodePattern.test(value), {
+    message: "Referral code must contain only letters and numbers",
+  });
+
+export type ReferralCodeParamDto = z.infer<typeof referralCodeParamSchema>;
+
+export const validateReferralQuerySchema = z.object({
+  email: z.string().trim().optional().default(""),
+});
+
+export type ValidateReferralQueryDto = z.infer<typeof validateReferralQuerySchema>;
+
+export const referralEligibilityQuerySchema = z.object({
+  amount: z.coerce.number().int().min(1, "Amount must be greater than 0"),
+  type: z.enum(["DAY", "NIGHT", "FULL_DAY"], {
+    error: "Booking type is required and must be valid.",
+  }),
+});
+
+export type ReferralEligibilityQueryDto = z.infer<typeof referralEligibilityQuerySchema>;

--- a/src/modules/referral/referral-api.service.spec.ts
+++ b/src/modules/referral/referral-api.service.spec.ts
@@ -1,0 +1,157 @@
+import { Test, type TestingModule } from "@nestjs/testing";
+import { BookingReferralStatus } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DatabaseService } from "../database/database.service";
+import { ReferralInvalidCodeException, ReferralSelfReferralException } from "./referral.error";
+import { ReferralApiService } from "./referral-api.service";
+
+describe("ReferralApiService", () => {
+  let service: ReferralApiService;
+  let mockDatabaseService: {
+    user: {
+      findUnique: ReturnType<typeof vi.fn>;
+    };
+    booking: {
+      findFirst: ReturnType<typeof vi.fn>;
+      aggregate: ReturnType<typeof vi.fn>;
+    };
+    userReferralStats: {
+      findUnique: ReturnType<typeof vi.fn>;
+    };
+    referralProgramConfig: {
+      findMany: ReturnType<typeof vi.fn>;
+    };
+  };
+
+  beforeEach(async () => {
+    mockDatabaseService = {
+      user: {
+        findUnique: vi.fn(),
+      },
+      booking: {
+        findFirst: vi.fn(),
+        aggregate: vi.fn(),
+      },
+      userReferralStats: {
+        findUnique: vi.fn(),
+      },
+      referralProgramConfig: {
+        findMany: vi.fn(),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReferralApiService,
+        {
+          provide: DatabaseService,
+          useValue: mockDatabaseService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<ReferralApiService>(ReferralApiService);
+  });
+
+  it("throws not-found exception for invalid referral code", async () => {
+    mockDatabaseService.user.findUnique.mockResolvedValue(null);
+
+    await expect(service.validateReferralCode("ABCDEFGH", "")).rejects.toThrow(
+      ReferralInvalidCodeException,
+    );
+  });
+
+  it("throws self-referral exception when email matches referrer", async () => {
+    mockDatabaseService.user.findUnique.mockResolvedValue({
+      id: "user-1",
+      name: "Referrer",
+      email: "referrer@example.com",
+      referralCode: "ABCDEFGH",
+    });
+
+    await expect(service.validateReferralCode("ABCDEFGH", "referrer@example.com")).rejects.toThrow(
+      ReferralSelfReferralException,
+    );
+  });
+
+  it("returns eligibility false when user has reserved or rewarded referral booking", async () => {
+    mockDatabaseService.referralProgramConfig.findMany.mockResolvedValue([]);
+    mockDatabaseService.user.findUnique.mockResolvedValue({
+      referredByUserId: "referrer-1",
+      referralDiscountUsed: false,
+      referralSignupAt: new Date(),
+    });
+    mockDatabaseService.booking.findFirst.mockResolvedValue({
+      id: "booking-1",
+      referralStatus: BookingReferralStatus.APPLIED,
+    });
+
+    const result = await service.checkReferralEligibility("user-1", 30000, "DAY");
+
+    expect(result).toEqual({
+      eligible: false,
+      reason: "Referral discount already reserved or used",
+      discountAmount: 0,
+    });
+  });
+
+  it("maps user referral summary payload with shareLink and numeric fields", async () => {
+    mockDatabaseService.referralProgramConfig.findMany.mockResolvedValue([]);
+    mockDatabaseService.user.findUnique.mockResolvedValueOnce({
+      referralCode: "ABCDEFGH",
+      referredByUserId: null,
+      referralDiscountUsed: false,
+      referralSignupAt: null,
+      referralStats: {
+        totalReferrals: 2,
+        totalRewardsGranted: { toNumber: () => 2500 },
+        totalRewardsPending: { toNumber: () => 500 },
+        lastReferralAt: null,
+      },
+      referrals: [
+        {
+          id: "user-2",
+          name: "New User",
+          email: "new@example.com",
+          createdAt: new Date("2030-01-01T00:00:00.000Z"),
+        },
+      ],
+      referralRewardsEarned: [
+        {
+          id: "reward-1",
+          amount: { toNumber: () => 1500 },
+          status: "RELEASED",
+          createdAt: new Date("2030-01-02T00:00:00.000Z"),
+          processedAt: new Date("2030-01-03T00:00:00.000Z"),
+          referee: {
+            name: "Referee Name",
+            email: "referee@example.com",
+          },
+        },
+      ],
+    });
+    mockDatabaseService.userReferralStats.findUnique.mockResolvedValue({
+      totalRewardsGranted: { toNumber: () => 2500 },
+    });
+    mockDatabaseService.booking.aggregate
+      .mockResolvedValueOnce({
+        _sum: { referralCreditsUsed: { toNumber: () => 500 } },
+      })
+      .mockResolvedValueOnce({
+        _sum: { referralCreditsReserved: { toNumber: () => 300 } },
+      });
+
+    const result = await service.getUserReferralSummary("user-1", "http://localhost:3000");
+    expect(result).not.toBeNull();
+    if (!result) return;
+
+    expect(result.referralCode).toBe("ABCDEFGH");
+    expect(result.shareLink).toBe("http://localhost:3000/auth?ref=ABCDEFGH");
+    expect(result.stats.totalRewardsGranted).toBe(2500);
+    expect(result.stats.totalEarned).toBe(2500);
+    expect(result.stats.totalUsed).toBe(500);
+    expect(result.stats.availableCredits).toBe(1700);
+    expect(result.rewards[0]?.amount).toBe(1500);
+    expect(result.rewards[0]?.refereeName).toBe("Referee Name");
+  });
+});

--- a/src/modules/referral/referral-api.service.ts
+++ b/src/modules/referral/referral-api.service.ts
@@ -116,7 +116,7 @@ export class ReferralApiService {
 
   async getUserReferralSummary(
     userId: string,
-    requestOrigin: string,
+    requestOrigin: string | null,
   ): Promise<ReferralUserSummaryResponse | null> {
     const [referralInfo, bookingCredits, config] = await Promise.all([
       this.databaseService.user.findUnique({
@@ -169,9 +169,10 @@ export class ReferralApiService {
       return null;
     }
 
-    const shareLink = referralInfo.referralCode
-      ? `${requestOrigin}/auth?ref=${referralInfo.referralCode}`
-      : null;
+    const shareLink =
+      referralInfo.referralCode && requestOrigin
+        ? `${requestOrigin}/auth?ref=${referralInfo.referralCode}`
+        : null;
 
     const totalRewardsGranted = this.decimalToNumber(
       referralInfo.referralStats?.totalRewardsGranted,

--- a/src/modules/referral/referral-api.service.ts
+++ b/src/modules/referral/referral-api.service.ts
@@ -1,0 +1,299 @@
+import { Injectable } from "@nestjs/common";
+import { BookingReferralStatus, BookingStatus, PaymentStatus, type Prisma } from "@prisma/client";
+import { DatabaseService } from "../database/database.service";
+import { ReferralInvalidCodeException, ReferralSelfReferralException } from "./referral.error";
+import type { ReferralConfig, ReferralUserSummaryResponse } from "./referral.interface";
+
+@Injectable()
+export class ReferralApiService {
+  private configCache:
+    | {
+        value: ReferralConfig;
+        expiresAt: number;
+      }
+    | undefined;
+
+  private readonly configTtlMs = 60 * 1000;
+
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async validateReferralCode(code: string, userEmail: string) {
+    const referrer = await this.databaseService.user.findUnique({
+      where: { referralCode: code },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        referralCode: true,
+      },
+    });
+
+    if (!referrer) {
+      throw new ReferralInvalidCodeException();
+    }
+
+    if (userEmail?.toLowerCase() === referrer.email.toLowerCase()) {
+      throw new ReferralSelfReferralException();
+    }
+
+    return referrer;
+  }
+
+  async checkReferralEligibility(userId: string, bookingAmount: number, bookingType: string) {
+    const config = await this.getReferralConfig();
+
+    if (!config.REFERRAL_ENABLED) {
+      return { eligible: false, reason: "Referral program is disabled", discountAmount: 0 };
+    }
+
+    const user = await this.databaseService.user.findUnique({
+      where: { id: userId },
+      select: {
+        referredByUserId: true,
+        referralDiscountUsed: true,
+        referralSignupAt: true,
+      },
+    });
+
+    if (!user?.referredByUserId) {
+      return { eligible: false, reason: "User was not referred", discountAmount: 0 };
+    }
+
+    if (user.referralDiscountUsed) {
+      return { eligible: false, reason: "Referral discount already used", discountAmount: 0 };
+    }
+
+    const existingReserved = await this.databaseService.booking.findFirst({
+      where: {
+        userId,
+        referralStatus: { in: [BookingReferralStatus.APPLIED, BookingReferralStatus.REWARDED] },
+        status: {
+          in: [BookingStatus.PENDING, BookingStatus.CONFIRMED, BookingStatus.ACTIVE],
+        },
+      },
+      select: { id: true },
+    });
+
+    if (existingReserved) {
+      return {
+        eligible: false,
+        reason: "Referral discount already reserved or used",
+        discountAmount: 0,
+      };
+    }
+
+    if (bookingAmount < config.REFERRAL_MIN_BOOKING_AMOUNT) {
+      return {
+        eligible: false,
+        reason: `Booking amount must be at least ₦${config.REFERRAL_MIN_BOOKING_AMOUNT.toLocaleString()}`,
+        discountAmount: 0,
+      };
+    }
+
+    if (!config.REFERRAL_ELIGIBLE_TYPES.includes(bookingType)) {
+      return {
+        eligible: false,
+        reason: "Booking type is not eligible for referral discount",
+        discountAmount: 0,
+      };
+    }
+
+    if (config.REFERRAL_EXPIRY_DAYS > 0 && user.referralSignupAt) {
+      const expiryDate = new Date(user.referralSignupAt);
+      expiryDate.setDate(expiryDate.getDate() + config.REFERRAL_EXPIRY_DAYS);
+
+      if (new Date() > expiryDate) {
+        return { eligible: false, reason: "Referral discount has expired", discountAmount: 0 };
+      }
+    }
+
+    return {
+      eligible: true,
+      discountAmount: Math.min(config.REFERRAL_DISCOUNT_AMOUNT, bookingAmount),
+      reason: undefined,
+    };
+  }
+
+  async getUserReferralSummary(
+    userId: string,
+    requestOrigin: string,
+  ): Promise<ReferralUserSummaryResponse | null> {
+    const [referralInfo, bookingCredits, config] = await Promise.all([
+      this.databaseService.user.findUnique({
+        where: { id: userId },
+        select: {
+          referralCode: true,
+          referredByUserId: true,
+          referralDiscountUsed: true,
+          referralSignupAt: true,
+          referralStats: {
+            select: {
+              totalReferrals: true,
+              totalRewardsGranted: true,
+              totalRewardsPending: true,
+              lastReferralAt: true,
+            },
+          },
+          referrals: {
+            select: {
+              id: true,
+              name: true,
+              email: true,
+              createdAt: true,
+            },
+          },
+          referralRewardsEarned: {
+            select: {
+              id: true,
+              amount: true,
+              status: true,
+              createdAt: true,
+              processedAt: true,
+              referee: {
+                select: {
+                  name: true,
+                  email: true,
+                },
+              },
+            },
+            orderBy: { createdAt: "desc" },
+            take: 50,
+          },
+        },
+      }),
+      this.getUserBookingCredits(userId),
+      this.getReferralConfig(),
+    ]);
+
+    if (!referralInfo) {
+      return null;
+    }
+
+    const shareLink = referralInfo.referralCode
+      ? `${requestOrigin}/auth?ref=${referralInfo.referralCode}`
+      : null;
+
+    const totalRewardsGranted = this.decimalToNumber(
+      referralInfo.referralStats?.totalRewardsGranted,
+    );
+    const totalRewardsPending = this.decimalToNumber(
+      referralInfo.referralStats?.totalRewardsPending,
+    );
+
+    return {
+      referralCode: referralInfo.referralCode,
+      shareLink,
+      hasUsedDiscount: referralInfo.referralDiscountUsed,
+      referredBy: referralInfo.referredByUserId,
+      signupDate: referralInfo.referralSignupAt,
+      stats: {
+        totalReferrals: referralInfo.referralStats?.totalReferrals ?? 0,
+        totalRewardsGranted,
+        totalRewardsPending,
+        lastReferralAt: referralInfo.referralStats?.lastReferralAt ?? null,
+        totalEarned: bookingCredits.totalEarned,
+        totalUsed: bookingCredits.totalUsed,
+        availableCredits: bookingCredits.availableCredits,
+        maxCreditsPerBooking: config.REFERRAL_MAX_CREDITS_PER_BOOKING,
+      },
+      referrals: referralInfo.referrals,
+      rewards: referralInfo.referralRewardsEarned.map((reward) => ({
+        id: reward.id,
+        amount: this.decimalToNumber(reward.amount),
+        status: reward.status,
+        createdAt: reward.createdAt,
+        processedAt: reward.processedAt,
+        refereeName: reward.referee?.name || reward.referee?.email || "Unknown",
+      })),
+    };
+  }
+
+  private async getReferralConfig(): Promise<ReferralConfig> {
+    const now = Date.now();
+    if (this.configCache && this.configCache.expiresAt > now) {
+      return this.configCache.value;
+    }
+
+    const rows = await this.databaseService.referralProgramConfig.findMany();
+    const map = rows.reduce<Record<string, unknown>>((acc, row) => {
+      acc[row.key] = row.value;
+      return acc;
+    }, {});
+
+    const config: ReferralConfig = {
+      REFERRAL_ENABLED: Boolean(map.REFERRAL_ENABLED ?? true),
+      REFERRAL_DISCOUNT_AMOUNT: Number(map.REFERRAL_DISCOUNT_AMOUNT ?? 10000),
+      REFERRAL_MIN_BOOKING_AMOUNT: Number(map.REFERRAL_MIN_BOOKING_AMOUNT ?? 20000),
+      REFERRAL_ELIGIBLE_TYPES: this.asStringArray(map.REFERRAL_ELIGIBLE_TYPES, [
+        "DAY",
+        "NIGHT",
+        "FULL_DAY",
+      ]),
+      REFERRAL_RELEASE_CONDITION: map.REFERRAL_RELEASE_CONDITION === "PAID" ? "PAID" : "COMPLETED",
+      REFERRAL_EXPIRY_DAYS: Number(map.REFERRAL_EXPIRY_DAYS ?? 30),
+      REFERRAL_MAX_CREDITS_PER_BOOKING: Number(map.REFERRAL_MAX_CREDITS_PER_BOOKING ?? 30000),
+    };
+
+    this.configCache = {
+      value: config,
+      expiresAt: now + this.configTtlMs,
+    };
+
+    return config;
+  }
+
+  private async getUserBookingCredits(userId: string) {
+    const [stats, usedCredits, reservedCredits] = await Promise.all([
+      this.databaseService.userReferralStats.findUnique({
+        where: { userId },
+        select: { totalRewardsGranted: true },
+      }),
+      this.databaseService.booking.aggregate({
+        where: {
+          paymentStatus: PaymentStatus.PAID,
+          userId,
+          referralCreditsUsed: { gt: 0 },
+        },
+        _sum: { referralCreditsUsed: true },
+      }),
+      this.databaseService.booking.aggregate({
+        where: {
+          paymentStatus: PaymentStatus.UNPAID,
+          status: { notIn: [BookingStatus.CANCELLED] },
+          userId,
+          referralCreditsReserved: { gt: 0 },
+        },
+        _sum: { referralCreditsReserved: true },
+      }),
+    ]);
+
+    const totalEarned = this.decimalToNumber(stats?.totalRewardsGranted);
+    const totalUsed = this.decimalToNumber(usedCredits._sum.referralCreditsUsed);
+    const totalReserved = this.decimalToNumber(reservedCredits._sum.referralCreditsReserved);
+
+    return {
+      totalEarned,
+      totalUsed,
+      totalReserved,
+      availableCredits: Math.max(0, totalEarned - totalUsed - totalReserved),
+    };
+  }
+
+  private decimalToNumber(value: Prisma.Decimal | number | null | undefined): number {
+    if (value === null || value === undefined) {
+      return 0;
+    }
+    if (typeof value === "number") {
+      return value;
+    }
+    return value.toNumber();
+  }
+
+  private asStringArray(value: unknown, fallback: string[]): string[] {
+    if (!Array.isArray(value)) {
+      return fallback;
+    }
+    const strings = value.filter((item): item is string => typeof item === "string");
+    return strings.length > 0 ? strings : fallback;
+  }
+}

--- a/src/modules/referral/referral-processing.service.spec.ts
+++ b/src/modules/referral/referral-processing.service.spec.ts
@@ -1,0 +1,856 @@
+import { getQueueToken } from "@nestjs/bullmq";
+import { Test, TestingModule } from "@nestjs/testing";
+import { BookingReferralStatus, ReferralRewardStatus } from "@prisma/client";
+import { Queue } from "bullmq";
+import { REFERRAL_QUEUE } from "src/config/constants";
+import { createBooking } from "src/shared/helper.fixtures";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DatabaseService } from "../database/database.service";
+import { PROCESS_REFERRAL_COMPLETION, ReferralJobData } from "./referral.interface";
+import { ReferralProcessingService } from "./referral-processing.service";
+
+describe("ReferralProcessingService", () => {
+  let service: ReferralProcessingService;
+  let databaseService: DatabaseService;
+  let mockQueue: Partial<Queue<ReferralJobData>>;
+
+  beforeEach(async () => {
+    mockQueue = {
+      add: vi.fn().mockResolvedValue({ id: "job-123" }),
+    };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReferralProcessingService,
+        {
+          provide: DatabaseService,
+          useValue: {
+            referralProgramConfig: {
+              findMany: vi.fn(),
+            },
+            booking: {
+              findUnique: vi.fn(),
+              update: vi.fn(),
+            },
+            user: {
+              findUnique: vi.fn(),
+              update: vi.fn(),
+            },
+            referralReward: {
+              findFirst: vi.fn(),
+              update: vi.fn(),
+            },
+            $transaction: vi.fn(),
+            userReferralStats: {
+              upsert: vi.fn(),
+            },
+          },
+        },
+        {
+          provide: getQueueToken(REFERRAL_QUEUE),
+          useValue: mockQueue,
+        },
+      ],
+    }).compile();
+
+    service = module.get<ReferralProcessingService>(ReferralProcessingService);
+    databaseService = module.get<DatabaseService>(DatabaseService);
+  });
+
+  describe("processReferralCompletionForBooking - Configuration-Based Early Returns", () => {
+    it("should skip processing when REFERRAL_ENABLED is false", async () => {
+      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
+        { key: "REFERRAL_ENABLED", value: false, updatedAt: new Date(), updatedBy: "system" },
+        {
+          key: "REFERRAL_RELEASE_CONDITION",
+          value: "COMPLETED",
+          updatedAt: new Date(),
+          updatedBy: "system",
+        },
+      ]);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(databaseService.referralProgramConfig.findMany).toHaveBeenCalled();
+      expect(databaseService.booking.findUnique).not.toHaveBeenCalled();
+    });
+
+    it("should skip processing when REFERRAL_RELEASE_CONDITION is PAID (not COMPLETED)", async () => {
+      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
+        { key: "REFERRAL_ENABLED", value: true, updatedAt: new Date(), updatedBy: "system" },
+        {
+          key: "REFERRAL_RELEASE_CONDITION",
+          value: "PAID",
+          updatedAt: new Date(),
+          updatedBy: "system",
+        },
+      ]);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(databaseService.referralProgramConfig.findMany).toHaveBeenCalled();
+      expect(databaseService.booking.findUnique).not.toHaveBeenCalled();
+    });
+
+    it("should skip processing when REFERRAL_ENABLED is false AND REFERRAL_RELEASE_CONDITION is PAID", async () => {
+      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
+        { key: "REFERRAL_ENABLED", value: false, updatedAt: new Date(), updatedBy: "system" },
+        {
+          key: "REFERRAL_RELEASE_CONDITION",
+          value: "PAID",
+          updatedAt: new Date(),
+          updatedBy: "system",
+        },
+      ]);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(databaseService.referralProgramConfig.findMany).toHaveBeenCalled();
+      expect(databaseService.booking.findUnique).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("processReferralCompletionForBooking - Booking Eligibility Checks", () => {
+    beforeEach(() => {
+      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
+        { key: "REFERRAL_ENABLED", value: true, updatedAt: new Date(), updatedBy: "system" },
+        {
+          key: "REFERRAL_RELEASE_CONDITION",
+          value: "COMPLETED",
+          updatedAt: new Date(),
+          updatedBy: "system",
+        },
+      ]);
+    });
+
+    it("should skip processing when booking does not exist", async () => {
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValue(null);
+
+      await service.processReferralCompletionForBooking("non-existent-booking");
+
+      expect(databaseService.booking.findUnique).toHaveBeenCalledWith({
+        where: { id: "non-existent-booking" },
+        select: {
+          id: true,
+          userId: true,
+          referralReferrerUserId: true,
+          referralStatus: true,
+        },
+      });
+      expect(databaseService.$transaction).not.toHaveBeenCalled();
+    });
+
+    it("should skip processing when booking referralStatus is not APPLIED", async () => {
+      const booking = createBooking({ id: "booking-1231" });
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValue(booking);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(databaseService.booking.findUnique).toHaveBeenCalled();
+      expect(databaseService.$transaction).not.toHaveBeenCalled();
+    });
+
+    it("should skip processing when booking has no userId", async () => {
+      const booking = createBooking({
+        id: "booking-1231",
+        referralStatus: BookingReferralStatus.APPLIED,
+        referralReferrerUserId: "referrer-123",
+        userId: undefined,
+      });
+
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValue(booking);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(databaseService.booking.findUnique).toHaveBeenCalled();
+      expect(databaseService.$transaction).not.toHaveBeenCalled();
+    });
+
+    it("should skip processing when booking has no referralReferrerUserId", async () => {
+      const booking = createBooking({
+        id: "booking-1231",
+        referralStatus: BookingReferralStatus.APPLIED,
+        referralReferrerUserId: undefined,
+      });
+
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValue(booking);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(databaseService.booking.findUnique).toHaveBeenCalled();
+      expect(databaseService.$transaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("processReferralCompletionForBooking - Idempotency and Transaction Logic", () => {
+    beforeEach(() => {
+      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
+        { key: "REFERRAL_ENABLED", value: true, updatedAt: new Date(), updatedBy: "system" },
+        {
+          key: "REFERRAL_RELEASE_CONDITION",
+          value: "COMPLETED",
+          updatedAt: new Date(),
+          updatedBy: "system",
+        },
+        { key: "REFERRAL_EXPIRY_DAYS", value: 0, updatedAt: new Date(), updatedBy: "system" },
+      ]);
+
+      const booking = createBooking({
+        id: "booking-1231",
+        referralStatus: BookingReferralStatus.APPLIED,
+        referralReferrerUserId: "referrer-123",
+      });
+
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValue(booking);
+    });
+
+    it("should skip processing when reward is already released (idempotency)", async () => {
+      const mockTransaction = vi.fn(async (callback) => {
+        const mockTx = {
+          referralReward: {
+            findFirst: vi.fn().mockResolvedValue({
+              id: "reward-already-released",
+              status: ReferralRewardStatus.RELEASED,
+            }),
+          },
+        };
+        return callback(mockTx);
+      });
+
+      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(databaseService.$transaction).toHaveBeenCalled();
+    });
+  });
+
+  describe("processReferralCompletionForBooking - Expiry Window Checks", () => {
+    beforeEach(() => {
+      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
+        { key: "REFERRAL_ENABLED", value: true, updatedAt: new Date(), updatedBy: "system" },
+        {
+          key: "REFERRAL_RELEASE_CONDITION",
+          value: "COMPLETED",
+          updatedAt: new Date(),
+          updatedBy: "system",
+        },
+        { key: "REFERRAL_EXPIRY_DAYS", value: 30, updatedAt: new Date(), updatedBy: "system" },
+      ]);
+
+      const booking = createBooking({
+        id: "booking-1231",
+        referralStatus: BookingReferralStatus.APPLIED,
+        referralReferrerUserId: "referrer-123",
+      });
+
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValue(booking);
+    });
+
+    it("should skip processing when referral has expired", async () => {
+      const fortyDaysAgo = new Date();
+      fortyDaysAgo.setDate(fortyDaysAgo.getDate() - 40);
+
+      const mockTransaction = vi.fn(async (callback) => {
+        const mockTx = {
+          referralReward: {
+            findFirst: vi.fn().mockResolvedValue(null),
+          },
+          user: {
+            findUnique: vi.fn().mockResolvedValue({
+              id: "user-123",
+              referralSignupAt: fortyDaysAgo,
+              referralDiscountUsed: false,
+            }),
+          },
+        };
+        return callback(mockTx);
+      });
+
+      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(databaseService.$transaction).toHaveBeenCalled();
+    });
+
+    it("should process when within expiry window - signup date is 20 days ago (within 30 day window)", async () => {
+      const twentyDaysAgo = new Date();
+      twentyDaysAgo.setDate(twentyDaysAgo.getDate() - 20);
+
+      const mockTransaction = vi.fn(async (callback) => {
+        const mockTx = {
+          referralReward: {
+            findFirst: vi
+              .fn()
+              .mockResolvedValueOnce(null) // First call: check if already released
+              .mockResolvedValueOnce({
+                // Second call: find pending reward
+                id: "reward-123",
+                bookingId: "booking-123",
+                referrerUserId: "referrer-123",
+                amount: 1000,
+                status: ReferralRewardStatus.PENDING,
+              }),
+            update: vi.fn().mockResolvedValue({}),
+          },
+          user: {
+            findUnique: vi.fn().mockResolvedValue({
+              id: "user-123",
+              referralSignupAt: twentyDaysAgo,
+              referralDiscountUsed: false,
+            }),
+            update: vi.fn().mockResolvedValue({}),
+          },
+          booking: {
+            update: vi.fn().mockResolvedValue({}),
+          },
+          userReferralStats: {
+            upsert: vi.fn().mockResolvedValue({}),
+          },
+        };
+        return callback(mockTx);
+      });
+
+      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(databaseService.$transaction).toHaveBeenCalled();
+    });
+
+    it("should process when REFERRAL_EXPIRY_DAYS is 0 (disabled)", async () => {
+      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
+        { key: "REFERRAL_ENABLED", value: true, updatedAt: new Date(), updatedBy: "system" },
+        {
+          key: "REFERRAL_RELEASE_CONDITION",
+          value: "COMPLETED",
+          updatedAt: new Date(),
+          updatedBy: "system",
+        },
+        { key: "REFERRAL_EXPIRY_DAYS", value: 0, updatedAt: new Date(), updatedBy: "system" },
+      ]);
+
+      const veryOldDate = new Date("2020-01-01");
+
+      const mockTransaction = vi.fn(async (callback) => {
+        const mockTx = {
+          referralReward: {
+            findFirst: vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce({
+              id: "reward-123",
+              bookingId: "booking-123",
+              referrerUserId: "referrer-123",
+              amount: 1000,
+              status: ReferralRewardStatus.PENDING,
+            }),
+            update: vi.fn().mockResolvedValue({}),
+          },
+          user: {
+            findUnique: vi.fn().mockResolvedValue({
+              id: "user-123",
+              referralSignupAt: veryOldDate,
+              referralDiscountUsed: false,
+            }),
+            update: vi.fn().mockResolvedValue({}),
+          },
+          booking: {
+            update: vi.fn().mockResolvedValue({}),
+          },
+          userReferralStats: {
+            upsert: vi.fn().mockResolvedValue({}),
+          },
+        };
+        return callback(mockTx);
+      });
+
+      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(databaseService.$transaction).toHaveBeenCalled();
+    });
+
+    it("should process when referee has no referralSignupAt date", async () => {
+      const mockTransaction = vi.fn(async (callback) => {
+        const mockTx = {
+          referralReward: {
+            findFirst: vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce({
+              id: "reward-123",
+              bookingId: "booking-123",
+              referrerUserId: "referrer-123",
+              amount: 1000,
+              status: ReferralRewardStatus.PENDING,
+            }),
+            update: vi.fn().mockResolvedValue({}),
+          },
+          user: {
+            findUnique: vi.fn().mockResolvedValue({
+              id: "user-123",
+              referralSignupAt: null,
+              referralDiscountUsed: false,
+            }),
+            update: vi.fn().mockResolvedValue({}),
+          },
+          booking: {
+            update: vi.fn().mockResolvedValue({}),
+          },
+          userReferralStats: {
+            upsert: vi.fn().mockResolvedValue({}),
+          },
+        };
+        return callback(mockTx);
+      });
+
+      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(databaseService.$transaction).toHaveBeenCalled();
+    });
+  });
+
+  describe("processReferralCompletionForBooking - Pending Reward Checks", () => {
+    beforeEach(() => {
+      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
+        { key: "REFERRAL_ENABLED", value: true, updatedAt: new Date(), updatedBy: "system" },
+        {
+          key: "REFERRAL_RELEASE_CONDITION",
+          value: "COMPLETED",
+          updatedAt: new Date(),
+          updatedBy: "system",
+        },
+        { key: "REFERRAL_EXPIRY_DAYS", value: 0, updatedAt: new Date(), updatedBy: "system" },
+      ]);
+
+      const booking = createBooking({
+        referralReferrerUserId: "referrer-123",
+        referralStatus: BookingReferralStatus.APPLIED,
+      });
+
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValue(booking);
+    });
+
+    it("should skip processing when no pending reward is found", async () => {
+      const mockTransaction = vi.fn(async (callback) => {
+        const mockTx = {
+          referralReward: {
+            findFirst: vi
+              .fn()
+              .mockResolvedValueOnce(null) // Not already released
+              .mockResolvedValueOnce(null), // No pending reward
+          },
+          user: {
+            findUnique: vi.fn().mockResolvedValue({
+              id: "user-123",
+              referralSignupAt: new Date(),
+              referralDiscountUsed: false,
+            }),
+            update: vi.fn().mockResolvedValue({}),
+          },
+        };
+        return callback(mockTx);
+      });
+
+      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(databaseService.$transaction).toHaveBeenCalled();
+    });
+
+    it("should skip processing when only non-PENDING rewards exist", async () => {
+      const mockTransaction = vi.fn(async (callback) => {
+        const mockTx = {
+          referralReward: {
+            findFirst: vi
+              .fn()
+              .mockResolvedValueOnce(null) // Not already released
+              .mockResolvedValueOnce(null), // No pending reward (could be CANCELLED)
+          },
+          user: {
+            findUnique: vi.fn().mockResolvedValue({
+              id: "user-123",
+              referralSignupAt: new Date(),
+              referralDiscountUsed: false,
+            }),
+            update: vi.fn().mockResolvedValue({}),
+          },
+        };
+        return callback(mockTx);
+      });
+
+      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(databaseService.$transaction).toHaveBeenCalled();
+    });
+  });
+
+  describe("processReferralCompletionForBooking - Discount Usage Marking", () => {
+    beforeEach(() => {
+      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
+        { key: "REFERRAL_ENABLED", value: true, updatedAt: new Date(), updatedBy: "system" },
+        {
+          key: "REFERRAL_RELEASE_CONDITION",
+          value: "COMPLETED",
+          updatedAt: new Date(),
+          updatedBy: "system",
+        },
+        { key: "REFERRAL_EXPIRY_DAYS", value: 0, updatedAt: new Date(), updatedBy: "system" },
+      ]);
+
+      const booking = createBooking({
+        referralReferrerUserId: "referrer-123",
+        referralStatus: BookingReferralStatus.APPLIED,
+      });
+
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValue(booking);
+    });
+
+    it("should mark referee discount as used when not already marked", async () => {
+      const mockUserUpdate = vi.fn().mockResolvedValue({});
+
+      const mockTransaction = vi.fn(async (callback) => {
+        const mockTx = {
+          referralReward: {
+            findFirst: vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce({
+              id: "reward-123",
+              bookingId: "booking-123",
+              referrerUserId: "referrer-123",
+              amount: 1000,
+              status: ReferralRewardStatus.PENDING,
+            }),
+            update: vi.fn().mockResolvedValue({}),
+          },
+          user: {
+            findUnique: vi.fn().mockResolvedValue({
+              id: "user-123",
+              referralSignupAt: new Date(),
+              referralDiscountUsed: false,
+            }),
+            update: mockUserUpdate,
+          },
+          booking: {
+            update: vi.fn().mockResolvedValue({}),
+          },
+          userReferralStats: {
+            upsert: vi.fn().mockResolvedValue({}),
+          },
+        };
+        return callback(mockTx);
+      });
+
+      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(mockUserUpdate).toHaveBeenCalledWith({
+        where: { id: "user-123" },
+        data: { referralDiscountUsed: true },
+      });
+    });
+
+    it("should NOT update discount when already marked as used", async () => {
+      const mockUserUpdate = vi.fn().mockResolvedValue({});
+
+      const mockTransaction = vi.fn(async (callback) => {
+        const mockTx = {
+          referralReward: {
+            findFirst: vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce({
+              id: "reward-123",
+              bookingId: "booking-123",
+              referrerUserId: "referrer-123",
+              amount: 1000,
+              status: ReferralRewardStatus.PENDING,
+            }),
+            update: vi.fn().mockResolvedValue({}),
+          },
+          user: {
+            findUnique: vi.fn().mockResolvedValue({
+              id: "user-123",
+              referralSignupAt: new Date(),
+              referralDiscountUsed: true, // Already used
+            }),
+            update: mockUserUpdate,
+          },
+          booking: {
+            update: vi.fn().mockResolvedValue({}),
+          },
+          userReferralStats: {
+            upsert: vi.fn().mockResolvedValue({}),
+          },
+        };
+        return callback(mockTx);
+      });
+
+      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(mockUserUpdate).not.toHaveBeenCalled();
+    });
+
+    it("should handle missing referee data gracefully", async () => {
+      const mockTransaction = vi.fn(async (callback) => {
+        const mockTx = {
+          referralReward: {
+            findFirst: vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce({
+              id: "reward-123",
+              bookingId: "booking-123",
+              referrerUserId: "referrer-123",
+              amount: 1000,
+              status: ReferralRewardStatus.PENDING,
+            }),
+            update: vi.fn().mockResolvedValue({}),
+          },
+          user: {
+            findUnique: vi.fn().mockResolvedValue(null),
+          },
+          booking: {
+            update: vi.fn().mockResolvedValue({}),
+          },
+          userReferralStats: {
+            upsert: vi.fn().mockResolvedValue({}),
+          },
+        };
+        return callback(mockTx);
+      });
+
+      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(databaseService.$transaction).toHaveBeenCalled();
+    });
+  });
+
+  describe("processReferralCompletionForBooking - Successful Processing Path", () => {
+    beforeEach(() => {
+      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
+        { key: "REFERRAL_ENABLED", value: true, updatedAt: new Date(), updatedBy: "system" },
+        {
+          key: "REFERRAL_RELEASE_CONDITION",
+          value: "COMPLETED",
+          updatedAt: new Date(),
+          updatedBy: "system",
+        },
+        { key: "REFERRAL_EXPIRY_DAYS", value: 0, updatedAt: new Date(), updatedBy: "system" },
+      ]);
+
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValue(
+        createBooking({
+          referralReferrerUserId: "referrer-123",
+          referralStatus: BookingReferralStatus.APPLIED,
+        }),
+      );
+    });
+
+    it("should successfully release reward and create new referrer stats", async () => {
+      const mockRewardUpdate = vi.fn().mockResolvedValue({});
+      const mockBookingUpdate = vi.fn().mockResolvedValue({});
+      const mockStatsUpsert = vi.fn().mockResolvedValue({});
+
+      const mockTransaction = vi.fn(async (callback) => {
+        const mockTx = {
+          referralReward: {
+            findFirst: vi
+              .fn()
+              .mockResolvedValueOnce(null) // Not already released
+              .mockResolvedValueOnce({
+                // Pending reward exists
+                id: "reward-123",
+                bookingId: "booking-123",
+                referrerUserId: "referrer-123",
+                amount: 1000,
+                status: ReferralRewardStatus.PENDING,
+              }),
+            update: mockRewardUpdate,
+          },
+          user: {
+            findUnique: vi.fn().mockResolvedValue({
+              id: "user-123",
+              referralSignupAt: new Date(),
+              referralDiscountUsed: false,
+            }),
+            update: vi.fn().mockResolvedValue({}),
+          },
+          booking: {
+            update: mockBookingUpdate,
+          },
+          userReferralStats: {
+            upsert: mockStatsUpsert,
+          },
+        };
+        return callback(mockTx);
+      });
+
+      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(mockRewardUpdate).toHaveBeenCalledWith({
+        where: { id: "reward-123" },
+        data: expect.objectContaining({
+          status: ReferralRewardStatus.RELEASED,
+          processedAt: expect.any(Date),
+        }),
+      });
+
+      expect(mockBookingUpdate).toHaveBeenCalledWith({
+        where: { id: "booking-123" },
+        data: { referralStatus: BookingReferralStatus.REWARDED },
+      });
+
+      expect(mockStatsUpsert).toHaveBeenCalledWith({
+        where: { userId: "referrer-123" },
+        create: {
+          userId: "referrer-123",
+          totalReferrals: 0,
+          totalRewardsGranted: 1000,
+          totalRewardsPending: 0,
+          lastReferralAt: expect.any(Date),
+        },
+        update: {
+          totalRewardsGranted: { increment: 1000 },
+          totalRewardsPending: { decrement: 1000 },
+          lastReferralAt: expect.any(Date),
+        },
+      });
+    });
+
+    it("should successfully release reward and update existing referrer stats", async () => {
+      const mockStatsUpsert = vi.fn().mockResolvedValue({});
+
+      const mockTransaction = vi.fn(async (callback) => {
+        const mockTx = {
+          referralReward: {
+            findFirst: vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce({
+              id: "reward-123",
+              bookingId: "booking-123",
+              referrerUserId: "referrer-123",
+              amount: 500,
+              status: ReferralRewardStatus.PENDING,
+            }),
+            update: vi.fn().mockResolvedValue({}),
+          },
+          user: {
+            findUnique: vi.fn().mockResolvedValue({
+              id: "user-123",
+              referralSignupAt: new Date(),
+              referralDiscountUsed: true,
+            }),
+            update: vi.fn().mockResolvedValue({}),
+          },
+          booking: {
+            update: vi.fn().mockResolvedValue({}),
+          },
+          userReferralStats: {
+            upsert: mockStatsUpsert,
+          },
+        };
+        return callback(mockTx);
+      });
+
+      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(mockStatsUpsert).toHaveBeenCalledWith({
+        where: { userId: "referrer-123" },
+        create: expect.anything(),
+        update: {
+          totalRewardsGranted: { increment: 500 },
+          totalRewardsPending: { decrement: 500 },
+          lastReferralAt: expect.any(Date),
+        },
+      });
+    });
+  });
+
+  describe("processReferralCompletionForBooking - Transaction and Error Handling", () => {
+    beforeEach(() => {
+      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
+        { key: "REFERRAL_ENABLED", value: true, updatedAt: new Date(), updatedBy: "system" },
+        {
+          key: "REFERRAL_RELEASE_CONDITION",
+          value: "COMPLETED",
+          updatedAt: new Date(),
+          updatedBy: "system",
+        },
+        { key: "REFERRAL_EXPIRY_DAYS", value: 0, updatedAt: new Date(), updatedBy: "system" },
+      ]);
+
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValue(
+        createBooking({
+          id: "booking-123",
+          userId: "user-123",
+          referralReferrerUserId: "referrer-123",
+          referralStatus: BookingReferralStatus.APPLIED,
+        }),
+      );
+    });
+
+    it("should rollback all changes if any database operation fails", async () => {
+      const mockTransaction = vi.fn(async () => {
+        throw new Error("Database constraint violation");
+      });
+
+      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
+
+      await service.processReferralCompletionForBooking("booking-123");
+
+      expect(databaseService.$transaction).toHaveBeenCalled();
+    });
+
+    it("should catch and log errors without throwing", async () => {
+      const mockTransaction = vi.fn(async () => {
+        throw new Error("Unexpected database error");
+      });
+
+      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
+
+      await expect(
+        service.processReferralCompletionForBooking("booking-123"),
+      ).resolves.not.toThrow();
+    });
+
+    it("should handle database connection errors gracefully", async () => {
+      const mockTransaction = vi.fn(async () => {
+        const error = new Error("Connection timeout");
+        error.name = "DatabaseConnectionError";
+        throw error;
+      });
+
+      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
+
+      await expect(
+        service.processReferralCompletionForBooking("booking-123"),
+      ).resolves.not.toThrow();
+
+      expect(databaseService.$transaction).toHaveBeenCalled();
+    });
+  });
+
+  describe("queueReferralProcessing", () => {
+    it("should successfully queue a referral processing job", async () => {
+      const bookingId = "booking-123";
+
+      await service.queueReferralProcessing(bookingId);
+
+      expect(mockQueue.add).toHaveBeenCalledWith(PROCESS_REFERRAL_COMPLETION, {
+        bookingId,
+        timestamp: expect.any(String),
+      });
+    });
+
+    it("should throw error when queue fails", async () => {
+      const bookingId = "booking-123";
+      const queueError = new Error("Redis connection failed");
+      vi.mocked(mockQueue.add).mockRejectedValue(queueError);
+
+      await expect(service.queueReferralProcessing(bookingId)).rejects.toThrow(
+        "Redis connection failed",
+      );
+    });
+  });
+});

--- a/src/modules/referral/referral-processing.service.ts
+++ b/src/modules/referral/referral-processing.service.ts
@@ -1,0 +1,209 @@
+import { InjectQueue } from "@nestjs/bullmq";
+import { Injectable, Logger } from "@nestjs/common";
+import { BookingReferralStatus, ReferralRewardStatus } from "@prisma/client";
+import { Queue } from "bullmq";
+import { REFERRAL_QUEUE } from "../../config/constants";
+import { DatabaseService } from "../database/database.service";
+import { PROCESS_REFERRAL_COMPLETION, ReferralJobData } from "./referral.interface";
+
+@Injectable()
+export class ReferralProcessingService {
+  private readonly logger = new Logger(ReferralProcessingService.name);
+
+  constructor(
+    private readonly databaseService: DatabaseService,
+    @InjectQueue(REFERRAL_QUEUE)
+    private readonly referralQueue: Queue<ReferralJobData>,
+  ) {}
+
+  /**
+   * Queue a referral completion job for async processing
+   */
+  async queueReferralProcessing(bookingId: string): Promise<void> {
+    try {
+      await this.referralQueue.add(PROCESS_REFERRAL_COMPLETION, {
+        bookingId,
+        timestamp: new Date().toISOString(),
+      });
+
+      this.logger.log(`Queued referral processing for booking ${bookingId}`);
+    } catch (error) {
+      this.logger.error("Failed to queue referral processing", {
+        bookingId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Process referral release for a completed booking when configured for COMPLETED.
+   * - Checks global referral config and idempotency
+   * - Optionally enforces expiry window
+   * - Marks referee discount as used
+   * - Releases pending reward and updates stats
+   * - Sets booking.referralStatus = REWARDED
+   */
+  async processReferralCompletionForBooking(bookingId: string) {
+    // Load config
+    const configs = await this.databaseService.referralProgramConfig.findMany();
+    const configMap = configs.reduce<Record<string, unknown>>((acc, c) => {
+      acc[c.key] = c.value;
+      return acc;
+    }, {});
+
+    const REFERRAL_ENABLED = configMap.REFERRAL_ENABLED ?? true;
+    const REFERRAL_RELEASE_CONDITION = (configMap.REFERRAL_RELEASE_CONDITION ?? "COMPLETED") as
+      | "PAID"
+      | "COMPLETED";
+
+    if (REFERRAL_RELEASE_CONDITION !== "PAID" && REFERRAL_RELEASE_CONDITION !== "COMPLETED") {
+      this.logger.warn("Invalid REFERRAL_RELEASE_CONDITION value", {
+        value: REFERRAL_RELEASE_CONDITION,
+      });
+      return;
+    }
+
+    const REFERRAL_EXPIRY_DAYS = Number(configMap.REFERRAL_EXPIRY_DAYS ?? 0);
+
+    if (!REFERRAL_ENABLED || REFERRAL_RELEASE_CONDITION !== "COMPLETED") {
+      this.logger.log("Skipping referral completion due to config", {
+        REFERRAL_ENABLED,
+        REFERRAL_RELEASE_CONDITION,
+      });
+      return;
+    }
+
+    const booking = await this.databaseService.booking.findUnique({
+      where: { id: bookingId },
+      select: {
+        id: true,
+        userId: true,
+        referralReferrerUserId: true,
+        referralStatus: true,
+      },
+    });
+
+    if (
+      booking?.referralStatus !== BookingReferralStatus.APPLIED ||
+      !booking?.userId ||
+      !booking?.referralReferrerUserId
+    ) {
+      this.logger.log("Skipping referral completion: booking not eligible", {
+        bookingId,
+        hasBooking: !!booking,
+        referralStatus: booking?.referralStatus,
+        hasUser: !!booking?.userId,
+        hasReferrer: !!booking?.referralReferrerUserId,
+      });
+      return;
+    }
+
+    try {
+      await this.databaseService.$transaction(async (tx) => {
+        // Idempotency: skip if already released
+        const alreadyReleased = await tx.referralReward.findFirst({
+          where: { bookingId: booking.id, status: ReferralRewardStatus.RELEASED },
+          select: { id: true },
+        });
+
+        if (alreadyReleased) {
+          this.logger.warn("Referral reward already released for booking", {
+            bookingId: booking.id,
+            rewardId: alreadyReleased.id,
+          });
+          return;
+        }
+
+        // Optional expiry check
+        const referee = await tx.user.findUnique({
+          where: { id: booking.userId },
+          select: { referralSignupAt: true, referralDiscountUsed: true },
+        });
+
+        if (REFERRAL_EXPIRY_DAYS > 0 && referee?.referralSignupAt) {
+          const daysSinceSignup = Math.floor(
+            (Date.now() - referee.referralSignupAt.getTime()) / (1000 * 60 * 60 * 24),
+          );
+
+          if (daysSinceSignup > REFERRAL_EXPIRY_DAYS) {
+            this.logger.warn("Referral expired before completion; not releasing reward", {
+              bookingId: booking.id,
+              userId: booking.userId,
+              daysSinceSignup,
+              expiryDays: REFERRAL_EXPIRY_DAYS,
+            });
+            return;
+          }
+        }
+
+        // Mark discount used if not already.
+        // Note: This is a fallback for bookings created before the race condition fix.
+        // New bookings set referralDiscountUsed=true during booking creation (in the same transaction)
+        // to prevent concurrent bookings from all receiving the one-time discount.
+        if (referee && !referee.referralDiscountUsed) {
+          await tx.user.update({
+            where: { id: booking.userId },
+            data: { referralDiscountUsed: true },
+          });
+
+          this.logger.log("Referral discount marked as used on completion (fallback)", {
+            bookingId: booking.id,
+            userId: booking.userId,
+          });
+        }
+
+        // Release pending reward
+        const pendingReward = await tx.referralReward.findFirst({
+          where: { bookingId: booking.id, status: ReferralRewardStatus.PENDING },
+        });
+
+        if (!pendingReward) {
+          this.logger.log("No pending referral reward found for booking", {
+            bookingId: booking.id,
+          });
+          return;
+        }
+
+        await tx.referralReward.update({
+          where: { id: pendingReward.id },
+          data: { status: ReferralRewardStatus.RELEASED, processedAt: new Date() },
+        });
+
+        await tx.booking.update({
+          where: { id: booking.id },
+          data: { referralStatus: BookingReferralStatus.REWARDED },
+        });
+
+        await tx.userReferralStats.upsert({
+          where: { userId: pendingReward.referrerUserId },
+          create: {
+            userId: pendingReward.referrerUserId,
+            totalReferrals: 0,
+            totalRewardsGranted: pendingReward.amount,
+            totalRewardsPending: 0,
+            lastReferralAt: new Date(),
+          },
+          update: {
+            totalRewardsGranted: { increment: pendingReward.amount },
+            totalRewardsPending: { decrement: pendingReward.amount },
+            lastReferralAt: new Date(),
+          },
+        });
+
+        this.logger.log("Referral reward released on completion", {
+          bookingId: booking.id,
+          rewardId: pendingReward.id,
+          rewardAmount: pendingReward.amount,
+          referrerId: pendingReward.referrerUserId,
+        });
+      });
+    } catch (error) {
+      this.logger.error("Failed to process referral completion", {
+        bookingId: booking.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      // Don't throw - allow graceful degradation
+    }
+  }
+}

--- a/src/modules/referral/referral-throttler.guard.ts
+++ b/src/modules/referral/referral-throttler.guard.ts
@@ -1,0 +1,80 @@
+import { CanActivate, ExecutionContext, Injectable } from "@nestjs/common";
+import { ThrottlerStorage } from "@nestjs/throttler";
+import type { Response } from "express";
+import {
+  getClientIp,
+  getRetryAfterSeconds,
+  isThrottled,
+  setRateLimitHeaders,
+} from "../../common/throttling/throttling.helper";
+import { AUTH_SESSION_KEY, type AuthSession } from "../auth/guards/session.guard";
+import { ReferralRateLimitExceededException } from "./referral.error";
+import type { ReferralThrottleRequestContext } from "./referral.interface";
+
+@Injectable()
+export class ReferralThrottlerGuard implements CanActivate {
+  private readonly ttlMs = 60 * 60 * 1000;
+  private readonly ttlSeconds = 60 * 60;
+  private readonly userLimit = 20;
+  private readonly ipLimit = 60;
+
+  constructor(private readonly throttlerStorage: ThrottlerStorage) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<
+      ReferralThrottleRequestContext & {
+        [AUTH_SESSION_KEY]?: AuthSession;
+      }
+    >();
+    const response = context.switchToHttp().getResponse<Response>();
+
+    const ipTracker = getClientIp(request);
+    const userTracker = this.getUserTracker(request);
+    const routePath = request.route?.path || "validate";
+    const method = request.method || "GET";
+
+    const userHit = await this.throttlerStorage.increment(
+      `referral-validation:user:${method}:${routePath}:${userTracker}`,
+      this.ttlMs,
+      this.userLimit,
+      this.ttlMs,
+      "referral-validation",
+    );
+
+    const ipHit = await this.throttlerStorage.increment(
+      `referral-validation:ip:${method}:${routePath}:${ipTracker}`,
+      this.ttlMs,
+      this.ipLimit,
+      this.ttlMs,
+      "referral-validation",
+    );
+
+    const userBlocked = isThrottled(userHit, this.userLimit);
+    const ipBlocked = isThrottled(ipHit, this.ipLimit);
+
+    if (!userBlocked && !ipBlocked) {
+      return true;
+    }
+
+    const activeHit = userBlocked ? userHit : ipHit;
+    const activeLimit = userBlocked ? this.userLimit : this.ipLimit;
+    const retryAfter = getRetryAfterSeconds(activeHit, this.ttlSeconds);
+
+    setRateLimitHeaders(response, {
+      limit: activeLimit,
+      windowSeconds: this.ttlSeconds,
+      retryAfterSeconds: retryAfter,
+      remaining: 0,
+    });
+
+    throw new ReferralRateLimitExceededException();
+  }
+
+  private getUserTracker(
+    request: ReferralThrottleRequestContext & {
+      [AUTH_SESSION_KEY]?: AuthSession;
+    },
+  ): string {
+    return request[AUTH_SESSION_KEY]?.user?.id || "anonymous";
+  }
+}

--- a/src/modules/referral/referral.controller.spec.ts
+++ b/src/modules/referral/referral.controller.spec.ts
@@ -1,0 +1,147 @@
+import { Reflector } from "@nestjs/core";
+import { Test, type TestingModule } from "@nestjs/testing";
+import { ThrottlerModule } from "@nestjs/throttler";
+import type { Response } from "express";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthService } from "../auth/auth.service";
+import type { AuthSession } from "../auth/guards/session.guard";
+import { ReferralController } from "./referral.controller";
+import { ReferralService } from "./referral.service";
+
+function createMockAuthUser(overrides: Partial<AuthSession["user"]> = {}): AuthSession["user"] {
+  const now = new Date("2026-01-01T00:00:00.000Z");
+  return {
+    id: "user-1",
+    createdAt: now,
+    updatedAt: now,
+    emailVerified: false,
+    name: "Test User",
+    email: "test-user@example.com",
+    image: null,
+    roles: ["user"],
+    ...overrides,
+  };
+}
+
+describe("ReferralController", () => {
+  let controller: ReferralController;
+  let referralService: ReferralService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        ThrottlerModule.forRoot([
+          {
+            name: "default",
+            ttl: 3600,
+            limit: 10,
+          },
+        ]),
+      ],
+      controllers: [ReferralController],
+      providers: [
+        {
+          provide: ReferralService,
+          useValue: {
+            validateReferralCode: vi.fn(),
+            getReferralEligibility: vi.fn(),
+            getCurrentUserReferralInfo: vi.fn(),
+          },
+        },
+        {
+          provide: AuthService,
+          useValue: {
+            isInitialized: true,
+            auth: {
+              api: {
+                getSession: vi.fn().mockResolvedValue(null),
+              },
+            },
+            getUserRoles: vi.fn().mockResolvedValue(["user"]),
+          },
+        },
+        Reflector,
+      ],
+    }).compile();
+
+    controller = module.get<ReferralController>(ReferralController);
+    referralService = module.get<ReferralService>(ReferralService);
+  });
+
+  it("validates referral code and returns successful payload", async () => {
+    vi.mocked(referralService.validateReferralCode).mockResolvedValue({
+      valid: true,
+      referrer: { name: "Referrer Name" },
+      message: "Valid referral code.",
+    });
+
+    const response = {
+      setHeader: vi.fn(),
+    };
+
+    const result = await controller.validateReferralCode(
+      "ABCDEFGH",
+      { email: "new-user@example.com" },
+      response as unknown as Response,
+    );
+
+    expect(result).toEqual({
+      valid: true,
+      referrer: { name: "Referrer Name" },
+      message: "Valid referral code.",
+    });
+    expect(response.setHeader).toHaveBeenCalledWith("Cache-Control", "no-store");
+  });
+
+  it("returns eligibility payload for authenticated user", async () => {
+    vi.mocked(referralService.getReferralEligibility).mockResolvedValue({
+      eligible: true,
+      discountAmount: 5000,
+      reason: undefined,
+    });
+
+    const result = await controller.getReferralEligibility(createMockAuthUser(), {
+      amount: 50000,
+      type: "DAY",
+    });
+
+    expect(result).toEqual({
+      eligible: true,
+      discountAmount: 5000,
+      reason: undefined,
+    });
+  });
+
+  it("returns user referral info for authenticated user", async () => {
+    vi.mocked(referralService.getCurrentUserReferralInfo).mockResolvedValue({
+      referralCode: "ABCDEFGH",
+      shareLink: "http://localhost:3000/auth?ref=ABCDEFGH",
+      hasUsedDiscount: false,
+      referredBy: null,
+      signupDate: null,
+      stats: {
+        totalReferrals: 1,
+        totalRewardsGranted: 1000,
+        totalRewardsPending: 0,
+        lastReferralAt: null,
+        totalEarned: 1000,
+        totalUsed: 0,
+        availableCredits: 1000,
+        maxCreditsPerBooking: 30000,
+      },
+      referrals: [],
+      rewards: [],
+    });
+
+    const request = {
+      headers: {},
+      protocol: "http",
+      get: vi.fn().mockReturnValue("localhost:3000"),
+    } as never;
+
+    const result = await controller.getCurrentUserReferralInfo(createMockAuthUser(), request);
+
+    expect(result.referralCode).toBe("ABCDEFGH");
+    expect(referralService.getCurrentUserReferralInfo).toHaveBeenCalledWith("user-1", request);
+  });
+});

--- a/src/modules/referral/referral.controller.spec.ts
+++ b/src/modules/referral/referral.controller.spec.ts
@@ -1,7 +1,7 @@
 import { Reflector } from "@nestjs/core";
 import { Test, type TestingModule } from "@nestjs/testing";
 import { ThrottlerModule } from "@nestjs/throttler";
-import type { Response } from "express";
+import type { Request, Response } from "express";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AuthService } from "../auth/auth.service";
 import type { AuthSession } from "../auth/guards/session.guard";
@@ -137,7 +137,7 @@ describe("ReferralController", () => {
       headers: {},
       protocol: "http",
       get: vi.fn().mockReturnValue("localhost:3000"),
-    } as never;
+    } as unknown as Request;
 
     const result = await controller.getCurrentUserReferralInfo(createMockAuthUser(), request);
 

--- a/src/modules/referral/referral.controller.ts
+++ b/src/modules/referral/referral.controller.ts
@@ -1,0 +1,48 @@
+import { Controller, Get, Req, Res, UseGuards } from "@nestjs/common";
+import type { Request, Response } from "express";
+import { ZodParam, ZodQuery } from "../../common/decorators/zod-validation.decorator";
+import { CurrentUser } from "../auth/decorators/current-user.decorator";
+import { type AuthSession, SessionGuard } from "../auth/guards/session.guard";
+import {
+  type ReferralEligibilityQueryDto,
+  referralCodeParamSchema,
+  referralEligibilityQuerySchema,
+  type ValidateReferralQueryDto,
+  validateReferralQuerySchema,
+} from "./dto/referral.dto";
+import { ReferralService } from "./referral.service";
+import { ReferralThrottlerGuard } from "./referral-throttler.guard";
+
+@Controller("api/referrals")
+export class ReferralController {
+  constructor(private readonly referralService: ReferralService) {}
+
+  @Get("validate/:code")
+  @UseGuards(SessionGuard, ReferralThrottlerGuard)
+  async validateReferralCode(
+    @ZodParam("code", referralCodeParamSchema) code: string,
+    @ZodQuery(validateReferralQuerySchema) query: ValidateReferralQueryDto,
+    @Res({ passthrough: true }) response: Response,
+  ) {
+    response.setHeader("Cache-Control", "no-store");
+    return this.referralService.validateReferralCode(code, query);
+  }
+
+  @Get("eligibility")
+  @UseGuards(SessionGuard)
+  async getReferralEligibility(
+    @CurrentUser() user: AuthSession["user"],
+    @ZodQuery(referralEligibilityQuerySchema) query: ReferralEligibilityQueryDto,
+  ) {
+    return this.referralService.getReferralEligibility(user.id, query);
+  }
+
+  @Get("user")
+  @UseGuards(SessionGuard)
+  async getCurrentUserReferralInfo(
+    @CurrentUser() user: AuthSession["user"],
+    @Req() request: Request,
+  ) {
+    return this.referralService.getCurrentUserReferralInfo(user.id, request);
+  }
+}

--- a/src/modules/referral/referral.error.ts
+++ b/src/modules/referral/referral.error.ts
@@ -1,0 +1,98 @@
+import { HttpStatus } from "@nestjs/common";
+import { AppException } from "../../common/errors/app.exception";
+
+export const ReferralErrorCode = {
+  INVALID_REFERRAL_CODE: "INVALID_REFERRAL_CODE",
+  SELF_REFERRAL: "SELF_REFERRAL",
+  REFERRAL_RATE_LIMIT_EXCEEDED: "REFERRAL_RATE_LIMIT_EXCEEDED",
+  REFERRAL_VALIDATION_FAILED: "REFERRAL_VALIDATION_FAILED",
+  REFERRAL_ELIGIBILITY_CHECK_FAILED: "REFERRAL_ELIGIBILITY_CHECK_FAILED",
+  REFERRAL_USER_FETCH_FAILED: "REFERRAL_USER_FETCH_FAILED",
+  REFERRAL_USER_NOT_FOUND: "REFERRAL_USER_NOT_FOUND",
+} as const;
+
+export class ReferralException extends AppException {
+  constructor(errorCode: string, detail: string, status: HttpStatus, title: string) {
+    super(errorCode, detail, status, {
+      type: errorCode,
+      title,
+    });
+  }
+}
+
+export class ReferralInvalidCodeException extends ReferralException {
+  constructor() {
+    super(
+      ReferralErrorCode.INVALID_REFERRAL_CODE,
+      "The referral code you entered is invalid.",
+      HttpStatus.NOT_FOUND,
+      "Referral Code Not Found",
+    );
+  }
+}
+
+export class ReferralSelfReferralException extends ReferralException {
+  constructor() {
+    super(
+      ReferralErrorCode.SELF_REFERRAL,
+      "You cannot refer yourself.",
+      HttpStatus.BAD_REQUEST,
+      "Invalid Referral Request",
+    );
+  }
+}
+
+export class ReferralRateLimitExceededException extends ReferralException {
+  constructor() {
+    super(
+      ReferralErrorCode.REFERRAL_RATE_LIMIT_EXCEEDED,
+      "Too many validation attempts. Please try again later.",
+      HttpStatus.TOO_MANY_REQUESTS,
+      "Too Many Referral Validation Attempts",
+    );
+  }
+}
+
+export class ReferralValidationFailedException extends ReferralException {
+  constructor() {
+    super(
+      ReferralErrorCode.REFERRAL_VALIDATION_FAILED,
+      "Failed to validate referral code",
+      HttpStatus.INTERNAL_SERVER_ERROR,
+      "Referral Validation Failed",
+    );
+  }
+}
+
+export class ReferralEligibilityCheckFailedException extends ReferralException {
+  constructor() {
+    super(
+      ReferralErrorCode.REFERRAL_ELIGIBILITY_CHECK_FAILED,
+      "Failed to check referral eligibility",
+      HttpStatus.INTERNAL_SERVER_ERROR,
+      "Referral Eligibility Check Failed",
+    );
+  }
+}
+
+export class ReferralUserFetchFailedException extends ReferralException {
+  constructor() {
+    super(
+      ReferralErrorCode.REFERRAL_USER_FETCH_FAILED,
+      "Failed to fetch referral information",
+      HttpStatus.INTERNAL_SERVER_ERROR,
+      "Referral Fetch Failed",
+    );
+  }
+}
+
+export class ReferralUserNotFoundException extends ReferralException {
+  constructor() {
+    super(
+      ReferralErrorCode.REFERRAL_USER_NOT_FOUND,
+      "User not found",
+      HttpStatus.NOT_FOUND,
+      "Referral User Not Found",
+    );
+  }
+}

--- a/src/modules/referral/referral.interface.ts
+++ b/src/modules/referral/referral.interface.ts
@@ -4,3 +4,72 @@ export interface ReferralJobData {
 }
 
 export const PROCESS_REFERRAL_COMPLETION = "process-referral-completion";
+
+export interface ReferralConfig {
+  REFERRAL_ENABLED: boolean;
+  REFERRAL_DISCOUNT_AMOUNT: number;
+  REFERRAL_MIN_BOOKING_AMOUNT: number;
+  REFERRAL_ELIGIBLE_TYPES: string[];
+  REFERRAL_RELEASE_CONDITION: "PAID" | "COMPLETED";
+  REFERRAL_EXPIRY_DAYS: number;
+  REFERRAL_MAX_CREDITS_PER_BOOKING: number;
+}
+
+export interface ReferralStatsResponse {
+  totalReferrals: number;
+  totalRewardsGranted: number;
+  totalRewardsPending: number;
+  lastReferralAt: Date | null;
+  totalEarned: number;
+  totalUsed: number;
+  availableCredits: number;
+  maxCreditsPerBooking: number;
+}
+
+export interface ReferralUserSummaryResponse {
+  referralCode: string | null;
+  shareLink: string | null;
+  hasUsedDiscount: boolean;
+  referredBy: string | null;
+  signupDate: Date | null;
+  stats: ReferralStatsResponse;
+  referrals: Array<{
+    id: string;
+    name: string | null;
+    email: string;
+    createdAt: Date;
+  }>;
+  rewards: Array<{
+    id: string;
+    amount: number;
+    status: string;
+    createdAt: Date;
+    processedAt: Date | null;
+    refereeName: string;
+  }>;
+}
+
+export interface RateLimitEntry {
+  count: number;
+  resetAt: number;
+}
+
+export interface RateLimitDecision {
+  allowed: boolean;
+  limit: number;
+  remaining: number;
+  resetAt: number;
+  retryAfterSeconds: number;
+}
+
+export interface ReferralThrottleRequestContext {
+  ip?: string;
+  headers?: Record<string, string | string[] | undefined>;
+  route?: { path?: string };
+  method?: string;
+  authSession?: {
+    user?: {
+      id?: string;
+    };
+  };
+}

--- a/src/modules/referral/referral.interface.ts
+++ b/src/modules/referral/referral.interface.ts
@@ -49,19 +49,6 @@ export interface ReferralUserSummaryResponse {
   }>;
 }
 
-export interface RateLimitEntry {
-  count: number;
-  resetAt: number;
-}
-
-export interface RateLimitDecision {
-  allowed: boolean;
-  limit: number;
-  remaining: number;
-  resetAt: number;
-  retryAfterSeconds: number;
-}
-
 export interface ReferralThrottleRequestContext {
   ip?: string;
   headers?: Record<string, string | string[] | undefined>;

--- a/src/modules/referral/referral.module.ts
+++ b/src/modules/referral/referral.module.ts
@@ -23,6 +23,11 @@ import { ReferralThrottlerGuard } from "./referral-throttler.guard";
         ttl: 3600,
         limit: 10,
       },
+      {
+        name: "manual-triggers",
+        ttl: 3600,
+        limit: 1,
+      },
     ]),
     BullModule.registerQueue({
       name: REFERRAL_QUEUE,

--- a/src/modules/referral/referral.module.ts
+++ b/src/modules/referral/referral.module.ts
@@ -20,12 +20,12 @@ import { ReferralThrottlerGuard } from "./referral-throttler.guard";
     ThrottlerModule.forRoot([
       {
         name: "referral-validation",
-        ttl: 3600,
+        ttl: 3600 * 1000,
         limit: 10,
       },
       {
         name: "manual-triggers",
-        ttl: 3600,
+        ttl: 3600 * 1000,
         limit: 1,
       },
     ]),

--- a/src/modules/referral/referral.processor.ts
+++ b/src/modules/referral/referral.processor.ts
@@ -3,13 +3,13 @@ import { Logger } from "@nestjs/common";
 import { Job } from "bullmq";
 import { REFERRAL_QUEUE } from "../../config/constants";
 import { PROCESS_REFERRAL_COMPLETION, ReferralJobData } from "./referral.interface";
-import { ReferralService } from "./referral.service";
+import { ReferralProcessingService } from "./referral-processing.service";
 
 @Processor(REFERRAL_QUEUE)
 export class ReferralProcessor extends WorkerHost {
   private readonly logger = new Logger(ReferralProcessor.name);
 
-  constructor(private readonly referralService: ReferralService) {
+  constructor(private readonly referralProcessingService: ReferralProcessingService) {
     super();
   }
 
@@ -21,7 +21,9 @@ export class ReferralProcessor extends WorkerHost {
 
     try {
       if (job.name === PROCESS_REFERRAL_COMPLETION) {
-        await this.referralService.processReferralCompletionForBooking(job.data.bookingId);
+        await this.referralProcessingService.processReferralCompletionForBooking(
+          job.data.bookingId,
+        );
         this.logger.log(
           `Referral completion processed successfully for booking ${job.data.bookingId}`,
         );

--- a/src/modules/referral/referral.service.spec.ts
+++ b/src/modules/referral/referral.service.spec.ts
@@ -1,862 +1,102 @@
-/** biome-ignore-all lint/complexity/useLiteralKeys: Bracket notation required to access private logger property for test spies */
-import { getQueueToken } from "@nestjs/bullmq";
-import { Test, TestingModule } from "@nestjs/testing";
-import { BookingReferralStatus, ReferralRewardStatus } from "@prisma/client";
-import { Queue } from "bullmq";
-import { REFERRAL_QUEUE } from "src/config/constants";
-import { createBooking } from "src/shared/helper.fixtures";
+import { Test, type TestingModule } from "@nestjs/testing";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { DatabaseService } from "../database/database.service";
-import { PROCESS_REFERRAL_COMPLETION, ReferralJobData } from "./referral.interface";
+import {
+  ReferralInvalidCodeException,
+  ReferralUserNotFoundException,
+  ReferralValidationFailedException,
+} from "./referral.error";
 import { ReferralService } from "./referral.service";
+import { ReferralApiService } from "./referral-api.service";
+import { ReferralProcessingService } from "./referral-processing.service";
 
 describe("ReferralService", () => {
   let service: ReferralService;
-  let databaseService: DatabaseService;
-  let mockQueue: Partial<Queue<ReferralJobData>>;
+  let referralApiService: ReferralApiService;
+  let referralProcessingService: ReferralProcessingService;
 
   beforeEach(async () => {
-    mockQueue = {
-      add: vi.fn().mockResolvedValue({ id: "job-123" }),
-    };
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ReferralService,
         {
-          provide: DatabaseService,
+          provide: ReferralApiService,
           useValue: {
-            referralProgramConfig: {
-              findMany: vi.fn(),
-            },
-            booking: {
-              findUnique: vi.fn(),
-              update: vi.fn(),
-            },
-            user: {
-              findUnique: vi.fn(),
-              update: vi.fn(),
-            },
-            referralReward: {
-              findFirst: vi.fn(),
-              update: vi.fn(),
-            },
-            $transaction: vi.fn(),
-            userReferralStats: {
-              upsert: vi.fn(),
-            },
+            validateReferralCode: vi.fn(),
+            checkReferralEligibility: vi.fn(),
+            getUserReferralSummary: vi.fn(),
           },
         },
         {
-          provide: getQueueToken(REFERRAL_QUEUE),
-          useValue: mockQueue,
+          provide: ReferralProcessingService,
+          useValue: {
+            queueReferralProcessing: vi.fn(),
+            processReferralCompletionForBooking: vi.fn(),
+          },
         },
       ],
     }).compile();
 
     service = module.get<ReferralService>(ReferralService);
-    databaseService = module.get<DatabaseService>(DatabaseService);
-
-    // Suppress logger output during tests
-    vi.spyOn(service["logger"], "log").mockImplementation(() => undefined);
-    vi.spyOn(service["logger"], "error").mockImplementation(() => undefined);
-    vi.spyOn(service["logger"], "warn").mockImplementation(() => undefined);
-    vi.spyOn(service["logger"], "debug").mockImplementation(() => undefined);
+    referralApiService = module.get<ReferralApiService>(ReferralApiService);
+    referralProcessingService = module.get<ReferralProcessingService>(ReferralProcessingService);
   });
-  describe("processReferralCompletionForBooking - Configuration-Based Early Returns", () => {
-    it("should skip processing when REFERRAL_ENABLED is false", async () => {
-      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
-        { key: "REFERRAL_ENABLED", value: false, updatedAt: new Date(), updatedBy: "system" },
-        {
-          key: "REFERRAL_RELEASE_CONDITION",
-          value: "COMPLETED",
-          updatedAt: new Date(),
-          updatedBy: "system",
-        },
-      ]);
 
-      await service.processReferralCompletionForBooking("booking-123");
+  it("delegates queue referral processing", async () => {
+    await service.queueReferralProcessing("booking-1");
+    expect(referralProcessingService.queueReferralProcessing).toHaveBeenCalledWith("booking-1");
+  });
 
-      expect(databaseService.referralProgramConfig.findMany).toHaveBeenCalled();
-      expect(databaseService.booking.findUnique).not.toHaveBeenCalled();
+  it("returns normalized validate payload", async () => {
+    vi.mocked(referralApiService.validateReferralCode).mockResolvedValue({
+      id: "user-1",
+      email: "referrer@example.com",
+      referralCode: "ABCDEFGH",
+      name: null,
     });
 
-    it("should skip processing when REFERRAL_RELEASE_CONDITION is PAID (not COMPLETED)", async () => {
-      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
-        { key: "REFERRAL_ENABLED", value: true, updatedAt: new Date(), updatedBy: "system" },
-        {
-          key: "REFERRAL_RELEASE_CONDITION",
-          value: "PAID",
-          updatedAt: new Date(),
-          updatedBy: "system",
-        },
-      ]);
-
-      await service.processReferralCompletionForBooking("booking-123");
-
-      expect(databaseService.referralProgramConfig.findMany).toHaveBeenCalled();
-      expect(databaseService.booking.findUnique).not.toHaveBeenCalled();
+    const result = await service.validateReferralCode("ABCDEFGH", {
+      email: "new@example.com",
     });
 
-    it("should skip processing when REFERRAL_ENABLED is false AND REFERRAL_RELEASE_CONDITION is PAID", async () => {
-      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
-        { key: "REFERRAL_ENABLED", value: false, updatedAt: new Date(), updatedBy: "system" },
-        {
-          key: "REFERRAL_RELEASE_CONDITION",
-          value: "PAID",
-          updatedAt: new Date(),
-          updatedBy: "system",
-        },
-      ]);
-
-      await service.processReferralCompletionForBooking("booking-123");
-
-      expect(databaseService.referralProgramConfig.findMany).toHaveBeenCalled();
-      expect(databaseService.booking.findUnique).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      valid: true,
+      referrer: { name: "Anonymous" },
+      message: "Valid referral code.",
     });
   });
 
-  describe("processReferralCompletionForBooking - Booking Eligibility Checks", () => {
-    beforeEach(() => {
-      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
-        { key: "REFERRAL_ENABLED", value: true, updatedAt: new Date(), updatedBy: "system" },
-        {
-          key: "REFERRAL_RELEASE_CONDITION",
-          value: "COMPLETED",
-          updatedAt: new Date(),
-          updatedBy: "system",
-        },
-      ]);
-    });
+  it("rethrows known referral errors during validation", async () => {
+    const knownError = new ReferralInvalidCodeException();
+    vi.mocked(referralApiService.validateReferralCode).mockRejectedValue(knownError);
 
-    it("should skip processing when booking does not exist", async () => {
-      vi.mocked(databaseService.booking.findUnique).mockResolvedValue(null);
-
-      await service.processReferralCompletionForBooking("non-existent-booking");
-
-      expect(databaseService.booking.findUnique).toHaveBeenCalledWith({
-        where: { id: "non-existent-booking" },
-        select: {
-          id: true,
-          userId: true,
-          referralReferrerUserId: true,
-          referralStatus: true,
-        },
-      });
-      expect(databaseService.$transaction).not.toHaveBeenCalled();
-    });
-
-    it("should skip processing when booking referralStatus is not APPLIED", async () => {
-      const booking = createBooking({ id: "booking-1231" });
-      vi.mocked(databaseService.booking.findUnique).mockResolvedValue(booking);
-
-      await service.processReferralCompletionForBooking("booking-123");
-
-      expect(databaseService.booking.findUnique).toHaveBeenCalled();
-      expect(databaseService.$transaction).not.toHaveBeenCalled();
-    });
-
-    it("should skip processing when booking has no userId", async () => {
-      const booking = createBooking({
-        id: "booking-1231",
-        referralStatus: BookingReferralStatus.APPLIED,
-        referralReferrerUserId: "referrer-123",
-        userId: undefined,
-      });
-
-      vi.mocked(databaseService.booking.findUnique).mockResolvedValue(booking);
-
-      await service.processReferralCompletionForBooking("booking-123");
-
-      expect(databaseService.booking.findUnique).toHaveBeenCalled();
-      expect(databaseService.$transaction).not.toHaveBeenCalled();
-    });
-
-    it("should skip processing when booking has no referralReferrerUserId", async () => {
-      const booking = createBooking({
-        id: "booking-1231",
-        referralStatus: BookingReferralStatus.APPLIED,
-        referralReferrerUserId: undefined,
-      });
-
-      vi.mocked(databaseService.booking.findUnique).mockResolvedValue(booking);
-
-      await service.processReferralCompletionForBooking("booking-123");
-
-      expect(databaseService.booking.findUnique).toHaveBeenCalled();
-      expect(databaseService.$transaction).not.toHaveBeenCalled();
-    });
+    await expect(
+      service.validateReferralCode("ABCDEFGH", {
+        email: "new@example.com",
+      }),
+    ).rejects.toBe(knownError);
   });
 
-  describe("processReferralCompletionForBooking - Idempotency and Transaction Logic", () => {
-    beforeEach(() => {
-      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
-        { key: "REFERRAL_ENABLED", value: true, updatedAt: new Date(), updatedBy: "system" },
-        {
-          key: "REFERRAL_RELEASE_CONDITION",
-          value: "COMPLETED",
-          updatedAt: new Date(),
-          updatedBy: "system",
-        },
-        { key: "REFERRAL_EXPIRY_DAYS", value: 0, updatedAt: new Date(), updatedBy: "system" },
-      ]);
+  it("throws generic validation failed error for unknown exceptions", async () => {
+    vi.mocked(referralApiService.validateReferralCode).mockRejectedValue(new Error("boom"));
 
-      const booking = createBooking({
-        id: "booking-1231",
-        referralStatus: BookingReferralStatus.APPLIED,
-        referralReferrerUserId: "referrer-123",
-      });
-
-      vi.mocked(databaseService.booking.findUnique).mockResolvedValue(booking);
-    });
-
-    it("should skip processing when reward is already released (idempotency)", async () => {
-      const mockTransaction = vi.fn(async (callback) => {
-        const mockTx = {
-          referralReward: {
-            findFirst: vi.fn().mockResolvedValue({
-              id: "reward-already-released",
-              status: ReferralRewardStatus.RELEASED,
-            }),
-          },
-        };
-        return callback(mockTx);
-      });
-
-      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
-
-      await service.processReferralCompletionForBooking("booking-123");
-
-      expect(databaseService.$transaction).toHaveBeenCalled();
-    });
+    await expect(
+      service.validateReferralCode("ABCDEFGH", {
+        email: "new@example.com",
+      }),
+    ).rejects.toBeInstanceOf(ReferralValidationFailedException);
   });
 
-  describe("processReferralCompletionForBooking - Expiry Window Checks", () => {
-    beforeEach(() => {
-      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
-        { key: "REFERRAL_ENABLED", value: true, updatedAt: new Date(), updatedBy: "system" },
-        {
-          key: "REFERRAL_RELEASE_CONDITION",
-          value: "COMPLETED",
-          updatedAt: new Date(),
-          updatedBy: "system",
-        },
-        { key: "REFERRAL_EXPIRY_DAYS", value: 30, updatedAt: new Date(), updatedBy: "system" },
-      ]);
-
-      const booking = createBooking({
-        id: "booking-1231",
-        referralStatus: BookingReferralStatus.APPLIED,
-        referralReferrerUserId: "referrer-123",
-      });
-
-      vi.mocked(databaseService.booking.findUnique).mockResolvedValue(booking);
-    });
-
-    it("should skip processing when referral has expired", async () => {
-      const fortyDaysAgo = new Date();
-      fortyDaysAgo.setDate(fortyDaysAgo.getDate() - 40);
-
-      const mockTransaction = vi.fn(async (callback) => {
-        const mockTx = {
-          referralReward: {
-            findFirst: vi.fn().mockResolvedValue(null),
-          },
-          user: {
-            findUnique: vi.fn().mockResolvedValue({
-              id: "user-123",
-              referralSignupAt: fortyDaysAgo,
-              referralDiscountUsed: false,
-            }),
-          },
-        };
-        return callback(mockTx);
-      });
-
-      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
-
-      await service.processReferralCompletionForBooking("booking-123");
-
-      expect(databaseService.$transaction).toHaveBeenCalled();
-    });
-
-    it("should process when within expiry window - signup date is 20 days ago (within 30 day window)", async () => {
-      const twentyDaysAgo = new Date();
-      twentyDaysAgo.setDate(twentyDaysAgo.getDate() - 20);
-
-      const mockTransaction = vi.fn(async (callback) => {
-        const mockTx = {
-          referralReward: {
-            findFirst: vi
-              .fn()
-              .mockResolvedValueOnce(null) // First call: check if already released
-              .mockResolvedValueOnce({
-                // Second call: find pending reward
-                id: "reward-123",
-                bookingId: "booking-123",
-                referrerUserId: "referrer-123",
-                amount: 1000,
-                status: ReferralRewardStatus.PENDING,
-              }),
-            update: vi.fn().mockResolvedValue({}),
-          },
-          user: {
-            findUnique: vi.fn().mockResolvedValue({
-              id: "user-123",
-              referralSignupAt: twentyDaysAgo,
-              referralDiscountUsed: false,
-            }),
-            update: vi.fn().mockResolvedValue({}),
-          },
-          booking: {
-            update: vi.fn().mockResolvedValue({}),
-          },
-          userReferralStats: {
-            upsert: vi.fn().mockResolvedValue({}),
-          },
-        };
-        return callback(mockTx);
-      });
-
-      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
-
-      await service.processReferralCompletionForBooking("booking-123");
-
-      expect(databaseService.$transaction).toHaveBeenCalled();
-    });
-
-    it("should process when REFERRAL_EXPIRY_DAYS is 0 (disabled)", async () => {
-      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
-        { key: "REFERRAL_ENABLED", value: true, updatedAt: new Date(), updatedBy: "system" },
-        {
-          key: "REFERRAL_RELEASE_CONDITION",
-          value: "COMPLETED",
-          updatedAt: new Date(),
-          updatedBy: "system",
-        },
-        { key: "REFERRAL_EXPIRY_DAYS", value: 0, updatedAt: new Date(), updatedBy: "system" },
-      ]);
-
-      const veryOldDate = new Date("2020-01-01");
-
-      const mockTransaction = vi.fn(async (callback) => {
-        const mockTx = {
-          referralReward: {
-            findFirst: vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce({
-              id: "reward-123",
-              bookingId: "booking-123",
-              referrerUserId: "referrer-123",
-              amount: 1000,
-              status: ReferralRewardStatus.PENDING,
-            }),
-            update: vi.fn().mockResolvedValue({}),
-          },
-          user: {
-            findUnique: vi.fn().mockResolvedValue({
-              id: "user-123",
-              referralSignupAt: veryOldDate,
-              referralDiscountUsed: false,
-            }),
-            update: vi.fn().mockResolvedValue({}),
-          },
-          booking: {
-            update: vi.fn().mockResolvedValue({}),
-          },
-          userReferralStats: {
-            upsert: vi.fn().mockResolvedValue({}),
-          },
-        };
-        return callback(mockTx);
-      });
-
-      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
-
-      await service.processReferralCompletionForBooking("booking-123");
-
-      expect(databaseService.$transaction).toHaveBeenCalled();
-    });
-
-    it("should process when referee has no referralSignupAt date", async () => {
-      const mockTransaction = vi.fn(async (callback) => {
-        const mockTx = {
-          referralReward: {
-            findFirst: vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce({
-              id: "reward-123",
-              bookingId: "booking-123",
-              referrerUserId: "referrer-123",
-              amount: 1000,
-              status: ReferralRewardStatus.PENDING,
-            }),
-            update: vi.fn().mockResolvedValue({}),
-          },
-          user: {
-            findUnique: vi.fn().mockResolvedValue({
-              id: "user-123",
-              referralSignupAt: null,
-              referralDiscountUsed: false,
-            }),
-            update: vi.fn().mockResolvedValue({}),
-          },
-          booking: {
-            update: vi.fn().mockResolvedValue({}),
-          },
-          userReferralStats: {
-            upsert: vi.fn().mockResolvedValue({}),
-          },
-        };
-        return callback(mockTx);
-      });
-
-      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
-
-      await service.processReferralCompletionForBooking("booking-123");
-
-      expect(databaseService.$transaction).toHaveBeenCalled();
-    });
-  });
-
-  describe("processReferralCompletionForBooking - Pending Reward Checks", () => {
-    beforeEach(() => {
-      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
-        { key: "REFERRAL_ENABLED", value: true, updatedAt: new Date(), updatedBy: "system" },
-        {
-          key: "REFERRAL_RELEASE_CONDITION",
-          value: "COMPLETED",
-          updatedAt: new Date(),
-          updatedBy: "system",
-        },
-        { key: "REFERRAL_EXPIRY_DAYS", value: 0, updatedAt: new Date(), updatedBy: "system" },
-      ]);
-
-      const booking = createBooking({
-        referralReferrerUserId: "referrer-123",
-        referralStatus: BookingReferralStatus.APPLIED,
-      });
-
-      vi.mocked(databaseService.booking.findUnique).mockResolvedValue(booking);
-    });
-
-    it("should skip processing when no pending reward is found", async () => {
-      const mockTransaction = vi.fn(async (callback) => {
-        const mockTx = {
-          referralReward: {
-            findFirst: vi
-              .fn()
-              .mockResolvedValueOnce(null) // Not already released
-              .mockResolvedValueOnce(null), // No pending reward
-          },
-          user: {
-            findUnique: vi.fn().mockResolvedValue({
-              id: "user-123",
-              referralSignupAt: new Date(),
-              referralDiscountUsed: false,
-            }),
-            update: vi.fn().mockResolvedValue({}),
-          },
-        };
-        return callback(mockTx);
-      });
-
-      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
-
-      await service.processReferralCompletionForBooking("booking-123");
-
-      expect(databaseService.$transaction).toHaveBeenCalled();
-    });
-
-    it("should skip processing when only non-PENDING rewards exist", async () => {
-      const mockTransaction = vi.fn(async (callback) => {
-        const mockTx = {
-          referralReward: {
-            findFirst: vi
-              .fn()
-              .mockResolvedValueOnce(null) // Not already released
-              .mockResolvedValueOnce(null), // No pending reward (could be CANCELLED)
-          },
-          user: {
-            findUnique: vi.fn().mockResolvedValue({
-              id: "user-123",
-              referralSignupAt: new Date(),
-              referralDiscountUsed: false,
-            }),
-            update: vi.fn().mockResolvedValue({}),
-          },
-        };
-        return callback(mockTx);
-      });
-
-      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
-
-      await service.processReferralCompletionForBooking("booking-123");
-
-      expect(databaseService.$transaction).toHaveBeenCalled();
-    });
-  });
-
-  describe("processReferralCompletionForBooking - Discount Usage Marking", () => {
-    beforeEach(() => {
-      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
-        { key: "REFERRAL_ENABLED", value: true, updatedAt: new Date(), updatedBy: "system" },
-        {
-          key: "REFERRAL_RELEASE_CONDITION",
-          value: "COMPLETED",
-          updatedAt: new Date(),
-          updatedBy: "system",
-        },
-        { key: "REFERRAL_EXPIRY_DAYS", value: 0, updatedAt: new Date(), updatedBy: "system" },
-      ]);
-
-      const booking = createBooking({
-        referralReferrerUserId: "referrer-123",
-        referralStatus: BookingReferralStatus.APPLIED,
-      });
-
-      vi.mocked(databaseService.booking.findUnique).mockResolvedValue(booking);
-    });
-
-    it("should mark referee discount as used when not already marked", async () => {
-      const mockUserUpdate = vi.fn().mockResolvedValue({});
-
-      const mockTransaction = vi.fn(async (callback) => {
-        const mockTx = {
-          referralReward: {
-            findFirst: vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce({
-              id: "reward-123",
-              bookingId: "booking-123",
-              referrerUserId: "referrer-123",
-              amount: 1000,
-              status: ReferralRewardStatus.PENDING,
-            }),
-            update: vi.fn().mockResolvedValue({}),
-          },
-          user: {
-            findUnique: vi.fn().mockResolvedValue({
-              id: "user-123",
-              referralSignupAt: new Date(),
-              referralDiscountUsed: false,
-            }),
-            update: mockUserUpdate,
-          },
-          booking: {
-            update: vi.fn().mockResolvedValue({}),
-          },
-          userReferralStats: {
-            upsert: vi.fn().mockResolvedValue({}),
-          },
-        };
-        return callback(mockTx);
-      });
-
-      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
-
-      await service.processReferralCompletionForBooking("booking-123");
-
-      expect(mockUserUpdate).toHaveBeenCalledWith({
-        where: { id: "user-123" },
-        data: { referralDiscountUsed: true },
-      });
-    });
-
-    it("should NOT update discount when already marked as used", async () => {
-      const mockUserUpdate = vi.fn().mockResolvedValue({});
-
-      const mockTransaction = vi.fn(async (callback) => {
-        const mockTx = {
-          referralReward: {
-            findFirst: vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce({
-              id: "reward-123",
-              bookingId: "booking-123",
-              referrerUserId: "referrer-123",
-              amount: 1000,
-              status: ReferralRewardStatus.PENDING,
-            }),
-            update: vi.fn().mockResolvedValue({}),
-          },
-          user: {
-            findUnique: vi.fn().mockResolvedValue({
-              id: "user-123",
-              referralSignupAt: new Date(),
-              referralDiscountUsed: true, // Already used
-            }),
-            update: mockUserUpdate,
-          },
-          booking: {
-            update: vi.fn().mockResolvedValue({}),
-          },
-          userReferralStats: {
-            upsert: vi.fn().mockResolvedValue({}),
-          },
-        };
-        return callback(mockTx);
-      });
-
-      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
-
-      await service.processReferralCompletionForBooking("booking-123");
-
-      expect(mockUserUpdate).not.toHaveBeenCalled();
-    });
-
-    it("should handle missing referee data gracefully", async () => {
-      const mockTransaction = vi.fn(async (callback) => {
-        const mockTx = {
-          referralReward: {
-            findFirst: vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce({
-              id: "reward-123",
-              bookingId: "booking-123",
-              referrerUserId: "referrer-123",
-              amount: 1000,
-              status: ReferralRewardStatus.PENDING,
-            }),
-            update: vi.fn().mockResolvedValue({}),
-          },
-          user: {
-            findUnique: vi.fn().mockResolvedValue(null),
-          },
-          booking: {
-            update: vi.fn().mockResolvedValue({}),
-          },
-          userReferralStats: {
-            upsert: vi.fn().mockResolvedValue({}),
-          },
-        };
-        return callback(mockTx);
-      });
-
-      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
-
-      await service.processReferralCompletionForBooking("booking-123");
-
-      expect(databaseService.$transaction).toHaveBeenCalled();
-    });
-  });
-
-  describe("processReferralCompletionForBooking - Successful Processing Path", () => {
-    beforeEach(() => {
-      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
-        { key: "REFERRAL_ENABLED", value: true, updatedAt: new Date(), updatedBy: "system" },
-        {
-          key: "REFERRAL_RELEASE_CONDITION",
-          value: "COMPLETED",
-          updatedAt: new Date(),
-          updatedBy: "system",
-        },
-        { key: "REFERRAL_EXPIRY_DAYS", value: 0, updatedAt: new Date(), updatedBy: "system" },
-      ]);
-
-      vi.mocked(databaseService.booking.findUnique).mockResolvedValue(
-        createBooking({
-          referralReferrerUserId: "referrer-123",
-          referralStatus: BookingReferralStatus.APPLIED,
-        }),
-      );
-    });
-
-    it("should successfully release reward and create new referrer stats", async () => {
-      const mockRewardUpdate = vi.fn().mockResolvedValue({});
-      const mockBookingUpdate = vi.fn().mockResolvedValue({});
-      const mockStatsUpsert = vi.fn().mockResolvedValue({});
-
-      const mockTransaction = vi.fn(async (callback) => {
-        const mockTx = {
-          referralReward: {
-            findFirst: vi
-              .fn()
-              .mockResolvedValueOnce(null) // Not already released
-              .mockResolvedValueOnce({
-                // Pending reward exists
-                id: "reward-123",
-                bookingId: "booking-123",
-                referrerUserId: "referrer-123",
-                amount: 1000,
-                status: ReferralRewardStatus.PENDING,
-              }),
-            update: mockRewardUpdate,
-          },
-          user: {
-            findUnique: vi.fn().mockResolvedValue({
-              id: "user-123",
-              referralSignupAt: new Date(),
-              referralDiscountUsed: false,
-            }),
-            update: vi.fn().mockResolvedValue({}),
-          },
-          booking: {
-            update: mockBookingUpdate,
-          },
-          userReferralStats: {
-            upsert: mockStatsUpsert,
-          },
-        };
-        return callback(mockTx);
-      });
-
-      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
-
-      await service.processReferralCompletionForBooking("booking-123");
-
-      expect(mockRewardUpdate).toHaveBeenCalledWith({
-        where: { id: "reward-123" },
-        data: expect.objectContaining({
-          status: ReferralRewardStatus.RELEASED,
-          processedAt: expect.any(Date),
-        }),
-      });
-
-      expect(mockBookingUpdate).toHaveBeenCalledWith({
-        where: { id: "booking-123" },
-        data: { referralStatus: BookingReferralStatus.REWARDED },
-      });
-
-      expect(mockStatsUpsert).toHaveBeenCalledWith({
-        where: { userId: "referrer-123" },
-        create: {
-          userId: "referrer-123",
-          totalReferrals: 0,
-          totalRewardsGranted: 1000,
-          totalRewardsPending: 0,
-          lastReferralAt: expect.any(Date),
-        },
-        update: {
-          totalRewardsGranted: { increment: 1000 },
-          totalRewardsPending: { decrement: 1000 },
-          lastReferralAt: expect.any(Date),
-        },
-      });
-    });
-
-    it("should successfully release reward and update existing referrer stats", async () => {
-      const mockStatsUpsert = vi.fn().mockResolvedValue({});
-
-      const mockTransaction = vi.fn(async (callback) => {
-        const mockTx = {
-          referralReward: {
-            findFirst: vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce({
-              id: "reward-123",
-              bookingId: "booking-123",
-              referrerUserId: "referrer-123",
-              amount: 500,
-              status: ReferralRewardStatus.PENDING,
-            }),
-            update: vi.fn().mockResolvedValue({}),
-          },
-          user: {
-            findUnique: vi.fn().mockResolvedValue({
-              id: "user-123",
-              referralSignupAt: new Date(),
-              referralDiscountUsed: true,
-            }),
-            update: vi.fn().mockResolvedValue({}),
-          },
-          booking: {
-            update: vi.fn().mockResolvedValue({}),
-          },
-          userReferralStats: {
-            upsert: mockStatsUpsert,
-          },
-        };
-        return callback(mockTx);
-      });
-
-      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
-
-      await service.processReferralCompletionForBooking("booking-123");
-
-      expect(mockStatsUpsert).toHaveBeenCalledWith({
-        where: { userId: "referrer-123" },
-        create: expect.anything(),
-        update: {
-          totalRewardsGranted: { increment: 500 },
-          totalRewardsPending: { decrement: 500 },
-          lastReferralAt: expect.any(Date),
-        },
-      });
-    });
-  });
-
-  describe("processReferralCompletionForBooking - Transaction and Error Handling", () => {
-    beforeEach(() => {
-      vi.mocked(databaseService.referralProgramConfig.findMany).mockResolvedValue([
-        { key: "REFERRAL_ENABLED", value: true, updatedAt: new Date(), updatedBy: "system" },
-        {
-          key: "REFERRAL_RELEASE_CONDITION",
-          value: "COMPLETED",
-          updatedAt: new Date(),
-          updatedBy: "system",
-        },
-        { key: "REFERRAL_EXPIRY_DAYS", value: 0, updatedAt: new Date(), updatedBy: "system" },
-      ]);
-
-      vi.mocked(databaseService.booking.findUnique).mockResolvedValue(
-        createBooking({
-          id: "booking-123",
-          userId: "user-123",
-          referralReferrerUserId: "referrer-123",
-          referralStatus: BookingReferralStatus.APPLIED,
-        }),
-      );
-    });
-
-    it("should rollback all changes if any database operation fails", async () => {
-      const mockTransaction = vi.fn(async () => {
-        throw new Error("Database constraint violation");
-      });
-
-      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
-
-      await service.processReferralCompletionForBooking("booking-123");
-
-      expect(databaseService.$transaction).toHaveBeenCalled();
-    });
-
-    it("should catch and log errors without throwing", async () => {
-      const mockTransaction = vi.fn(async () => {
-        throw new Error("Unexpected database error");
-      });
-
-      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
-
-      await expect(
-        service.processReferralCompletionForBooking("booking-123"),
-      ).resolves.not.toThrow();
-    });
-
-    it("should handle database connection errors gracefully", async () => {
-      const mockTransaction = vi.fn(async () => {
-        const error = new Error("Connection timeout");
-        error.name = "DatabaseConnectionError";
-        throw error;
-      });
-
-      vi.mocked(databaseService.$transaction).mockImplementation(mockTransaction);
-
-      await expect(
-        service.processReferralCompletionForBooking("booking-123"),
-      ).resolves.not.toThrow();
-
-      expect(databaseService.$transaction).toHaveBeenCalled();
-    });
-  });
-
-  describe("queueReferralProcessing", () => {
-    it("should successfully queue a referral processing job", async () => {
-      const bookingId = "booking-123";
-
-      await service.queueReferralProcessing(bookingId);
-
-      expect(mockQueue.add).toHaveBeenCalledWith(PROCESS_REFERRAL_COMPLETION, {
-        bookingId,
-        timestamp: expect.any(String),
-      });
-    });
-
-    it("should throw error when queue fails", async () => {
-      const bookingId = "booking-123";
-      const queueError = new Error("Redis connection failed");
-      vi.mocked(mockQueue.add).mockRejectedValue(queueError);
-
-      await expect(service.queueReferralProcessing(bookingId)).rejects.toThrow(
-        "Redis connection failed",
-      );
-    });
+  it("throws user not found when referral summary is missing", async () => {
+    vi.mocked(referralApiService.getUserReferralSummary).mockResolvedValue(null);
+
+    const request = {
+      headers: {},
+      protocol: "http",
+      get: vi.fn().mockReturnValue("localhost:3000"),
+    } as never;
+
+    await expect(service.getCurrentUserReferralInfo("user-1", request)).rejects.toBeInstanceOf(
+      ReferralUserNotFoundException,
+    );
   });
 });

--- a/src/modules/referral/referral.service.spec.ts
+++ b/src/modules/referral/referral.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, type TestingModule } from "@nestjs/testing";
+import type { Request } from "express";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ReferralInvalidCodeException,
@@ -93,7 +94,7 @@ describe("ReferralService", () => {
       headers: {},
       protocol: "http",
       get: vi.fn().mockReturnValue("localhost:3000"),
-    } as never;
+    } as unknown as Request;
 
     await expect(service.getCurrentUserReferralInfo("user-1", request)).rejects.toBeInstanceOf(
       ReferralUserNotFoundException,

--- a/src/modules/referral/referral.service.ts
+++ b/src/modules/referral/referral.service.ts
@@ -1,209 +1,86 @@
-import { InjectQueue } from "@nestjs/bullmq";
-import { Injectable, Logger } from "@nestjs/common";
-import { BookingReferralStatus, ReferralRewardStatus } from "@prisma/client";
-import { Queue } from "bullmq";
-import { REFERRAL_QUEUE } from "../../config/constants";
-import { DatabaseService } from "../database/database.service";
-import { PROCESS_REFERRAL_COMPLETION, ReferralJobData } from "./referral.interface";
+import { Injectable } from "@nestjs/common";
+import type { Request } from "express";
+import { getRequestOrigin } from "../../common/http/request.helper";
+import type { ReferralEligibilityQueryDto, ValidateReferralQueryDto } from "./dto/referral.dto";
+import {
+  ReferralEligibilityCheckFailedException,
+  ReferralException,
+  ReferralUserFetchFailedException,
+  ReferralUserNotFoundException,
+  ReferralValidationFailedException,
+} from "./referral.error";
+import { ReferralApiService } from "./referral-api.service";
+import { ReferralProcessingService } from "./referral-processing.service";
 
 @Injectable()
 export class ReferralService {
-  private readonly logger = new Logger(ReferralService.name);
-
   constructor(
-    private readonly databaseService: DatabaseService,
-    @InjectQueue(REFERRAL_QUEUE)
-    private readonly referralQueue: Queue<ReferralJobData>,
+    private readonly referralApiService: ReferralApiService,
+    private readonly referralProcessingService: ReferralProcessingService,
   ) {}
 
-  /**
-   * Queue a referral completion job for async processing
-   */
   async queueReferralProcessing(bookingId: string): Promise<void> {
-    try {
-      await this.referralQueue.add(PROCESS_REFERRAL_COMPLETION, {
-        bookingId,
-        timestamp: new Date().toISOString(),
-      });
+    return this.referralProcessingService.queueReferralProcessing(bookingId);
+  }
 
-      this.logger.log(`Queued referral processing for booking ${bookingId}`);
+  async processReferralCompletionForBooking(bookingId: string) {
+    return this.referralProcessingService.processReferralCompletionForBooking(bookingId);
+  }
+
+  async validateReferralCode(code: string, query: ValidateReferralQueryDto) {
+    try {
+      const referrer = await this.referralApiService.validateReferralCode(code, query.email);
+      return {
+        valid: true,
+        referrer: {
+          name: referrer.name ?? "Anonymous",
+        },
+        message: "Valid referral code.",
+      };
     } catch (error) {
-      this.logger.error("Failed to queue referral processing", {
-        bookingId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      throw error;
+      if (error instanceof ReferralException) {
+        throw error;
+      }
+      throw new ReferralValidationFailedException();
     }
   }
 
-  /**
-   * Process referral release for a completed booking when configured for COMPLETED.
-   * - Checks global referral config and idempotency
-   * - Optionally enforces expiry window
-   * - Marks referee discount as used
-   * - Releases pending reward and updates stats
-   * - Sets booking.referralStatus = REWARDED
-   */
-  async processReferralCompletionForBooking(bookingId: string) {
-    // Load config
-    const configs = await this.databaseService.referralProgramConfig.findMany();
-    const configMap = configs.reduce<Record<string, unknown>>((acc, c) => {
-      acc[c.key] = c.value;
-      return acc;
-    }, {});
-
-    const REFERRAL_ENABLED = configMap.REFERRAL_ENABLED ?? true;
-    const REFERRAL_RELEASE_CONDITION = (configMap.REFERRAL_RELEASE_CONDITION ?? "COMPLETED") as
-      | "PAID"
-      | "COMPLETED";
-
-    if (REFERRAL_RELEASE_CONDITION !== "PAID" && REFERRAL_RELEASE_CONDITION !== "COMPLETED") {
-      this.logger.warn("Invalid REFERRAL_RELEASE_CONDITION value", {
-        value: REFERRAL_RELEASE_CONDITION,
-      });
-      return;
-    }
-
-    const REFERRAL_EXPIRY_DAYS = Number(configMap.REFERRAL_EXPIRY_DAYS ?? 0);
-
-    if (!REFERRAL_ENABLED || REFERRAL_RELEASE_CONDITION !== "COMPLETED") {
-      this.logger.log("Skipping referral completion due to config", {
-        REFERRAL_ENABLED,
-        REFERRAL_RELEASE_CONDITION,
-      });
-      return;
-    }
-
-    const booking = await this.databaseService.booking.findUnique({
-      where: { id: bookingId },
-      select: {
-        id: true,
-        userId: true,
-        referralReferrerUserId: true,
-        referralStatus: true,
-      },
-    });
-
-    if (
-      booking?.referralStatus !== BookingReferralStatus.APPLIED ||
-      !booking?.userId ||
-      !booking?.referralReferrerUserId
-    ) {
-      this.logger.log("Skipping referral completion: booking not eligible", {
-        bookingId,
-        hasBooking: !!booking,
-        referralStatus: booking?.referralStatus,
-        hasUser: !!booking?.userId,
-        hasReferrer: !!booking?.referralReferrerUserId,
-      });
-      return;
-    }
-
+  async getReferralEligibility(userId: string, query: ReferralEligibilityQueryDto) {
     try {
-      await this.databaseService.$transaction(async (tx) => {
-        // Idempotency: skip if already released
-        const alreadyReleased = await tx.referralReward.findFirst({
-          where: { bookingId: booking.id, status: ReferralRewardStatus.RELEASED },
-          select: { id: true },
-        });
+      const eligibility = await this.referralApiService.checkReferralEligibility(
+        userId,
+        query.amount,
+        query.type,
+      );
 
-        if (alreadyReleased) {
-          this.logger.warn("Referral reward already released for booking", {
-            bookingId: booking.id,
-            rewardId: alreadyReleased.id,
-          });
-          return;
-        }
-
-        // Optional expiry check
-        const referee = await tx.user.findUnique({
-          where: { id: booking.userId },
-          select: { referralSignupAt: true, referralDiscountUsed: true },
-        });
-
-        if (REFERRAL_EXPIRY_DAYS > 0 && referee?.referralSignupAt) {
-          const daysSinceSignup = Math.floor(
-            (Date.now() - referee.referralSignupAt.getTime()) / (1000 * 60 * 60 * 24),
-          );
-
-          if (daysSinceSignup > REFERRAL_EXPIRY_DAYS) {
-            this.logger.warn("Referral expired before completion; not releasing reward", {
-              bookingId: booking.id,
-              userId: booking.userId,
-              daysSinceSignup,
-              expiryDays: REFERRAL_EXPIRY_DAYS,
-            });
-            return;
-          }
-        }
-
-        // Mark discount used if not already.
-        // Note: This is a fallback for bookings created before the race condition fix.
-        // New bookings set referralDiscountUsed=true during booking creation (in the same transaction)
-        // to prevent concurrent bookings from all receiving the one-time discount.
-        if (referee && !referee.referralDiscountUsed) {
-          await tx.user.update({
-            where: { id: booking.userId },
-            data: { referralDiscountUsed: true },
-          });
-
-          this.logger.log("Referral discount marked as used on completion (fallback)", {
-            bookingId: booking.id,
-            userId: booking.userId,
-          });
-        }
-
-        // Release pending reward
-        const pendingReward = await tx.referralReward.findFirst({
-          where: { bookingId: booking.id, status: ReferralRewardStatus.PENDING },
-        });
-
-        if (!pendingReward) {
-          this.logger.log("No pending referral reward found for booking", {
-            bookingId: booking.id,
-          });
-          return;
-        }
-
-        await tx.referralReward.update({
-          where: { id: pendingReward.id },
-          data: { status: ReferralRewardStatus.RELEASED, processedAt: new Date() },
-        });
-
-        await tx.booking.update({
-          where: { id: booking.id },
-          data: { referralStatus: BookingReferralStatus.REWARDED },
-        });
-
-        await tx.userReferralStats.upsert({
-          where: { userId: pendingReward.referrerUserId },
-          create: {
-            userId: pendingReward.referrerUserId,
-            totalReferrals: 0,
-            totalRewardsGranted: pendingReward.amount,
-            totalRewardsPending: 0,
-            lastReferralAt: new Date(),
-          },
-          update: {
-            totalRewardsGranted: { increment: pendingReward.amount },
-            totalRewardsPending: { decrement: pendingReward.amount },
-            lastReferralAt: new Date(),
-          },
-        });
-
-        this.logger.log("Referral reward released on completion", {
-          bookingId: booking.id,
-          rewardId: pendingReward.id,
-          rewardAmount: pendingReward.amount,
-          referrerId: pendingReward.referrerUserId,
-        });
-      });
+      return {
+        eligible: eligibility.eligible,
+        discountAmount: eligibility.discountAmount || 0,
+        reason: eligibility.reason,
+      };
     } catch (error) {
-      this.logger.error("Failed to process referral completion", {
-        bookingId: booking.id,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      // Don't throw - allow graceful degradation
+      if (error instanceof ReferralException) {
+        throw error;
+      }
+      throw new ReferralEligibilityCheckFailedException();
+    }
+  }
+
+  async getCurrentUserReferralInfo(userId: string, request: Request) {
+    try {
+      const origin = getRequestOrigin(request);
+      const referralInfo = await this.referralApiService.getUserReferralSummary(userId, origin);
+
+      if (!referralInfo) {
+        throw new ReferralUserNotFoundException();
+      }
+
+      return referralInfo;
+    } catch (error) {
+      if (error instanceof ReferralException) {
+        throw error;
+      }
+      throw new ReferralUserFetchFailedException();
     }
   }
 }

--- a/src/modules/referral/referral.service.ts
+++ b/src/modules/referral/referral.service.ts
@@ -68,8 +68,11 @@ export class ReferralService {
 
   async getCurrentUserReferralInfo(userId: string, request: Request) {
     try {
-      const origin = getRequestOrigin(request);
-      const referralInfo = await this.referralApiService.getUserReferralSummary(userId, origin);
+      const requestOrigin = getRequestOrigin(request);
+      const referralInfo = await this.referralApiService.getUserReferralSummary(
+        userId,
+        requestOrigin,
+      );
 
       if (!referralInfo) {
         throw new ReferralUserNotFoundException();

--- a/src/modules/reviews/reviews-write.service.spec.ts
+++ b/src/modules/reviews/reviews-write.service.spec.ts
@@ -1,7 +1,13 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { BookingStatus, Prisma } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createBooking, createReview } from "../../shared/helper.fixtures";
+import {
+  createBooking,
+  createCar,
+  createChauffeur,
+  createReview,
+  createUser,
+} from "../../shared/helper.fixtures";
 import { DatabaseService } from "../database/database.service";
 import { NotificationService } from "../notification/notification.service";
 import {
@@ -58,36 +64,48 @@ describe("ReviewsWriteService", () => {
       serviceRating: 5,
       comment: "Great service",
     };
+    const createReviewBookingMock = (
+      overrides: Partial<{
+        id: string;
+        userId: string;
+        status: BookingStatus;
+        endDate: Date;
+        chauffeurId: string | null;
+        bookingReference: string;
+      }> = {},
+    ) => {
+      const car = createCar({
+        make: "Toyota",
+        model: "Camry",
+        year: 2023,
+      });
+      const chauffeur = createChauffeur({
+        id: "chauffeur-1",
+        name: "Driver",
+        email: "driver@example.com",
+      });
+      const user = createUser({
+        name: "Customer",
+        email: "customer@example.com",
+      });
 
-    it("creates review for eligible booking", async () => {
-      vi.mocked(databaseService.booking.findFirst).mockResolvedValueOnce({
+      return createBooking({
         id: input.bookingId,
         userId: "user-1",
         status: BookingStatus.COMPLETED,
         endDate: new Date(),
         chauffeurId: "chauffeur-1",
         bookingReference: "BK-12345678",
-        car: {
-          make: "Toyota",
-          model: "Camry",
-          year: 2023,
-          owner: {
-            id: "owner-1",
-            name: "Fleet Owner",
-            email: "owner@example.com",
-          },
-        },
-        chauffeur: {
-          id: "chauffeur-1",
-          name: "Driver",
-          email: "driver@example.com",
-        },
-        user: {
-          name: "Customer",
-          email: "customer@example.com",
-        },
+        car,
+        chauffeur,
+        user,
         deletedAt: null,
-      } as never);
+        ...overrides,
+      });
+    };
+
+    it("creates review for eligible booking", async () => {
+      vi.mocked(databaseService.booking.findFirst).mockResolvedValueOnce(createReviewBookingMock());
 
       vi.mocked(databaseService.review.create).mockResolvedValueOnce(
         createReview({
@@ -155,34 +173,7 @@ describe("ReviewsWriteService", () => {
     });
 
     it("throws when review already exists", async () => {
-      vi.mocked(databaseService.booking.findFirst).mockResolvedValueOnce({
-        id: input.bookingId,
-        userId: "user-1",
-        status: BookingStatus.COMPLETED,
-        endDate: new Date(),
-        chauffeurId: "chauffeur-1",
-        bookingReference: "BK-12345678",
-        car: {
-          make: "Toyota",
-          model: "Camry",
-          year: 2023,
-          owner: {
-            id: "owner-1",
-            name: "Fleet Owner",
-            email: "owner@example.com",
-          },
-        },
-        chauffeur: {
-          id: "chauffeur-1",
-          name: "Driver",
-          email: "driver@example.com",
-        },
-        user: {
-          name: "Customer",
-          email: "customer@example.com",
-        },
-        deletedAt: null,
-      } as never);
+      vi.mocked(databaseService.booking.findFirst).mockResolvedValueOnce(createReviewBookingMock());
 
       vi.mocked(databaseService.review.create).mockRejectedValueOnce(
         new Prisma.PrismaClientKnownRequestError("Unique failed", {
@@ -198,34 +189,7 @@ describe("ReviewsWriteService", () => {
     });
 
     it("does not fail review creation when notification queueing fails", async () => {
-      vi.mocked(databaseService.booking.findFirst).mockResolvedValueOnce({
-        id: input.bookingId,
-        userId: "user-1",
-        status: BookingStatus.COMPLETED,
-        endDate: new Date(),
-        chauffeurId: "chauffeur-1",
-        bookingReference: "BK-12345678",
-        car: {
-          make: "Toyota",
-          model: "Camry",
-          year: 2023,
-          owner: {
-            id: "owner-1",
-            name: "Fleet Owner",
-            email: "owner@example.com",
-          },
-        },
-        chauffeur: {
-          id: "chauffeur-1",
-          name: "Driver",
-          email: "driver@example.com",
-        },
-        user: {
-          name: "Customer",
-          email: "customer@example.com",
-        },
-        deletedAt: null,
-      } as never);
+      vi.mocked(databaseService.booking.findFirst).mockResolvedValueOnce(createReviewBookingMock());
 
       vi.mocked(databaseService.review.create).mockResolvedValueOnce(
         createReview({

--- a/test/flightaware.e2e-spec.ts
+++ b/test/flightaware.e2e-spec.ts
@@ -71,13 +71,6 @@ describe("FlightAware E2E Tests", () => {
     process.env.FLIGHTAWARE_WEBHOOK_SECRET = originalFlightawareSecret;
   });
 
-  it("GET /api/search-flight validates query params", async () => {
-    const response = await request(app.getHttpServer()).get("/api/search-flight?flightNumber=BA74");
-
-    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
-    expect(response.body.type).toBe("VALIDATION_ERROR");
-  });
-
   it("GET /api/search-flight returns info for non-Lagos destination", async () => {
     vi.mocked(flightAwareService.searchAirportPickupFlight).mockResolvedValueOnce({
       message:

--- a/test/maps.e2e-spec.ts
+++ b/test/maps.e2e-spec.ts
@@ -61,11 +61,4 @@ describe("Maps E2E Tests", () => {
       isEstimate: false,
     });
   });
-
-  it("GET /api/calculate-trip-duration returns 400 when destination is missing", async () => {
-    const response = await request(app.getHttpServer()).get("/api/calculate-trip-duration");
-
-    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
-    expect(vi.mocked(mapsService.calculateAirportTripDuration)).not.toHaveBeenCalled();
-  });
 });

--- a/test/referrals.e2e-spec.ts
+++ b/test/referrals.e2e-spec.ts
@@ -1,0 +1,169 @@
+import { HttpStatus, type INestApplication } from "@nestjs/common";
+import { HttpAdapterHost } from "@nestjs/core";
+import { Test, type TestingModule } from "@nestjs/testing";
+import request from "supertest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppModule } from "../src/app.module";
+import { GlobalExceptionFilter } from "../src/common/filters/global-exception.filter";
+import { AuthEmailService } from "../src/modules/auth/auth-email.service";
+import { DatabaseService } from "../src/modules/database/database.service";
+import { TestDataFactory, uniqueEmail } from "./helpers";
+
+describe("Referrals E2E Tests", () => {
+  let app: INestApplication;
+  let databaseService: DatabaseService;
+  let factory: TestDataFactory;
+  let userCookie: string;
+  let userId: string;
+
+  beforeAll(async () => {
+    const mockSendOtpEmail = vi.fn().mockResolvedValue(undefined);
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(AuthEmailService)
+      .useValue({ sendOTPEmail: mockSendOtpEmail })
+      .compile();
+
+    app = moduleFixture.createNestApplication({ logger: false });
+    const httpAdapterHost = app.get(HttpAdapterHost);
+    app.useGlobalFilters(new GlobalExceptionFilter(httpAdapterHost));
+
+    databaseService = app.get(DatabaseService);
+    factory = new TestDataFactory(databaseService, app);
+
+    await app.init();
+
+    const auth = await factory.authenticateAndGetUser(uniqueEmail("referral-user"), "user");
+    userCookie = auth.cookie;
+    userId = auth.user.id;
+  });
+
+  beforeEach(async () => {
+    await factory.clearRateLimits();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe("GET /api/referrals/validate/:code", () => {
+    it("requires authentication", async () => {
+      const response = await request(app.getHttpServer()).get("/api/referrals/validate/ABCD1234");
+
+      expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+    });
+
+    it("returns 429 after exceeding validation attempts from same IP", async () => {
+      for (let attempt = 0; attempt < 20; attempt += 1) {
+        await request(app.getHttpServer())
+          .get("/api/referrals/validate/INVAL123")
+          .set("Cookie", userCookie)
+          .set("x-forwarded-for", "10.10.10.10");
+      }
+
+      const response = await request(app.getHttpServer())
+        .get("/api/referrals/validate/INVAL123")
+        .set("Cookie", userCookie)
+        .set("x-forwarded-for", "10.10.10.10");
+
+      expect(response.status).toBe(HttpStatus.TOO_MANY_REQUESTS);
+      expect(response.body.detail).toBe("Too many validation attempts. Please try again later.");
+      expect(response.headers["retry-after"]).toBeDefined();
+      expect(response.headers["ratelimit-limit"]).toBe("20");
+      expect(response.headers["ratelimit-remaining"]).toBe("0");
+    });
+  });
+
+  describe("GET /api/referrals/eligibility", () => {
+    it("requires authentication", async () => {
+      const response = await request(app.getHttpServer()).get(
+        "/api/referrals/eligibility?amount=50000&type=DAY",
+      );
+
+      expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+    });
+  });
+
+  describe("GET /api/referrals/user", () => {
+    it("returns referral user summary payload", async () => {
+      await databaseService.user.update({
+        where: { id: userId },
+        data: {
+          referralCode: "USRREF01",
+          referralDiscountUsed: false,
+          referralSignupAt: new Date("2030-01-01T00:00:00.000Z"),
+        },
+      });
+
+      const referredUser = await factory.createUser();
+      await databaseService.user.update({
+        where: { id: referredUser.id },
+        data: {
+          referredByUserId: userId,
+        },
+      });
+
+      const booking = await factory.createBookingWithDependencies(referredUser.id, {
+        booking: { status: "COMPLETED", paymentStatus: "PAID" },
+      });
+
+      await databaseService.referralReward.create({
+        data: {
+          referrerUserId: userId,
+          refereeUserId: referredUser.id,
+          bookingId: booking.id,
+          amount: 1200,
+          status: "RELEASED",
+          releaseCondition: "COMPLETED",
+          processedAt: new Date(),
+        },
+      });
+
+      await databaseService.userReferralStats.upsert({
+        where: { userId },
+        create: {
+          userId,
+          totalReferrals: 1,
+          totalRewardsGranted: 1200,
+          totalRewardsPending: 0,
+        },
+        update: {
+          totalReferrals: 1,
+          totalRewardsGranted: 1200,
+          totalRewardsPending: 0,
+        },
+      });
+
+      const paidBooking = await factory.createBookingWithDependencies(userId, {
+        booking: { paymentStatus: "PAID", status: "COMPLETED" },
+      });
+      await databaseService.booking.update({
+        where: { id: paidBooking.id },
+        data: { referralCreditsUsed: 200 },
+      });
+
+      const unpaidBooking = await factory.createBookingWithDependencies(userId, {
+        booking: { paymentStatus: "UNPAID", status: "PENDING" },
+      });
+      await databaseService.booking.update({
+        where: { id: unpaidBooking.id },
+        data: { referralCreditsReserved: 100 },
+      });
+
+      const response = await request(app.getHttpServer())
+        .get("/api/referrals/user")
+        .set("Cookie", userCookie);
+
+      expect(response.status).toBe(HttpStatus.OK);
+      expect(response.body.referralCode).toBe("USRREF01");
+      expect(response.body.shareLink).toContain("/auth?ref=USRREF01");
+      expect(response.body.stats.totalEarned).toBe(1200);
+      expect(response.body.stats.totalUsed).toBe(200);
+      expect(response.body.stats.availableCredits).toBe(900);
+      expect(Array.isArray(response.body.referrals)).toBe(true);
+      expect(Array.isArray(response.body.rewards)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Expose the referral API endpoints (/api/referrals/validate/:code, /api/referrals/eligibility, /api/referrals/user) and refactor module architecture to keep controllers thin by introducing a facade ReferralService and renaming queue/domain processing into ReferralProcessingService.
Align test naming with service ownership, add typed auth-user test helpers, extract request-origin helper, and trim e2e suites to focus on integration contracts (auth/guards/throttling/persistence) while removing unit-level validation/branch duplicates in referrals, maps, flightaware, and payments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new referral HTTP endpoints and refactors referral reward-processing logic (including DB writes and async queue processing), plus new rate-limiting behavior; mistakes could impact referral credit calculations or allow/deny requests incorrectly.
> 
> **Overview**
> Adds a new `ReferralController` exposing `GET /api/referrals/validate/:code`, `GET /api/referrals/eligibility`, and `GET /api/referrals/user`, with Zod-validated params/queries and a dedicated `ReferralThrottlerGuard` that enforces per-user and per-IP rate limits and returns standard RateLimit/Retry-After headers.
> 
> Refactors the referrals domain into a facade `ReferralService` plus two focused services: `ReferralApiService` (DB-backed validation/eligibility/user summary with cached config) and `ReferralProcessingService` (queueing and transactional reward release on booking completion). Updates `ReferralProcessor` and `ReferralModule` wiring accordingly.
> 
> Introduces reusable infra helpers (`getRequestOrigin` for safe origin derivation and common throttling utilities), fixes `JobThrottlerGuard` retry-after TTL unit handling, centralizes FlightAware ISO date-only parsing, and updates/reshapes unit + e2e tests (adds referrals e2e; trims some redundant validation/branch coverage in other suites).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bbc73d02e4a3632fb8f128142e98031fd8bea014. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->