### PR TITLE
feat(api): add account deletion, twilio webhook, and admin pdf proxy endpoints (#82)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,12 +9,15 @@ import { createBullBoardAuthMiddleware } from "./common/middlewares/bull-board-a
 import { RequestIdMiddleware } from "./common/middlewares/request-id.middleware";
 import { EnvConfig, validateEnvironment } from "./config/env.config";
 import { parseOtlpHeaders } from "./config/tracing.config";
+import { AccountModule } from "./modules/account/account.module";
 import { AuthModule } from "./modules/auth/auth.module";
 import { DatabaseModule } from "./modules/database/database.module";
+import { DocumentsModule } from "./modules/documents/documents.module";
 import { FlutterwaveModule } from "./modules/flutterwave/flutterwave.module";
 import { HealthModule } from "./modules/health/health.module";
 import { HttpClientModule } from "./modules/http-client/http-client.module";
 import { JobModule } from "./modules/job/job.module";
+import { MessagingModule } from "./modules/messaging/messaging.module";
 import { NotificationModule } from "./modules/notification/notification.module";
 import { PaymentModule } from "./modules/payment/payment.module";
 import { ReferralModule } from "./modules/referral/referral.module";
@@ -145,7 +148,10 @@ import { StatusChangeModule } from "./modules/status-change/status-change.module
     // Queues are registered in their respective feature modules
     HttpClientModule,
     DatabaseModule,
+    AccountModule,
     FlutterwaveModule,
+    DocumentsModule,
+    MessagingModule,
     NotificationModule,
     PaymentModule,
     ReminderModule,

--- a/src/common/security/webhook-signature.helper.spec.ts
+++ b/src/common/security/webhook-signature.helper.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { timingSafeSecretMatch } from "./webhook-signature.helper";
+
+describe("timingSafeSecretMatch", () => {
+  const hmacKey = "test-hmac-key";
+
+  it("returns true for matching secrets", () => {
+    expect(timingSafeSecretMatch("secret-123", "secret-123", hmacKey)).toBe(true);
+  });
+
+  it("returns false for different secrets", () => {
+    expect(timingSafeSecretMatch("secret-123", "wrong-secret", hmacKey)).toBe(false);
+  });
+
+  it("returns false for different-length secrets", () => {
+    expect(timingSafeSecretMatch("short", "a-much-longer-secret-value", hmacKey)).toBe(false);
+  });
+});

--- a/src/common/security/webhook-signature.helper.ts
+++ b/src/common/security/webhook-signature.helper.ts
@@ -1,0 +1,15 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+/**
+ * Performs timing-safe string comparison by hashing both values first.
+ * This avoids length-based timing leaks when comparing secrets.
+ */
+export function timingSafeSecretMatch(
+  receivedSecret: string,
+  expectedSecret: string,
+  hmacKey: string,
+): boolean {
+  const receivedHash = createHmac("sha256", hmacKey).update(receivedSecret).digest();
+  const expectedHash = createHmac("sha256", hmacKey).update(expectedSecret).digest();
+  return timingSafeEqual(receivedHash, expectedHash);
+}

--- a/src/modules/account/account.controller.spec.ts
+++ b/src/modules/account/account.controller.spec.ts
@@ -1,0 +1,50 @@
+import { Test, type TestingModule } from "@nestjs/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthService } from "../auth/auth.service";
+import { AccountController } from "./account.controller";
+import { AccountService } from "./account.service";
+
+describe("AccountController", () => {
+  let controller: AccountController;
+  let accountService: AccountService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AccountController],
+      providers: [
+        {
+          provide: AccountService,
+          useValue: {
+            deleteUserAccount: vi.fn(),
+          },
+        },
+        {
+          provide: AuthService,
+          useValue: {
+            isInitialized: true,
+            auth: {
+              api: {
+                getSession: vi.fn().mockResolvedValue(null),
+              },
+            },
+            getUserRoles: vi.fn().mockResolvedValue(["user"]),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<AccountController>(AccountController);
+    accountService = module.get<AccountService>(AccountService);
+  });
+
+  it("deletes the current user's account", async () => {
+    vi.mocked(accountService.deleteUserAccount).mockResolvedValue({ success: true });
+
+    const result = await controller.deleteCurrentUserAccount({
+      id: "user-1",
+    } as never);
+
+    expect(accountService.deleteUserAccount).toHaveBeenCalledWith("user-1");
+    expect(result).toEqual({ success: true });
+  });
+});

--- a/src/modules/account/account.controller.ts
+++ b/src/modules/account/account.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, HttpCode, HttpStatus, Post, UseGuards } from "@nestjs/common";
+import { CurrentUser } from "../auth/decorators/current-user.decorator";
+import { type AuthSession, SessionGuard } from "../auth/guards/session.guard";
+import type { DeleteAccountResponse } from "./account.interface";
+import { AccountService } from "./account.service";
+
+@Controller("api/account")
+export class AccountController {
+  constructor(private readonly accountService: AccountService) {}
+
+  @Post("delete")
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(SessionGuard)
+  async deleteCurrentUserAccount(
+    @CurrentUser() user: AuthSession["user"],
+  ): Promise<DeleteAccountResponse> {
+    return this.accountService.deleteUserAccount(user.id);
+  }
+}

--- a/src/modules/account/account.error.ts
+++ b/src/modules/account/account.error.ts
@@ -1,0 +1,32 @@
+import { HttpStatus } from "@nestjs/common";
+import { AppException } from "../../common/errors/app.exception";
+
+export const AccountErrorCode = {
+  ACCOUNT_USER_NOT_FOUND: "ACCOUNT_USER_NOT_FOUND",
+  ACCOUNT_DELETE_FAILED: "ACCOUNT_DELETE_FAILED",
+} as const;
+
+export class AccountException extends AppException {}
+
+export class AccountUserNotFoundException extends AccountException {
+  constructor() {
+    super(AccountErrorCode.ACCOUNT_USER_NOT_FOUND, "User not found", HttpStatus.NOT_FOUND, {
+      type: AccountErrorCode.ACCOUNT_USER_NOT_FOUND,
+      title: "User Not Found",
+    });
+  }
+}
+
+export class AccountDeleteFailedException extends AccountException {
+  constructor() {
+    super(
+      AccountErrorCode.ACCOUNT_DELETE_FAILED,
+      "Failed to delete account",
+      HttpStatus.INTERNAL_SERVER_ERROR,
+      {
+        type: AccountErrorCode.ACCOUNT_DELETE_FAILED,
+        title: "Account Deletion Failed",
+      },
+    );
+  }
+}

--- a/src/modules/account/account.interface.ts
+++ b/src/modules/account/account.interface.ts
@@ -1,0 +1,3 @@
+export interface DeleteAccountResponse {
+  success: true;
+}

--- a/src/modules/account/account.module.ts
+++ b/src/modules/account/account.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+import { AuthModule } from "../auth/auth.module";
+import { DatabaseModule } from "../database/database.module";
+import { AccountController } from "./account.controller";
+import { AccountService } from "./account.service";
+
+@Module({
+  imports: [DatabaseModule, AuthModule],
+  controllers: [AccountController],
+  providers: [AccountService],
+})
+export class AccountModule {}

--- a/src/modules/account/account.service.spec.ts
+++ b/src/modules/account/account.service.spec.ts
@@ -1,0 +1,74 @@
+import { Test, type TestingModule } from "@nestjs/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createUser } from "../../shared/helper.fixtures";
+import { DatabaseService } from "../database/database.service";
+import { AccountDeleteFailedException, AccountUserNotFoundException } from "./account.error";
+import { AccountService } from "./account.service";
+
+describe("AccountService", () => {
+  let service: AccountService;
+  let databaseService: DatabaseService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AccountService,
+        {
+          provide: DatabaseService,
+          useValue: {
+            user: {
+              findUnique: vi.fn(),
+              delete: vi.fn(),
+            },
+            booking: {
+              updateMany: vi.fn(),
+            },
+            $transaction: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<AccountService>(AccountService);
+    databaseService = module.get<DatabaseService>(DatabaseService);
+  });
+
+  it("throws not found when user does not exist", async () => {
+    vi.mocked(databaseService.user.findUnique).mockResolvedValue(null);
+
+    await expect(service.deleteUserAccount("missing-user")).rejects.toThrow(
+      AccountUserNotFoundException,
+    );
+  });
+
+  it("anonymizes bookings and deletes the user", async () => {
+    vi.mocked(databaseService.user.findUnique).mockResolvedValue(
+      createUser({
+        id: "user-1",
+        email: "user@example.com",
+      }),
+    );
+    vi.mocked(databaseService.$transaction).mockResolvedValue([{ count: 2 }, {}] as never);
+
+    const result = await service.deleteUserAccount("user-1");
+
+    expect(databaseService.booking.updateMany).toHaveBeenCalledWith({
+      where: { userId: "user-1" },
+      data: { userId: null, guestUser: null },
+    });
+    expect(databaseService.user.delete).toHaveBeenCalledWith({ where: { id: "user-1" } });
+    expect(result).toEqual({ success: true });
+  });
+
+  it("throws account deletion failed when transaction throws unexpected error", async () => {
+    vi.mocked(databaseService.user.findUnique).mockResolvedValue(
+      createUser({
+        id: "user-1",
+        email: "user@example.com",
+      }),
+    );
+    vi.mocked(databaseService.$transaction).mockRejectedValue(new Error("db failure"));
+
+    await expect(service.deleteUserAccount("user-1")).rejects.toThrow(AccountDeleteFailedException);
+  });
+});

--- a/src/modules/account/account.service.ts
+++ b/src/modules/account/account.service.ts
@@ -1,0 +1,53 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { DatabaseService } from "../database/database.service";
+import {
+  AccountDeleteFailedException,
+  AccountException,
+  AccountUserNotFoundException,
+} from "./account.error";
+import type { DeleteAccountResponse } from "./account.interface";
+
+@Injectable()
+export class AccountService {
+  private readonly logger = new Logger(AccountService.name);
+
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async deleteUserAccount(userId: string): Promise<DeleteAccountResponse> {
+    try {
+      const user = await this.databaseService.user.findUnique({
+        where: { id: userId },
+        select: { id: true, email: true },
+      });
+
+      if (!user) {
+        throw new AccountUserNotFoundException();
+      }
+
+      const [anonymizedBookings] = await this.databaseService.$transaction([
+        this.databaseService.booking.updateMany({
+          where: { userId },
+          data: {
+            userId: null,
+            guestUser: null,
+          },
+        }),
+        this.databaseService.user.delete({
+          where: { id: userId },
+        }),
+      ]);
+
+      this.logger.log("Account deleted", {
+        userId,
+        anonymizedBookings: anonymizedBookings.count,
+      });
+
+      return { success: true };
+    } catch (error) {
+      if (error instanceof AccountException) {
+        throw error;
+      }
+      throw new AccountDeleteFailedException();
+    }
+  }
+}

--- a/src/modules/documents/document-proxy.service.spec.ts
+++ b/src/modules/documents/document-proxy.service.spec.ts
@@ -1,0 +1,125 @@
+import { Readable } from "node:stream";
+import { Test, type TestingModule } from "@nestjs/testing";
+import { AxiosError } from "axios";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DatabaseService } from "../database/database.service";
+import { HttpClientService } from "../http-client/http-client.service";
+import { DocumentProxyService } from "./document-proxy.service";
+import {
+  DocumentFileFetchFailedException,
+  DocumentFileNotFoundException,
+  DocumentNotFoundException,
+} from "./documents.error";
+
+interface MockDocumentApprovalData {
+  documentUrl: string;
+}
+
+function createMockDocumentApprovalData(
+  overrides: Partial<MockDocumentApprovalData> = {},
+): MockDocumentApprovalData {
+  return {
+    documentUrl: "https://example.com/files/sample.pdf",
+    ...overrides,
+  };
+}
+
+describe("DocumentProxyService", () => {
+  let service: DocumentProxyService;
+  let httpClientService: HttpClientService;
+
+  const documentApprovalMock = {
+    findUnique: vi.fn(),
+  };
+
+  const httpClientMock = {
+    get: vi.fn(),
+  };
+
+  beforeEach(async () => {
+    documentApprovalMock.findUnique.mockReset();
+    httpClientMock.get.mockReset();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DocumentProxyService,
+        {
+          provide: DatabaseService,
+          useValue: {
+            documentApproval: documentApprovalMock,
+          },
+        },
+        {
+          provide: HttpClientService,
+          useValue: {
+            createClient: vi.fn().mockReturnValue(httpClientMock),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<DocumentProxyService>(DocumentProxyService);
+    httpClientService = module.get<HttpClientService>(HttpClientService);
+  });
+
+  it("throws not found when document record does not exist", async () => {
+    vi.mocked(documentApprovalMock.findUnique).mockResolvedValue(null);
+
+    await expect(service.getPdfByDocumentId("missing-doc")).rejects.toThrow(
+      DocumentNotFoundException,
+    );
+  });
+
+  it("returns stream metadata when file exists", async () => {
+    vi.mocked(documentApprovalMock.findUnique).mockResolvedValue(createMockDocumentApprovalData());
+
+    const stream = Readable.from(Buffer.from("%PDF-1.4"));
+    vi.mocked(httpClientMock.get).mockResolvedValue({
+      data: stream,
+      headers: {
+        "content-type": "application/pdf",
+        "content-length": "8",
+      },
+    });
+
+    const result = await service.getPdfByDocumentId("doc-1");
+
+    expect(httpClientService.createClient).toHaveBeenCalled();
+    expect(result.fileName).toBe("sample.pdf");
+    expect(result.contentType).toBe("application/pdf");
+    expect(result.contentLength).toBe(8);
+    expect(result.stream).toBe(stream);
+  });
+
+  it("throws not found when upstream file is missing", async () => {
+    vi.mocked(documentApprovalMock.findUnique).mockResolvedValue(
+      createMockDocumentApprovalData({
+        documentUrl: "https://example.com/files/missing.pdf",
+      }),
+    );
+
+    vi.mocked(httpClientMock.get).mockRejectedValue(
+      new AxiosError("Not Found", "ERR_BAD_REQUEST", undefined, undefined, {
+        status: 404,
+        statusText: "Not Found",
+        headers: {},
+        config: {} as never,
+        data: {},
+      }),
+    );
+
+    await expect(service.getPdfByDocumentId("doc-1")).rejects.toThrow(
+      DocumentFileNotFoundException,
+    );
+  });
+
+  it("throws bad gateway when upstream fetch fails unexpectedly", async () => {
+    vi.mocked(documentApprovalMock.findUnique).mockResolvedValue(createMockDocumentApprovalData());
+
+    vi.mocked(httpClientMock.get).mockRejectedValue(new Error("network failure"));
+
+    await expect(service.getPdfByDocumentId("doc-1")).rejects.toThrow(
+      DocumentFileFetchFailedException,
+    );
+  });
+});

--- a/src/modules/documents/document-proxy.service.ts
+++ b/src/modules/documents/document-proxy.service.ts
@@ -1,0 +1,90 @@
+import { basename } from "node:path";
+import type { Readable } from "node:stream";
+import { Injectable } from "@nestjs/common";
+import { AxiosError } from "axios";
+import { DatabaseService } from "../database/database.service";
+import { HttpClientService } from "../http-client/http-client.service";
+import type { ProxiedPdfResult } from "./document.interface";
+import {
+  DocumentFileFetchFailedException,
+  DocumentFileNotFoundException,
+  DocumentNotFoundException,
+} from "./documents.error";
+
+@Injectable()
+export class DocumentProxyService {
+  constructor(
+    private readonly databaseService: DatabaseService,
+    private readonly httpClientService: HttpClientService,
+  ) {}
+
+  async getPdfByDocumentId(documentId: string): Promise<ProxiedPdfResult> {
+    const document = await this.databaseService.documentApproval.findUnique({
+      where: { id: documentId },
+      select: { documentUrl: true },
+    });
+
+    if (!document) {
+      throw new DocumentNotFoundException();
+    }
+
+    const httpClient = this.httpClientService.createClient({
+      serviceName: "DocumentProxy",
+      headers: {
+        Accept: "application/pdf",
+      },
+    });
+
+    try {
+      const response = await httpClient.get<Readable>(document.documentUrl, {
+        responseType: "stream",
+      });
+
+      return {
+        stream: response.data,
+        fileName: this.resolveFileName(documentId, document.documentUrl),
+        contentType: this.resolveContentType(response.headers["content-type"]),
+        contentLength: this.resolveContentLength(response.headers["content-length"]),
+      };
+    } catch (error) {
+      if (error instanceof AxiosError && error.response?.status === 404) {
+        throw new DocumentFileNotFoundException();
+      }
+
+      throw new DocumentFileFetchFailedException();
+    }
+  }
+
+  private resolveFileName(documentId: string, sourceUrl: string): string {
+    try {
+      const url = new URL(sourceUrl);
+      const fileName = basename(url.pathname);
+      if (fileName?.toLowerCase().endsWith(".pdf")) {
+        return fileName;
+      }
+    } catch {
+      // Fall through to default name
+    }
+
+    return `document-${documentId}.pdf`;
+  }
+
+  private resolveContentType(contentTypeHeader: unknown): string {
+    if (typeof contentTypeHeader === "string" && contentTypeHeader.length > 0) {
+      return contentTypeHeader;
+    }
+    return "application/pdf";
+  }
+
+  private resolveContentLength(contentLengthHeader: unknown): number | undefined {
+    if (typeof contentLengthHeader === "number") {
+      return Number.isFinite(contentLengthHeader) ? contentLengthHeader : undefined;
+    }
+    if (typeof contentLengthHeader !== "string") {
+      return undefined;
+    }
+
+    const parsedValue = Number.parseInt(contentLengthHeader, 10);
+    return Number.isNaN(parsedValue) ? undefined : parsedValue;
+  }
+}

--- a/src/modules/documents/document.interface.ts
+++ b/src/modules/documents/document.interface.ts
@@ -1,0 +1,8 @@
+import type { Readable } from "node:stream";
+
+export interface ProxiedPdfResult {
+  stream: Readable;
+  fileName: string;
+  contentType: string;
+  contentLength?: number;
+}

--- a/src/modules/documents/documents.controller.spec.ts
+++ b/src/modules/documents/documents.controller.spec.ts
@@ -64,5 +64,11 @@ describe("DocumentsController", () => {
 
     expect(documentProxyService.getPdfByDocumentId).toHaveBeenCalledWith("doc-1");
     expect(stream.pipe).toHaveBeenCalledWith(response);
+
+    expect(response.setHeader).toHaveBeenCalledWith("Content-Type", "application/pdf");
+    expect(response.setHeader).toHaveBeenCalledWith(
+      "Content-Disposition",
+      expect.stringContaining("sample.pdf"),
+    );
   });
 });

--- a/src/modules/documents/documents.controller.spec.ts
+++ b/src/modules/documents/documents.controller.spec.ts
@@ -1,0 +1,68 @@
+import type { Readable } from "node:stream";
+import { Reflector } from "@nestjs/core";
+import { Test, type TestingModule } from "@nestjs/testing";
+import type { Response } from "express";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthService } from "../auth/auth.service";
+import { DocumentProxyService } from "./document-proxy.service";
+import { DocumentsController } from "./documents.controller";
+
+describe("DocumentsController", () => {
+  let controller: DocumentsController;
+  let documentProxyService: DocumentProxyService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DocumentsController],
+      providers: [
+        {
+          provide: DocumentProxyService,
+          useValue: {
+            getPdfByDocumentId: vi.fn(),
+          },
+        },
+        {
+          provide: AuthService,
+          useValue: {
+            isInitialized: true,
+            auth: {
+              api: {
+                getSession: vi.fn().mockResolvedValue(null),
+              },
+            },
+            getUserRoles: vi.fn().mockResolvedValue(["admin"]),
+          },
+        },
+        Reflector,
+      ],
+    }).compile();
+
+    controller = module.get<DocumentsController>(DocumentsController);
+    documentProxyService = module.get<DocumentProxyService>(DocumentProxyService);
+  });
+
+  it("delegates to proxy service and pipes the stream", async () => {
+    const stream = {
+      on: vi.fn(),
+      pipe: vi.fn(),
+    };
+    vi.mocked(documentProxyService.getPdfByDocumentId).mockResolvedValue({
+      stream: stream as unknown as Readable,
+      fileName: "sample.pdf",
+      contentType: "application/pdf",
+      contentLength: 8,
+    });
+
+    const response = {
+      setHeader: vi.fn(),
+      status: vi.fn().mockReturnThis(),
+      end: vi.fn(),
+      headersSent: false,
+    };
+
+    await controller.proxyPdf("doc-1", response as unknown as Response);
+
+    expect(documentProxyService.getPdfByDocumentId).toHaveBeenCalledWith("doc-1");
+    expect(stream.pipe).toHaveBeenCalledWith(response);
+  });
+});

--- a/src/modules/documents/documents.controller.ts
+++ b/src/modules/documents/documents.controller.ts
@@ -1,0 +1,42 @@
+import { Controller, Get, Res, UseGuards } from "@nestjs/common";
+import type { Response } from "express";
+import { ZodParam } from "../../common/decorators/zod-validation.decorator";
+import { ADMIN } from "../auth/auth.types";
+import { Roles } from "../auth/decorators/roles.decorator";
+import { RoleGuard } from "../auth/guards/role.guard";
+import { SessionGuard } from "../auth/guards/session.guard";
+import { DocumentProxyService } from "./document-proxy.service";
+import { documentIdParamSchema } from "./dto/proxy-pdf.dto";
+
+@Controller("api")
+export class DocumentsController {
+  constructor(private readonly documentProxyService: DocumentProxyService) {}
+
+  @Get("proxy-pdf/:documentId")
+  @UseGuards(SessionGuard, RoleGuard)
+  @Roles(ADMIN)
+  async proxyPdf(
+    @ZodParam("documentId", documentIdParamSchema) documentId: string,
+    @Res() response: Response,
+  ): Promise<void> {
+    const proxiedFile = await this.documentProxyService.getPdfByDocumentId(documentId);
+
+    response.setHeader("Content-Type", proxiedFile.contentType);
+    response.setHeader("Content-Disposition", `inline; filename="${proxiedFile.fileName}"`);
+    response.setHeader("Cache-Control", "max-age=300");
+
+    if (proxiedFile.contentLength !== undefined) {
+      response.setHeader("Content-Length", proxiedFile.contentLength.toString());
+    }
+
+    proxiedFile.stream.on("error", () => {
+      if (!response.headersSent) {
+        response.status(502).end();
+        return;
+      }
+      response.end();
+    });
+
+    proxiedFile.stream.pipe(response);
+  }
+}

--- a/src/modules/documents/documents.error.ts
+++ b/src/modules/documents/documents.error.ts
@@ -1,0 +1,47 @@
+import { HttpStatus } from "@nestjs/common";
+import { AppException } from "../../common/errors/app.exception";
+
+export const DocumentsErrorCode = {
+  DOCUMENT_NOT_FOUND: "DOCUMENT_NOT_FOUND",
+  DOCUMENT_FILE_NOT_FOUND: "DOCUMENT_FILE_NOT_FOUND",
+  DOCUMENT_FILE_FETCH_FAILED: "DOCUMENT_FILE_FETCH_FAILED",
+} as const;
+
+export class DocumentsException extends AppException {}
+
+export class DocumentNotFoundException extends DocumentsException {
+  constructor() {
+    super(DocumentsErrorCode.DOCUMENT_NOT_FOUND, "Document not found", HttpStatus.NOT_FOUND, {
+      type: DocumentsErrorCode.DOCUMENT_NOT_FOUND,
+      title: "Document Not Found",
+    });
+  }
+}
+
+export class DocumentFileNotFoundException extends DocumentsException {
+  constructor() {
+    super(
+      DocumentsErrorCode.DOCUMENT_FILE_NOT_FOUND,
+      "Document file not found",
+      HttpStatus.NOT_FOUND,
+      {
+        type: DocumentsErrorCode.DOCUMENT_FILE_NOT_FOUND,
+        title: "Document File Not Found",
+      },
+    );
+  }
+}
+
+export class DocumentFileFetchFailedException extends DocumentsException {
+  constructor() {
+    super(
+      DocumentsErrorCode.DOCUMENT_FILE_FETCH_FAILED,
+      "Failed to fetch document file",
+      HttpStatus.BAD_GATEWAY,
+      {
+        type: DocumentsErrorCode.DOCUMENT_FILE_FETCH_FAILED,
+        title: "Document File Fetch Failed",
+      },
+    );
+  }
+}

--- a/src/modules/documents/documents.error.ts
+++ b/src/modules/documents/documents.error.ts
@@ -12,7 +12,6 @@ export class DocumentsException extends AppException {}
 export class DocumentNotFoundException extends DocumentsException {
   constructor() {
     super(DocumentsErrorCode.DOCUMENT_NOT_FOUND, "Document not found", HttpStatus.NOT_FOUND, {
-      type: DocumentsErrorCode.DOCUMENT_NOT_FOUND,
       title: "Document Not Found",
     });
   }
@@ -25,7 +24,6 @@ export class DocumentFileNotFoundException extends DocumentsException {
       "Document file not found",
       HttpStatus.NOT_FOUND,
       {
-        type: DocumentsErrorCode.DOCUMENT_FILE_NOT_FOUND,
         title: "Document File Not Found",
       },
     );
@@ -39,7 +37,6 @@ export class DocumentFileFetchFailedException extends DocumentsException {
       "Failed to fetch document file",
       HttpStatus.BAD_GATEWAY,
       {
-        type: DocumentsErrorCode.DOCUMENT_FILE_FETCH_FAILED,
         title: "Document File Fetch Failed",
       },
     );

--- a/src/modules/documents/documents.module.ts
+++ b/src/modules/documents/documents.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+import { AuthModule } from "../auth/auth.module";
+import { DatabaseModule } from "../database/database.module";
+import { DocumentProxyService } from "./document-proxy.service";
+import { DocumentsController } from "./documents.controller";
+
+@Module({
+  imports: [DatabaseModule, AuthModule],
+  controllers: [DocumentsController],
+  providers: [DocumentProxyService],
+})
+export class DocumentsModule {}

--- a/src/modules/documents/dto/proxy-pdf.dto.ts
+++ b/src/modules/documents/dto/proxy-pdf.dto.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const documentIdParamSchema = z
+  .string()
+  .min(1, "documentId is required")
+  .max(128, "documentId is too long");

--- a/src/modules/flightaware/guards/flightaware-webhook.guard.ts
+++ b/src/modules/flightaware/guards/flightaware-webhook.guard.ts
@@ -1,7 +1,7 @@
-import { createHmac, timingSafeEqual } from "node:crypto";
 import { CanActivate, ExecutionContext, Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import type { Request } from "express";
+import { timingSafeSecretMatch } from "src/common/security/webhook-signature.helper";
 import type { EnvConfig } from "src/config/env.config";
 
 @Injectable()
@@ -43,11 +43,6 @@ export class FlightAwareWebhookGuard implements CanActivate {
   }
 
   private verifySecret(received: string, expected: string): boolean {
-    // Hash both values with createHmac(..., this.hmacKey) so timingSafeEqual always compares
-    // fixed-length digests instead of variable-length user input.
-    const receivedHash = createHmac("sha256", this.hmacKey).update(received).digest();
-    const expectedHash = createHmac("sha256", this.hmacKey).update(expected).digest();
-
-    return timingSafeEqual(receivedHash, expectedHash);
+    return timingSafeSecretMatch(received, expected, this.hmacKey);
   }
 }

--- a/src/modules/messaging/guards/twilio-webhook.guard.spec.ts
+++ b/src/modules/messaging/guards/twilio-webhook.guard.spec.ts
@@ -1,0 +1,69 @@
+import type { ExecutionContext } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { Test, type TestingModule } from "@nestjs/testing";
+import twilio from "twilio";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TwilioWebhookGuard } from "./twilio-webhook.guard";
+
+describe("TwilioWebhookGuard", () => {
+  let guard: TwilioWebhookGuard;
+
+  const authToken = "test-twilio-auth-token";
+  const webhookUrl = "http://localhost:3000/api/messaging/webhook/twilio";
+
+  const createContext = (
+    headers: Record<string, string | undefined>,
+    body: Record<string, unknown> = {},
+  ): ExecutionContext =>
+    ({
+      switchToHttp: () => ({
+        getRequest: () => ({
+          headers,
+          body,
+        }),
+      }),
+    }) as unknown as ExecutionContext;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TwilioWebhookGuard,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: vi.fn((key: string) => {
+              if (key === "TWILIO_AUTH_TOKEN") return authToken;
+              if (key === "TWILIO_WEBHOOK_URL") return webhookUrl;
+              return undefined;
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    guard = module.get<TwilioWebhookGuard>(TwilioWebhookGuard);
+  });
+
+  it("allows request with valid Twilio signature", () => {
+    const params = { MessageSid: "SM123", MessageStatus: "delivered" };
+    const signature = twilio.getExpectedTwilioSignature(authToken, webhookUrl, params);
+    const context = createContext({ "x-twilio-signature": signature }, params);
+
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it("rejects request with invalid signature", () => {
+    const context = createContext(
+      { "x-twilio-signature": "invalid-signature" },
+      { MessageSid: "SM123" },
+    );
+
+    expect(guard.canActivate(context)).toBe(false);
+  });
+
+  it("rejects request when signature header is missing", () => {
+    const context = createContext({}, { MessageSid: "SM123" });
+
+    expect(guard.canActivate(context)).toBe(false);
+  });
+});

--- a/src/modules/messaging/guards/twilio-webhook.guard.ts
+++ b/src/modules/messaging/guards/twilio-webhook.guard.ts
@@ -1,0 +1,70 @@
+import { CanActivate, ExecutionContext, Injectable, Logger } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import type { Request } from "express";
+import twilio from "twilio";
+import type { EnvConfig } from "../../../config/env.config";
+
+@Injectable()
+export class TwilioWebhookGuard implements CanActivate {
+  private readonly logger = new Logger(TwilioWebhookGuard.name);
+  private readonly authToken: string | undefined;
+  private readonly webhookUrl: string | undefined;
+
+  constructor(private readonly configService: ConfigService<EnvConfig>) {
+    this.authToken = this.configService.get("TWILIO_AUTH_TOKEN", { infer: true });
+    this.webhookUrl = this.configService.get("TWILIO_WEBHOOK_URL", { infer: true });
+  }
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<Request>();
+    const signature = this.getSignature(request);
+
+    if (!signature) {
+      this.logger.warn("Missing Twilio signature header");
+      return false;
+    }
+
+    if (!this.webhookUrl) {
+      this.logger.error("Twilio webhook configuration is missing");
+      return false;
+    }
+
+    const params = this.normalizeBodyParams(request.body);
+    const isValid = twilio.validateRequest(this.authToken, signature, this.webhookUrl, params);
+
+    if (!isValid) {
+      this.logger.warn("Invalid Twilio webhook signature");
+    }
+
+    return isValid;
+  }
+
+  private getSignature(request: Request): string | null {
+    const signature =
+      request.headers["x-twilio-signature"] ?? request.headers["x-twilio-signature-256"];
+    return typeof signature === "string" ? signature : null;
+  }
+
+  private normalizeBodyParams(body: unknown): Record<string, string> {
+    if (!body || typeof body !== "object") {
+      return {};
+    }
+
+    return Object.entries(body as Record<string, unknown>).reduce<Record<string, string>>(
+      (acc, [key, value]) => {
+        if (value === null || value === undefined) {
+          return acc;
+        }
+
+        if (Array.isArray(value)) {
+          acc[key] = value.map(String).join(",");
+          return acc;
+        }
+
+        acc[key] = String(value);
+        return acc;
+      },
+      {},
+    );
+  }
+}

--- a/src/modules/messaging/guards/twilio-webhook.guard.ts
+++ b/src/modules/messaging/guards/twilio-webhook.guard.ts
@@ -40,8 +40,7 @@ export class TwilioWebhookGuard implements CanActivate {
   }
 
   private getSignature(request: Request): string | null {
-    const signature =
-      request.headers["x-twilio-signature"] ?? request.headers["x-twilio-signature-256"];
+    const signature = request.headers["x-twilio-signature"];
     return typeof signature === "string" ? signature : null;
   }
 

--- a/src/modules/messaging/messaging.controller.spec.ts
+++ b/src/modules/messaging/messaging.controller.spec.ts
@@ -1,0 +1,51 @@
+import { ConfigService } from "@nestjs/config";
+import { Test, type TestingModule } from "@nestjs/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MessagingController } from "./messaging.controller";
+import { MessagingService } from "./messaging.service";
+
+describe("MessagingController", () => {
+  let controller: MessagingController;
+  let messagingService: MessagingService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MessagingController],
+      providers: [
+        {
+          provide: MessagingService,
+          useValue: {
+            handleTwilioStatusCallback: vi.fn(),
+          },
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: vi.fn((key: string) => {
+              if (key === "TWILIO_AUTH_TOKEN") return "test-token";
+              if (key === "TWILIO_WEBHOOK_URL")
+                return "http://localhost:3000/api/messaging/webhook/twilio";
+              return undefined;
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<MessagingController>(MessagingController);
+    messagingService = module.get<MessagingService>(MessagingService);
+  });
+
+  it("forwards webhook payload to messaging service", async () => {
+    vi.mocked(messagingService.handleTwilioStatusCallback).mockResolvedValue(undefined);
+
+    const payload = {
+      MessageSid: "SM123",
+      MessageStatus: "delivered",
+    };
+
+    await controller.handleTwilioWebhook(payload);
+
+    expect(messagingService.handleTwilioStatusCallback).toHaveBeenCalledWith(payload);
+  });
+});

--- a/src/modules/messaging/messaging.controller.ts
+++ b/src/modules/messaging/messaging.controller.ts
@@ -1,0 +1,18 @@
+import { Body, Controller, Header, HttpCode, HttpStatus, Post, UseGuards } from "@nestjs/common";
+import { TwilioWebhookGuard } from "./guards/twilio-webhook.guard";
+import type { TwilioWebhookPayload } from "./messaging.interface";
+import { MessagingService } from "./messaging.service";
+
+@Controller("api/messaging")
+export class MessagingController {
+  constructor(private readonly messagingService: MessagingService) {}
+
+  @Post("webhook/twilio")
+  @HttpCode(HttpStatus.OK)
+  @Header("Content-Type", "application/xml")
+  @UseGuards(TwilioWebhookGuard)
+  async handleTwilioWebhook(@Body() payload: TwilioWebhookPayload): Promise<string> {
+    await this.messagingService.handleTwilioStatusCallback(payload);
+    return "<Response></Response>";
+  }
+}

--- a/src/modules/messaging/messaging.interface.ts
+++ b/src/modules/messaging/messaging.interface.ts
@@ -1,0 +1,5 @@
+export interface TwilioWebhookPayload {
+  MessageSid?: string;
+  MessageStatus?: string;
+  ErrorCode?: string;
+}

--- a/src/modules/messaging/messaging.module.ts
+++ b/src/modules/messaging/messaging.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { TwilioWebhookGuard } from "./guards/twilio-webhook.guard";
+import { MessagingController } from "./messaging.controller";
+import { MessagingService } from "./messaging.service";
+
+@Module({
+  controllers: [MessagingController],
+  providers: [MessagingService, TwilioWebhookGuard],
+})
+export class MessagingModule {}

--- a/src/modules/messaging/messaging.service.spec.ts
+++ b/src/modules/messaging/messaging.service.spec.ts
@@ -1,0 +1,24 @@
+import { Test, type TestingModule } from "@nestjs/testing";
+import { beforeEach, describe, expect, it } from "vitest";
+import { MessagingService } from "./messaging.service";
+
+describe("MessagingService", () => {
+  let service: MessagingService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MessagingService],
+    }).compile();
+
+    service = module.get<MessagingService>(MessagingService);
+  });
+
+  it("handles Twilio status callback without throwing", async () => {
+    await expect(
+      service.handleTwilioStatusCallback({
+        MessageSid: "SM123",
+        MessageStatus: "sent",
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/modules/messaging/messaging.service.ts
+++ b/src/modules/messaging/messaging.service.ts
@@ -1,0 +1,15 @@
+import { Injectable, Logger } from "@nestjs/common";
+import type { TwilioWebhookPayload } from "./messaging.interface";
+
+@Injectable()
+export class MessagingService {
+  private readonly logger = new Logger(MessagingService.name);
+
+  async handleTwilioStatusCallback(payload: TwilioWebhookPayload): Promise<void> {
+    this.logger.log("Processed Twilio status callback", {
+      messageSid: payload.MessageSid ?? null,
+      messageStatus: payload.MessageStatus ?? null,
+      hasErrorCode: Boolean(payload.ErrorCode),
+    });
+  }
+}

--- a/src/modules/payment/guards/flutterwave-webhook.guard.ts
+++ b/src/modules/payment/guards/flutterwave-webhook.guard.ts
@@ -1,7 +1,7 @@
-import { createHmac, timingSafeEqual } from "node:crypto";
 import { CanActivate, ExecutionContext, Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import type { Request } from "express";
+import { timingSafeSecretMatch } from "src/common/security/webhook-signature.helper";
 import { EnvConfig } from "src/config/env.config";
 
 /**
@@ -63,11 +63,6 @@ export class FlutterwaveWebhookGuard implements CanActivate {
    * This prevents timing attacks that could leak information about the secret.
    */
   private verifySignature(received: string, expected: string): boolean {
-    // Hash both values to get fixed-length outputs for comparison
-    // This prevents length-based timing attacks
-    const receivedHash = createHmac("sha256", this.hmacKey).update(received).digest();
-    const expectedHash = createHmac("sha256", this.hmacKey).update(expected).digest();
-
-    return timingSafeEqual(receivedHash, expectedHash);
+    return timingSafeSecretMatch(received, expected, this.hmacKey);
   }
 }

--- a/test/account.e2e-spec.ts
+++ b/test/account.e2e-spec.ts
@@ -1,0 +1,56 @@
+import { HttpStatus, type INestApplication } from "@nestjs/common";
+import { HttpAdapterHost } from "@nestjs/core";
+import { Test, type TestingModule } from "@nestjs/testing";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { AppModule } from "../src/app.module";
+import { GlobalExceptionFilter } from "../src/common/filters/global-exception.filter";
+import { AuthEmailService } from "../src/modules/auth/auth-email.service";
+import { DatabaseService } from "../src/modules/database/database.service";
+import { TestDataFactory, uniqueEmail } from "./helpers";
+
+describe("Account E2E Tests", () => {
+  let app: INestApplication;
+  let databaseService: DatabaseService;
+  let factory: TestDataFactory;
+  let userCookie: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(AuthEmailService)
+      .useValue({ sendOTPEmail: vi.fn().mockResolvedValue(undefined) })
+      .compile();
+
+    app = moduleFixture.createNestApplication({ logger: false });
+    const httpAdapterHost = app.get(HttpAdapterHost);
+    app.useGlobalFilters(new GlobalExceptionFilter(httpAdapterHost));
+
+    databaseService = app.get(DatabaseService);
+    factory = new TestDataFactory(databaseService, app);
+    await app.init();
+
+    const auth = await factory.authenticateAndGetUser(uniqueEmail("account-delete-user"), "user");
+    userCookie = auth.cookie;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("POST /api/account/delete requires authentication", async () => {
+    const response = await request(app.getHttpServer()).post("/api/account/delete");
+
+    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+  });
+
+  it("POST /api/account/delete returns success for authenticated users", async () => {
+    const response = await request(app.getHttpServer())
+      .post("/api/account/delete")
+      .set("Cookie", userCookie);
+
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(response.body.success).toBe(true);
+  });
+});

--- a/test/documents.e2e-spec.ts
+++ b/test/documents.e2e-spec.ts
@@ -1,0 +1,109 @@
+import { createServer, type Server } from "node:http";
+import { HttpStatus, type INestApplication } from "@nestjs/common";
+import { HttpAdapterHost } from "@nestjs/core";
+import { Test, type TestingModule } from "@nestjs/testing";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { AppModule } from "../src/app.module";
+import { GlobalExceptionFilter } from "../src/common/filters/global-exception.filter";
+import { AuthEmailService } from "../src/modules/auth/auth-email.service";
+import { DatabaseService } from "../src/modules/database/database.service";
+import { TestDataFactory, uniqueEmail } from "./helpers";
+
+describe("Documents E2E Tests", () => {
+  let app: INestApplication;
+  let databaseService: DatabaseService;
+  let factory: TestDataFactory;
+  let adminCookie: string;
+  let userCookie: string;
+  let localPdfServer: Server;
+  let localPdfUrl: string;
+  const pdfBody = Buffer.from("%PDF-1.4 test");
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(AuthEmailService)
+      .useValue({ sendOTPEmail: vi.fn().mockResolvedValue(undefined) })
+      .compile();
+
+    app = moduleFixture.createNestApplication({ logger: false });
+    const httpAdapterHost = app.get(HttpAdapterHost);
+    app.useGlobalFilters(new GlobalExceptionFilter(httpAdapterHost));
+
+    databaseService = app.get(DatabaseService);
+    factory = new TestDataFactory(databaseService, app);
+    await app.init();
+
+    const adminAuth = await factory.createAuthenticatedAdmin(uniqueEmail("doc-admin"));
+    adminCookie = adminAuth.cookie;
+
+    const userAuth = await factory.authenticateAndGetUser(uniqueEmail("doc-user"), "user");
+    userCookie = userAuth.cookie;
+
+    await new Promise<void>((resolve) => {
+      localPdfServer = createServer((_, res) => {
+        res.writeHead(200, {
+          "Content-Type": "application/pdf",
+          "Content-Length": pdfBody.length.toString(),
+        });
+        res.end(pdfBody);
+      });
+      localPdfServer.listen(0, "127.0.0.1", () => {
+        const address = localPdfServer.address();
+        if (address && typeof address !== "string") {
+          localPdfUrl = `http://127.0.0.1:${address.port}/sample.pdf`;
+        }
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await new Promise<void>((resolve, reject) => {
+      localPdfServer.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  });
+
+  it("GET /api/proxy-pdf/:documentId blocks non-admin users", async () => {
+    const document = await databaseService.documentApproval.create({
+      data: {
+        documentType: "NIN",
+        documentUrl: localPdfUrl,
+      },
+    });
+
+    const response = await request(app.getHttpServer())
+      .get(`/api/proxy-pdf/${document.id}`)
+      .set("Cookie", userCookie);
+
+    expect(response.status).toBe(HttpStatus.FORBIDDEN);
+  });
+
+  it("GET /api/proxy-pdf/:documentId streams PDF for admins", async () => {
+    const document = await databaseService.documentApproval.create({
+      data: {
+        documentType: "DRIVERS_LICENSE",
+        documentUrl: localPdfUrl,
+      },
+    });
+
+    const response = await request(app.getHttpServer())
+      .get(`/api/proxy-pdf/${document.id}`)
+      .set("Cookie", adminCookie)
+      .buffer(true);
+
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(response.headers["content-type"]).toContain("application/pdf");
+    expect(response.headers["content-disposition"]).toContain("inline; filename=");
+    expect(Buffer.compare(Buffer.from(response.body), pdfBody)).toBe(0);
+  });
+});

--- a/test/messaging.e2e-spec.ts
+++ b/test/messaging.e2e-spec.ts
@@ -1,0 +1,74 @@
+import { HttpStatus, type INestApplication } from "@nestjs/common";
+import { HttpAdapterHost } from "@nestjs/core";
+import { Test, type TestingModule } from "@nestjs/testing";
+import request from "supertest";
+import twilio from "twilio";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { AppModule } from "../src/app.module";
+import { GlobalExceptionFilter } from "../src/common/filters/global-exception.filter";
+import { AuthEmailService } from "../src/modules/auth/auth-email.service";
+
+describe("Messaging E2E Tests", () => {
+  let app: INestApplication;
+  let twilioAuthToken: string;
+  let twilioWebhookUrl: string;
+
+  beforeAll(async () => {
+    twilioAuthToken = process.env.TWILIO_AUTH_TOKEN ?? "test-twilio-auth-token";
+    twilioWebhookUrl =
+      process.env.TWILIO_WEBHOOK_URL ?? "http://localhost:3000/api/messaging/webhook/twilio";
+
+    process.env.TWILIO_AUTH_TOKEN = twilioAuthToken;
+    process.env.TWILIO_WEBHOOK_URL = twilioWebhookUrl;
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(AuthEmailService)
+      .useValue({ sendOTPEmail: vi.fn().mockResolvedValue(undefined) })
+      .compile();
+
+    app = moduleFixture.createNestApplication({ logger: false });
+    const httpAdapterHost = app.get(HttpAdapterHost);
+    app.useGlobalFilters(new GlobalExceptionFilter(httpAdapterHost));
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("POST /api/messaging/webhook/twilio rejects invalid signature", async () => {
+    const response = await request(app.getHttpServer())
+      .post("/api/messaging/webhook/twilio")
+      .type("form")
+      .set("x-twilio-signature", "invalid-signature")
+      .send({
+        MessageSid: "SM0001",
+        MessageStatus: "delivered",
+      });
+
+    expect(response.status).toBe(HttpStatus.FORBIDDEN);
+  });
+
+  it("POST /api/messaging/webhook/twilio accepts valid signature", async () => {
+    const params = {
+      MessageSid: "SM0002",
+      MessageStatus: "sent",
+      To: "+2348000000000",
+      From: "+2348111111111",
+    };
+
+    const signature = twilio.getExpectedTwilioSignature(twilioAuthToken, twilioWebhookUrl, params);
+
+    const response = await request(app.getHttpServer())
+      .post("/api/messaging/webhook/twilio")
+      .type("form")
+      .set("x-twilio-signature", signature)
+      .send(params);
+
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(response.text).toBe("<Response></Response>");
+    expect(response.headers["content-type"]).toContain("application/xml");
+  });
+});


### PR DESCRIPTION
Extract shared webhook signature helper from existing guards and add three new domain-split modules: account (NDPC-compliant user deletion with booking anonymization), messaging (Twilio status callback with signature verification), and documents (admin-only streamed PDF proxy). Includes module error classes, dedicated interface files, unit tests, and focused e2e coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new authenticated/role-guarded endpoints and performs destructive DB deletes plus external PDF streaming and webhook verification; mistakes could cause data loss, authorization gaps, or proxying issues.
> 
> **Overview**
> Adds three new API surfaces and wires them into `AppModule`: `POST /api/account/delete` to delete the current user (anonymizing related bookings in a DB transaction), `GET /api/proxy-pdf/:documentId` to stream stored document PDFs via an admin-only proxy, and `POST /api/messaging/webhook/twilio` to accept Twilio status callbacks guarded by signature validation.
> 
> Extracts a shared `timingSafeSecretMatch` helper and updates existing `FlightAwareWebhookGuard` and `FlutterwaveWebhookGuard` to use it. Adds unit tests and focused E2E coverage for the new endpoints and signature logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88758817a7f8717b55daba5905ae641ba1573b14. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->