### PR TITLE
feat(booking): expose read, update, cancel endpoints and cancellation notifications

### DIFF
--- a/src/modules/booking/booking-cancellation.service.spec.ts
+++ b/src/modules/booking/booking-cancellation.service.spec.ts
@@ -1,0 +1,150 @@
+import { Test, type TestingModule } from "@nestjs/testing";
+import { BookingStatus, PaymentStatus } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DatabaseService } from "../database/database.service";
+import { NotificationService } from "../notification/notification.service";
+import {
+  BookingCancellationFailedException,
+  BookingNotCancellableException,
+  BookingNotFoundException,
+} from "./booking.error";
+import { BookingCancellationService } from "./booking-cancellation.service";
+
+describe("BookingCancellationService", () => {
+  let service: BookingCancellationService;
+
+  const txMock = {
+    booking: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    car: {
+      update: vi.fn(),
+    },
+  };
+
+  const databaseServiceMock = {
+    $transaction: vi.fn(),
+  };
+  const notificationServiceMock = {
+    queueBookingCancellationNotifications: vi.fn(),
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    databaseServiceMock.$transaction.mockImplementation(
+      async (callback: (transaction: typeof txMock) => unknown) => callback(txMock),
+    );
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BookingCancellationService,
+        { provide: DatabaseService, useValue: databaseServiceMock },
+        { provide: NotificationService, useValue: notificationServiceMock },
+      ],
+    }).compile();
+
+    service = module.get<BookingCancellationService>(BookingCancellationService);
+  });
+
+  it("cancels a paid booking and marks payment as refund processing", async () => {
+    txMock.booking.findUnique.mockResolvedValueOnce({
+      id: "booking-1",
+      userId: "user-1",
+      status: BookingStatus.CONFIRMED,
+      paymentStatus: PaymentStatus.PAID,
+      carId: "car-1",
+    });
+    txMock.booking.update.mockResolvedValueOnce({
+      id: "booking-1",
+      status: BookingStatus.CANCELLED,
+      car: { owner: {} },
+      user: {},
+      legs: [],
+    });
+    txMock.car.update.mockResolvedValueOnce({ id: "car-1", status: "AVAILABLE" });
+
+    const result = await service.cancelBooking(
+      "booking-1",
+      "user-1",
+      "User requested cancellation",
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({ id: "booking-1", status: BookingStatus.CANCELLED }),
+    );
+    expect(txMock.booking.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "booking-1" },
+        data: expect.objectContaining({
+          status: BookingStatus.CANCELLED,
+          paymentStatus: PaymentStatus.REFUND_PROCESSING,
+          cancellationReason: "User requested cancellation",
+          referralCreditsReserved: 0,
+          referralCreditsUsed: 0,
+        }),
+      }),
+    );
+    expect(txMock.car.update).toHaveBeenCalledWith({
+      where: { id: "car-1" },
+      data: { status: "AVAILABLE" },
+    });
+    expect(notificationServiceMock.queueBookingCancellationNotifications).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "booking-1", status: BookingStatus.CANCELLED }),
+    );
+  });
+
+  it("queues cancellation notification for unpaid booking", async () => {
+    txMock.booking.findUnique.mockResolvedValueOnce({
+      id: "booking-2",
+      userId: "user-1",
+      status: BookingStatus.PENDING,
+      paymentStatus: PaymentStatus.UNPAID,
+      carId: "car-1",
+    });
+    txMock.booking.update.mockResolvedValueOnce({
+      id: "booking-2",
+      status: BookingStatus.CANCELLED,
+      car: { owner: {} },
+      user: {},
+      legs: [],
+    });
+    txMock.car.update.mockResolvedValueOnce({ id: "car-1", status: "AVAILABLE" });
+
+    await service.cancelBooking("booking-2", "user-1", "User requested cancellation");
+
+    expect(notificationServiceMock.queueBookingCancellationNotifications).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "booking-2", status: BookingStatus.CANCELLED }),
+    );
+  });
+
+  it("throws BookingNotFoundException when booking is missing or not owned by user", async () => {
+    txMock.booking.findUnique.mockResolvedValueOnce(null);
+
+    await expect(
+      service.cancelBooking("missing-booking", "user-1", "User requested cancellation"),
+    ).rejects.toBeInstanceOf(BookingNotFoundException);
+  });
+
+  it("throws BookingNotCancellableException when booking status is not cancellable", async () => {
+    txMock.booking.findUnique.mockResolvedValueOnce({
+      id: "booking-1",
+      userId: "user-1",
+      status: BookingStatus.COMPLETED,
+      paymentStatus: PaymentStatus.PAID,
+      carId: "car-1",
+    });
+
+    await expect(
+      service.cancelBooking("booking-1", "user-1", "User requested cancellation"),
+    ).rejects.toBeInstanceOf(BookingNotCancellableException);
+  });
+
+  it("throws BookingCancellationFailedException when transaction fails unexpectedly", async () => {
+    databaseServiceMock.$transaction.mockRejectedValueOnce(new Error("Transaction failed"));
+
+    await expect(
+      service.cancelBooking("booking-1", "user-1", "User requested cancellation"),
+    ).rejects.toBeInstanceOf(BookingCancellationFailedException);
+  });
+});

--- a/src/modules/booking/booking-cancellation.service.ts
+++ b/src/modules/booking/booking-cancellation.service.ts
@@ -1,0 +1,107 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { BookingStatus, PaymentStatus, Status } from "@prisma/client";
+import type { BookingWithRelations } from "../../types";
+import { DatabaseService } from "../database/database.service";
+import { NotificationService } from "../notification/notification.service";
+import {
+  BookingCancellationFailedException,
+  BookingException,
+  BookingNotCancellableException,
+  BookingNotFoundException,
+} from "./booking.error";
+
+@Injectable()
+export class BookingCancellationService {
+  private readonly logger = new Logger(BookingCancellationService.name);
+
+  constructor(
+    private readonly databaseService: DatabaseService,
+    private readonly notificationService: NotificationService,
+  ) {}
+
+  async cancelBooking(bookingId: string, userId: string, reason: string) {
+    try {
+      const updatedBooking = await this.databaseService.$transaction(async (tx) => {
+        const existingBooking = await tx.booking.findUnique({
+          where: { id: bookingId },
+          select: {
+            id: true,
+            userId: true,
+            status: true,
+            paymentStatus: true,
+            carId: true,
+          },
+        });
+
+        if (!existingBooking?.id || existingBooking.userId !== userId) {
+          throw new BookingNotFoundException();
+        }
+
+        const isCancellableStatus =
+          existingBooking.status === BookingStatus.CONFIRMED ||
+          existingBooking.status === BookingStatus.PENDING;
+
+        if (!isCancellableStatus) {
+          throw new BookingNotCancellableException();
+        }
+
+        const updatedBooking = await tx.booking.update({
+          where: { id: bookingId },
+          data: {
+            status: BookingStatus.CANCELLED,
+            paymentStatus:
+              existingBooking.paymentStatus === PaymentStatus.PAID
+                ? PaymentStatus.REFUND_PROCESSING
+                : existingBooking.paymentStatus,
+            cancelledAt: new Date(),
+            cancellationReason: reason,
+            referralCreditsReserved: 0,
+            ...(existingBooking.paymentStatus === PaymentStatus.PAID
+              ? { referralCreditsUsed: 0 }
+              : {}),
+          },
+          include: {
+            user: true,
+            chauffeur: true,
+            legs: { include: { extensions: true } },
+            car: { include: { owner: { include: { chauffeurs: true } } } },
+          },
+        });
+
+        await tx.car.update({
+          where: { id: existingBooking.carId },
+          data: { status: Status.AVAILABLE },
+        });
+
+        return updatedBooking;
+      });
+
+      await this.queueCancellationNotification(updatedBooking);
+
+      return updatedBooking;
+    } catch (error) {
+      if (error instanceof BookingException) {
+        throw error;
+      }
+
+      this.logger.error("Failed to cancel booking", {
+        bookingId,
+        userId,
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+      throw new BookingCancellationFailedException();
+    }
+  }
+
+  private async queueCancellationNotification(booking: BookingWithRelations): Promise<void> {
+    try {
+      await this.notificationService.queueBookingCancellationNotifications(booking);
+    } catch (error) {
+      this.logger.error("Failed to queue cancellation notification", {
+        bookingId: booking.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}

--- a/src/modules/booking/booking-extension.service.spec.ts
+++ b/src/modules/booking/booking-extension.service.spec.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, NotFoundException } from "@nestjs/common";
 import { Test, type TestingModule } from "@nestjs/testing";
 import { BookingStatus, BookingType, PaymentStatus } from "@prisma/client";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthSession } from "../auth/guards/session.guard";
 import { DatabaseService } from "../database/database.service";
 import { FlutterwaveService } from "../flutterwave/flutterwave.service";
@@ -47,7 +47,13 @@ describe("BookingExtensionService", () => {
     roles: ["user" as const],
   } satisfies AuthSession["user"];
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T10:00:00.000Z"));
     vi.clearAllMocks();
 
     const module: TestingModule = await Test.createTestingModule({

--- a/src/modules/booking/booking-read.service.spec.ts
+++ b/src/modules/booking/booking-read.service.spec.ts
@@ -1,0 +1,103 @@
+import { Test, type TestingModule } from "@nestjs/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DatabaseService } from "../database/database.service";
+import { BookingFetchFailedException, BookingNotFoundException } from "./booking.error";
+import { BookingReadService } from "./booking-read.service";
+
+describe("BookingReadService", () => {
+  let service: BookingReadService;
+  const databaseServiceMock = {
+    booking: {
+      findMany: vi.fn(),
+      findFirst: vi.fn(),
+    },
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [BookingReadService, { provide: DatabaseService, useValue: databaseServiceMock }],
+    }).compile();
+
+    service = module.get<BookingReadService>(BookingReadService);
+  });
+
+  it("groups current user bookings by status", async () => {
+    databaseServiceMock.booking.findMany.mockResolvedValueOnce([
+      {
+        id: "booking-1",
+        status: "CONFIRMED",
+        totalAmount: { toNumber: () => 15000 },
+      },
+      {
+        id: "booking-2",
+        status: "COMPLETED",
+        totalAmount: { toNumber: () => 21000 },
+      },
+      {
+        id: "booking-3",
+        status: "CONFIRMED",
+        totalAmount: { toNumber: () => 8000 },
+      },
+    ]);
+
+    const result = await service.getBookingsByStatus("user-1");
+
+    expect(result).toEqual({
+      CONFIRMED: [
+        { id: "booking-1", status: "CONFIRMED", totalAmount: 15000 },
+        { id: "booking-3", status: "CONFIRMED", totalAmount: 8000 },
+      ],
+      COMPLETED: [{ id: "booking-2", status: "COMPLETED", totalAmount: 21000 }],
+    });
+  });
+
+  it("returns booking details for the requesting user", async () => {
+    databaseServiceMock.booking.findFirst.mockResolvedValueOnce({
+      id: "booking-123",
+      userId: "user-1",
+      status: "CONFIRMED",
+      totalAmount: { toNumber: () => 12000 },
+      legs: [
+        {
+          id: "leg-1",
+          extensions: [{ id: "ext-1", totalAmount: { toNumber: () => 2000 } }],
+        },
+      ],
+    });
+
+    const result = await service.getBookingById("booking-123", "user-1");
+
+    expect(result).toEqual({
+      id: "booking-123",
+      userId: "user-1",
+      status: "CONFIRMED",
+      totalAmount: 12000,
+      legs: [{ id: "leg-1", extensions: [{ id: "ext-1", totalAmount: 2000 }] }],
+    });
+  });
+
+  it("throws BookingNotFoundException when booking does not exist for user", async () => {
+    databaseServiceMock.booking.findFirst.mockResolvedValueOnce(null);
+
+    await expect(service.getBookingById("missing-booking", "user-1")).rejects.toBeInstanceOf(
+      BookingNotFoundException,
+    );
+  });
+
+  it("throws BookingFetchFailedException when list query fails unexpectedly", async () => {
+    databaseServiceMock.booking.findMany.mockRejectedValueOnce(new Error("DB down"));
+
+    await expect(service.getBookingsByStatus("user-1")).rejects.toBeInstanceOf(
+      BookingFetchFailedException,
+    );
+  });
+
+  it("throws BookingFetchFailedException when detail query fails unexpectedly", async () => {
+    databaseServiceMock.booking.findFirst.mockRejectedValueOnce(new Error("DB down"));
+
+    await expect(service.getBookingById("booking-123", "user-1")).rejects.toBeInstanceOf(
+      BookingFetchFailedException,
+    );
+  });
+});

--- a/src/modules/booking/booking-read.service.ts
+++ b/src/modules/booking/booking-read.service.ts
@@ -1,0 +1,131 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { PaymentStatus } from "@prisma/client";
+import { DatabaseService } from "../database/database.service";
+import {
+  BookingException,
+  BookingFetchFailedException,
+  BookingNotFoundException,
+} from "./booking.error";
+
+@Injectable()
+export class BookingReadService {
+  private readonly logger = new Logger(BookingReadService.name);
+  private readonly bookingDetailsInclude = {
+    car: { include: { owner: true, images: true } },
+    user: true,
+    chauffeur: true,
+    flight: true,
+    review: {
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+            image: true,
+          },
+        },
+      },
+    },
+    legs: {
+      orderBy: { legDate: "asc" },
+      include: {
+        extensions: true,
+      },
+    },
+  } as const;
+
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async getBookingsByStatus(userId: string) {
+    try {
+      const bookings = await this.databaseService.booking.findMany({
+        where: {
+          userId,
+          paymentStatus: {
+            in: [PaymentStatus.PAID, PaymentStatus.PARTIALLY_REFUNDED, PaymentStatus.REFUNDED],
+          },
+        },
+        include: this.bookingDetailsInclude,
+        orderBy: { startDate: "asc" },
+      });
+
+      const serializedBookings = bookings.map((booking) => this.serializeValue(booking));
+
+      return serializedBookings.reduce<Record<string, unknown[]>>((acc, booking) => {
+        const status = booking.status;
+        if (!acc[status]) {
+          acc[status] = [];
+        }
+        acc[status].push(booking);
+        return acc;
+      }, {});
+    } catch (error) {
+      if (error instanceof BookingException) {
+        throw error;
+      }
+
+      this.logger.error("Failed to fetch bookings by status", {
+        userId,
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+      throw new BookingFetchFailedException();
+    }
+  }
+
+  async getBookingById(bookingId: string, userId: string) {
+    try {
+      const booking = await this.databaseService.booking.findFirst({
+        where: { id: bookingId, userId },
+        include: this.bookingDetailsInclude,
+      });
+
+      if (!booking) {
+        throw new BookingNotFoundException();
+      }
+
+      return this.serializeValue(booking);
+    } catch (error) {
+      if (error instanceof BookingException) {
+        throw error;
+      }
+
+      this.logger.error("Failed to fetch booking by id", {
+        bookingId,
+        userId,
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+      throw new BookingFetchFailedException();
+    }
+  }
+
+  private serializeValue<T>(value: T): T {
+    if (value === null || value === undefined) {
+      return value;
+    }
+
+    if (value instanceof Date) {
+      return value;
+    }
+
+    if (Array.isArray(value)) {
+      return value.map((item) => this.serializeValue(item)) as T;
+    }
+
+    if (typeof value === "object") {
+      const maybeDecimal = value as { toNumber?: () => number };
+      if (typeof maybeDecimal.toNumber === "function") {
+        return maybeDecimal.toNumber() as T;
+      }
+
+      const serializedObject: Record<string, unknown> = {};
+      for (const [key, nestedValue] of Object.entries(value as Record<string, unknown>)) {
+        serializedObject[key] = this.serializeValue(nestedValue);
+      }
+      return serializedObject as T;
+    }
+
+    return value;
+  }
+}

--- a/src/modules/booking/booking-update.service.spec.ts
+++ b/src/modules/booking/booking-update.service.spec.ts
@@ -1,0 +1,177 @@
+import { Test, type TestingModule } from "@nestjs/testing";
+import { BookingStatus, PaymentStatus } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DatabaseService } from "../database/database.service";
+import {
+  BookingNotFoundException,
+  BookingUpdateFailedException,
+  BookingUpdateNotAllowedException,
+  BookingValidationException,
+} from "./booking.error";
+import { BookingUpdateService } from "./booking-update.service";
+import { BookingValidationService } from "./booking-validation.service";
+
+describe("BookingUpdateService", () => {
+  let service: BookingUpdateService;
+
+  const databaseServiceMock = {
+    booking: {
+      findFirst: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  };
+
+  const bookingValidationServiceMock = {
+    validateDates: vi.fn(),
+    checkCarAvailability: vi.fn(),
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BookingUpdateService,
+        { provide: DatabaseService, useValue: databaseServiceMock },
+        { provide: BookingValidationService, useValue: bookingValidationServiceMock },
+      ],
+    }).compile();
+
+    service = module.get<BookingUpdateService>(BookingUpdateService);
+  });
+
+  it("updates booking pickup location", async () => {
+    databaseServiceMock.booking.findFirst.mockResolvedValueOnce({
+      id: "booking-1",
+      userId: "user-1",
+      carId: "car-1",
+      type: "DAY",
+      status: BookingStatus.CONFIRMED,
+      startDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      endDate: new Date(Date.now() + 36 * 60 * 60 * 1000),
+      pickupLocation: "Old pickup",
+      returnLocation: "Old return",
+    });
+    databaseServiceMock.booking.update.mockResolvedValueOnce({ id: "booking-1" });
+
+    await service.updateBooking("booking-1", "user-1", {
+      pickupAddress: "New pickup",
+    });
+
+    expect(databaseServiceMock.booking.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "booking-1" },
+        data: expect.objectContaining({
+          pickupLocation: "New pickup",
+        }),
+      }),
+    );
+  });
+
+  it("updates booking pickup time for DAY and checks availability", async () => {
+    const startDate = new Date(Date.now() + 48 * 60 * 60 * 1000);
+    databaseServiceMock.booking.findFirst.mockResolvedValueOnce({
+      id: "booking-1",
+      userId: "user-1",
+      carId: "car-1",
+      type: "DAY",
+      status: BookingStatus.CONFIRMED,
+      startDate,
+      endDate: new Date(startDate.getTime() + 12 * 60 * 60 * 1000),
+      pickupLocation: "Old pickup",
+      returnLocation: "Old return",
+    });
+    databaseServiceMock.booking.update.mockResolvedValueOnce({ id: "booking-1" });
+
+    await service.updateBooking("booking-1", "user-1", {
+      pickupTime: "10:30 AM",
+    });
+
+    expect(bookingValidationServiceMock.validateDates).toHaveBeenCalled();
+    expect(bookingValidationServiceMock.checkCarAvailability).toHaveBeenCalledWith(
+      expect.objectContaining({
+        carId: "car-1",
+        excludeBookingId: "booking-1",
+      }),
+    );
+  });
+
+  it("throws when booking does not exist for user", async () => {
+    databaseServiceMock.booking.findFirst.mockResolvedValueOnce(null);
+
+    await expect(
+      service.updateBooking("missing", "user-1", { pickupAddress: "New pickup" }),
+    ).rejects.toBeInstanceOf(BookingNotFoundException);
+  });
+
+  it("throws when booking is not confirmed", async () => {
+    databaseServiceMock.booking.findFirst.mockResolvedValueOnce({
+      id: "booking-1",
+      userId: "user-1",
+      carId: "car-1",
+      type: "DAY",
+      status: BookingStatus.COMPLETED,
+      startDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      endDate: new Date(Date.now() + 36 * 60 * 60 * 1000),
+      pickupLocation: "Old pickup",
+      returnLocation: "Old return",
+    });
+
+    await expect(
+      service.updateBooking("booking-1", "user-1", { pickupAddress: "New pickup" }),
+    ).rejects.toBeInstanceOf(BookingUpdateNotAllowedException);
+  });
+
+  it("throws validation error for pickupTime on unsupported booking type", async () => {
+    databaseServiceMock.booking.findFirst.mockResolvedValueOnce({
+      id: "booking-1",
+      userId: "user-1",
+      carId: "car-1",
+      type: "NIGHT",
+      status: BookingStatus.CONFIRMED,
+      startDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      endDate: new Date(Date.now() + 36 * 60 * 60 * 1000),
+      pickupLocation: "Old pickup",
+      returnLocation: "Old return",
+    });
+
+    await expect(
+      service.updateBooking("booking-1", "user-1", { pickupTime: "10 AM" }),
+    ).rejects.toBeInstanceOf(BookingValidationException);
+  });
+
+  it("throws booking update failed for unexpected errors", async () => {
+    databaseServiceMock.booking.findFirst.mockRejectedValueOnce(new Error("DB unavailable"));
+
+    await expect(
+      service.updateBooking("booking-1", "user-1", { pickupAddress: "New pickup" }),
+    ).rejects.toBeInstanceOf(BookingUpdateFailedException);
+  });
+
+  it("returns current booking when no changes detected", async () => {
+    const baseBooking = {
+      id: "booking-1",
+      userId: "user-1",
+      carId: "car-1",
+      type: "DAY",
+      status: BookingStatus.CONFIRMED,
+      startDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      endDate: new Date(Date.now() + 36 * 60 * 60 * 1000),
+      pickupLocation: "Old pickup",
+      returnLocation: "Old return",
+    };
+    databaseServiceMock.booking.findFirst.mockResolvedValueOnce(baseBooking);
+    databaseServiceMock.booking.findUnique.mockResolvedValueOnce({
+      id: "booking-1",
+      paymentStatus: PaymentStatus.PAID,
+    });
+
+    const result = await service.updateBooking("booking-1", "user-1", {
+      pickupAddress: "Old pickup",
+    });
+
+    expect(databaseServiceMock.booking.update).not.toHaveBeenCalled();
+    expect(result).toEqual({ id: "booking-1", paymentStatus: PaymentStatus.PAID });
+  });
+});

--- a/src/modules/booking/booking-update.service.ts
+++ b/src/modules/booking/booking-update.service.ts
@@ -1,0 +1,269 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { BookingStatus, type BookingType, PaymentStatus } from "@prisma/client";
+import { DatabaseService } from "../database/database.service";
+import { DAY_BOOKING_DURATION_HOURS, FULL_DAY_DURATION_HOURS } from "./booking.const";
+import {
+  BookingException,
+  BookingNotFoundException,
+  BookingUpdateFailedException,
+  BookingUpdateNotAllowedException,
+  BookingValidationException,
+} from "./booking.error";
+import { BookingValidationService } from "./booking-validation.service";
+import type { UpdateBookingBodyDto } from "./dto/update-booking.dto";
+
+type CurrentBookingRecord = {
+  id: string;
+  userId: string | null;
+  carId: string;
+  type: BookingType;
+  status: BookingStatus;
+  startDate: Date;
+  endDate: Date;
+  pickupLocation: string;
+  returnLocation: string;
+};
+
+@Injectable()
+export class BookingUpdateService {
+  private readonly logger = new Logger(BookingUpdateService.name);
+  private readonly bookingEditWindowMs = 12 * 60 * 60 * 1000;
+  private readonly bookingDetailsInclude = {
+    car: { include: { owner: true } },
+    user: true,
+    chauffeur: true,
+    flight: true,
+    review: {
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+            image: true,
+          },
+        },
+      },
+    },
+    legs: {
+      orderBy: { legDate: "asc" },
+      include: {
+        extensions: {
+          where: { status: "ACTIVE", paymentStatus: PaymentStatus.PAID },
+        },
+      },
+    },
+  } as const;
+
+  constructor(
+    private readonly bookingValidationService: BookingValidationService,
+    private readonly databaseService: DatabaseService,
+  ) {}
+
+  async updateBooking(bookingId: string, userId: string, input: UpdateBookingBodyDto) {
+    try {
+      return await this.updateBookingInternal(bookingId, userId, input);
+    } catch (error) {
+      if (error instanceof BookingException) {
+        throw error;
+      }
+
+      this.logger.error("Failed to update booking", {
+        bookingId,
+        userId,
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+      throw new BookingUpdateFailedException();
+    }
+  }
+
+  private async updateBookingInternal(
+    bookingId: string,
+    userId: string,
+    input: UpdateBookingBodyDto,
+  ) {
+    const currentBooking = await this.getCurrentBookingForUser(bookingId, userId);
+    this.assertBookingCanBeUpdated(currentBooking);
+
+    const { newStartDate, newEndDate } = this.resolveUpdatedDates(currentBooking, input.pickupTime);
+    this.assertWithinEditWindow(newStartDate ?? currentBooking.startDate);
+
+    const { newPickupLocation, newReturnLocation } = this.resolveLocationUpdates(
+      currentBooking,
+      input,
+    );
+    await this.validateUpdatedDatesAndAvailability(currentBooking, newStartDate, newEndDate);
+
+    const updateData = {
+      ...(newStartDate ? { startDate: newStartDate } : {}),
+      ...(newEndDate ? { endDate: newEndDate } : {}),
+      ...(newPickupLocation ? { pickupLocation: newPickupLocation } : {}),
+      ...(newReturnLocation ? { returnLocation: newReturnLocation } : {}),
+    };
+
+    if (Object.keys(updateData).length === 0) {
+      return this.getBookingDetailsById(currentBooking.id);
+    }
+
+    return this.databaseService.booking.update({
+      where: { id: bookingId },
+      data: updateData,
+      include: this.bookingDetailsInclude,
+    });
+  }
+
+  private getBookingDetailsById(bookingId: string) {
+    return this.databaseService.booking.findUnique({
+      where: { id: bookingId },
+      include: this.bookingDetailsInclude,
+    });
+  }
+
+  private resolveLocationUpdates(
+    currentBooking: CurrentBookingRecord,
+    input: UpdateBookingBodyDto,
+  ) {
+    const newPickupLocation =
+      input.pickupAddress && input.pickupAddress !== currentBooking.pickupLocation
+        ? input.pickupAddress
+        : undefined;
+    const effectivePickupLocation = newPickupLocation ?? currentBooking.pickupLocation;
+
+    const targetReturnLocation = this.resolveTargetReturnLocation(
+      input,
+      effectivePickupLocation,
+      currentBooking.returnLocation,
+    );
+    const newReturnLocation =
+      targetReturnLocation && targetReturnLocation !== currentBooking.returnLocation
+        ? targetReturnLocation
+        : undefined;
+
+    return { newPickupLocation, newReturnLocation };
+  }
+
+  private assertWithinEditWindow(effectiveStartDate: Date): void {
+    if (effectiveStartDate.getTime() - Date.now() < this.bookingEditWindowMs) {
+      throw new BookingUpdateNotAllowedException(
+        "Bookings cannot be edited within 12 hours of start time",
+      );
+    }
+  }
+
+  private async getCurrentBookingForUser(
+    bookingId: string,
+    userId: string,
+  ): Promise<CurrentBookingRecord> {
+    const currentBooking = await this.databaseService.booking.findFirst({
+      where: { id: bookingId, userId },
+      select: {
+        id: true,
+        userId: true,
+        carId: true,
+        type: true,
+        status: true,
+        startDate: true,
+        endDate: true,
+        pickupLocation: true,
+        returnLocation: true,
+      },
+    });
+
+    if (!currentBooking) {
+      throw new BookingNotFoundException();
+    }
+
+    return currentBooking;
+  }
+
+  private assertBookingCanBeUpdated(currentBooking: CurrentBookingRecord): void {
+    if (currentBooking.status !== BookingStatus.CONFIRMED) {
+      throw new BookingUpdateNotAllowedException("Only confirmed bookings can be updated");
+    }
+  }
+
+  private resolveTargetReturnLocation(
+    input: UpdateBookingBodyDto,
+    effectivePickupLocation: string,
+    currentReturnLocation: string,
+  ): string | undefined {
+    if (input.sameLocation === true) {
+      return effectivePickupLocation;
+    }
+    if (input.sameLocation === false) {
+      return input.dropOffAddress;
+    }
+    return input.dropOffAddress ?? currentReturnLocation;
+  }
+
+  private async validateUpdatedDatesAndAvailability(
+    currentBooking: CurrentBookingRecord,
+    newStartDate?: Date,
+    newEndDate?: Date,
+  ): Promise<void> {
+    if (!newStartDate || !newEndDate) {
+      return;
+    }
+
+    this.bookingValidationService.validateDates({
+      startDate: newStartDate,
+      endDate: newEndDate,
+      bookingType: currentBooking.type,
+    });
+
+    await this.bookingValidationService.checkCarAvailability({
+      carId: currentBooking.carId,
+      startDate: newStartDate,
+      endDate: newEndDate,
+      excludeBookingId: currentBooking.id,
+    });
+  }
+
+  private resolveUpdatedDates(
+    currentBooking: { type: BookingType; startDate: Date },
+    pickupTime?: string,
+  ): { newStartDate?: Date; newEndDate?: Date } {
+    if (!pickupTime) {
+      return {};
+    }
+
+    if (currentBooking.type !== "DAY" && currentBooking.type !== "FULL_DAY") {
+      throw new BookingValidationException([
+        {
+          field: "pickupTime",
+          message: "Pickup time can only be updated for DAY or FULL_DAY bookings",
+        },
+      ]);
+    }
+
+    const match = /^(1[0-2]|[1-9])(?::([0-5]\d))?\s?(AM|PM)$/i.exec(pickupTime.trim());
+    if (!match) {
+      throw new BookingValidationException([
+        {
+          field: "pickupTime",
+          message: "Invalid pickup time format. Expected H:MM AM/PM",
+        },
+      ]);
+    }
+
+    let hour = Number.parseInt(match[1], 10);
+    const minute = match[2] ? Number.parseInt(match[2], 10) : 0;
+    const period = match[3].toUpperCase();
+
+    if (period === "PM" && hour !== 12) {
+      hour += 12;
+    } else if (period === "AM" && hour === 12) {
+      hour = 0;
+    }
+
+    const newStartDate = new Date(currentBooking.startDate);
+    newStartDate.setHours(hour, minute, 0, 0);
+
+    const newEndDate = new Date(newStartDate);
+    const durationHours =
+      currentBooking.type === "FULL_DAY" ? FULL_DAY_DURATION_HOURS : DAY_BOOKING_DURATION_HOURS;
+    newEndDate.setHours(newEndDate.getHours() + durationHours);
+
+    return { newStartDate, newEndDate };
+  }
+}

--- a/src/modules/booking/booking.error.ts
+++ b/src/modules/booking/booking.error.ts
@@ -14,6 +14,12 @@ export const BookingErrorCode = {
   CAR_NOT_AVAILABLE: "CAR_NOT_AVAILABLE",
   PAYMENT_INTENT_FAILED: "PAYMENT_INTENT_FAILED",
   BOOKING_CREATION_FAILED: "BOOKING_CREATION_FAILED",
+  BOOKING_NOT_FOUND: "BOOKING_NOT_FOUND",
+  BOOKING_FETCH_FAILED: "BOOKING_FETCH_FAILED",
+  BOOKING_UPDATE_FAILED: "BOOKING_UPDATE_FAILED",
+  BOOKING_UPDATE_NOT_ALLOWED: "BOOKING_UPDATE_NOT_ALLOWED",
+  BOOKING_NOT_CANCELLABLE: "BOOKING_NOT_CANCELLABLE",
+  BOOKING_CANCELLATION_FAILED: "BOOKING_CANCELLATION_FAILED",
   REFERRAL_DISCOUNT_NO_LONGER_AVAILABLE: "REFERRAL_DISCOUNT_NO_LONGER_AVAILABLE",
 } as const;
 
@@ -31,11 +37,7 @@ export class BookingValidationException extends BookingException {
       BookingErrorCode.VALIDATION_ERROR,
       detail ?? "One or more validation errors occurred",
       HttpStatus.BAD_REQUEST,
-      {
-        type: BookingErrorCode.VALIDATION_ERROR,
-        title: "Validation Failed",
-        errors,
-      },
+      { title: "Validation Failed", errors },
     );
   }
 }
@@ -49,10 +51,7 @@ export class CarNotAvailableException extends BookingException {
       BookingErrorCode.CAR_NOT_AVAILABLE,
       reason ?? `Car ${carId} is not available for the selected dates`,
       HttpStatus.CONFLICT,
-      {
-        type: BookingErrorCode.CAR_NOT_AVAILABLE,
-        title: "Car Not Available",
-      },
+      { title: "Car Not Available" },
     );
   }
 }
@@ -66,10 +65,7 @@ export class CarNotFoundException extends BookingException {
       BookingErrorCode.CAR_NOT_FOUND,
       `Car with ID ${carId} was not found`,
       HttpStatus.NOT_FOUND,
-      {
-        type: BookingErrorCode.CAR_NOT_FOUND,
-        title: "Car Not Found",
-      },
+      { title: "Car Not Found" },
     );
   }
 }
@@ -83,10 +79,7 @@ export class PaymentIntentFailedException extends BookingException {
       BookingErrorCode.PAYMENT_INTENT_FAILED,
       detail ?? "Failed to create payment intent. Please try again.",
       HttpStatus.BAD_GATEWAY,
-      {
-        type: BookingErrorCode.PAYMENT_INTENT_FAILED,
-        title: "Payment Intent Failed",
-      },
+      { title: "Payment Intent Failed" },
     );
   }
 }
@@ -100,10 +93,7 @@ export class BookingCreationFailedException extends BookingException {
       BookingErrorCode.BOOKING_CREATION_FAILED,
       detail ?? "An unexpected error occurred while creating the booking",
       HttpStatus.INTERNAL_SERVER_ERROR,
-      {
-        type: BookingErrorCode.BOOKING_CREATION_FAILED,
-        title: "Booking Creation Failed",
-      },
+      { title: "Booking Creation Failed" },
     );
   }
 }
@@ -118,10 +108,73 @@ export class ReferralDiscountNoLongerAvailableException extends BookingException
       BookingErrorCode.REFERRAL_DISCOUNT_NO_LONGER_AVAILABLE,
       "The referral discount is no longer available. It may have been used in another booking. Please retry without the discount.",
       HttpStatus.CONFLICT,
-      {
-        type: BookingErrorCode.REFERRAL_DISCOUNT_NO_LONGER_AVAILABLE,
-        title: "Referral Discount No Longer Available",
-      },
+      { title: "Referral Discount No Longer Available" },
+    );
+  }
+}
+
+export class BookingNotFoundException extends BookingException {
+  constructor() {
+    super(
+      BookingErrorCode.BOOKING_NOT_FOUND,
+      "Booking not found or you do not have access to it",
+      HttpStatus.NOT_FOUND,
+      { title: "Booking Not Found" },
+    );
+  }
+}
+
+export class BookingFetchFailedException extends BookingException {
+  constructor() {
+    super(
+      BookingErrorCode.BOOKING_FETCH_FAILED,
+      "An unexpected error occurred while fetching bookings",
+      HttpStatus.INTERNAL_SERVER_ERROR,
+      { title: "Booking Fetch Failed" },
+    );
+  }
+}
+
+export class BookingUpdateFailedException extends BookingException {
+  constructor() {
+    super(
+      BookingErrorCode.BOOKING_UPDATE_FAILED,
+      "An unexpected error occurred while updating the booking",
+      HttpStatus.INTERNAL_SERVER_ERROR,
+      { title: "Booking Update Failed" },
+    );
+  }
+}
+
+export class BookingUpdateNotAllowedException extends BookingException {
+  constructor(detail?: string) {
+    super(
+      BookingErrorCode.BOOKING_UPDATE_NOT_ALLOWED,
+      detail ?? "This booking cannot be updated in its current state",
+      HttpStatus.CONFLICT,
+      { title: "Booking Update Not Allowed" },
+    );
+  }
+}
+
+export class BookingNotCancellableException extends BookingException {
+  constructor() {
+    super(
+      BookingErrorCode.BOOKING_NOT_CANCELLABLE,
+      "This booking cannot be cancelled in its current state",
+      HttpStatus.CONFLICT,
+      { title: "Booking Not Cancellable" },
+    );
+  }
+}
+
+export class BookingCancellationFailedException extends BookingException {
+  constructor() {
+    super(
+      BookingErrorCode.BOOKING_CANCELLATION_FAILED,
+      "An unexpected error occurred while cancelling the booking",
+      HttpStatus.INTERNAL_SERVER_ERROR,
+      { title: "Booking Cancellation Failed" },
     );
   }
 }

--- a/src/modules/booking/booking.module.ts
+++ b/src/modules/booking/booking.module.ts
@@ -7,10 +7,13 @@ import { NotificationModule } from "../notification/notification.module";
 import { RatesModule } from "../rates/rates.module";
 import { BookingController } from "./booking.controller";
 import { BookingCalculationService } from "./booking-calculation.service";
+import { BookingCancellationService } from "./booking-cancellation.service";
 import { BookingConfirmationService } from "./booking-confirmation.service";
 import { BookingCreationService } from "./booking-creation.service";
 import { BookingExtensionService } from "./booking-extension.service";
 import { BookingLegService } from "./booking-leg.service";
+import { BookingReadService } from "./booking-read.service";
+import { BookingUpdateService } from "./booking-update.service";
 import { BookingValidationService } from "./booking-validation.service";
 import { ExtensionConfirmationService } from "./extension-confirmation.service";
 
@@ -31,6 +34,9 @@ import { ExtensionConfirmationService } from "./extension-confirmation.service";
     BookingCalculationService,
     BookingCreationService,
     BookingExtensionService,
+    BookingReadService,
+    BookingUpdateService,
+    BookingCancellationService,
     ExtensionConfirmationService,
   ],
   exports: [
@@ -40,6 +46,9 @@ import { ExtensionConfirmationService } from "./extension-confirmation.service";
     BookingCalculationService,
     BookingCreationService,
     BookingExtensionService,
+    BookingReadService,
+    BookingUpdateService,
+    BookingCancellationService,
     ExtensionConfirmationService,
   ],
 })

--- a/src/modules/booking/dto/cancel-booking.dto.ts
+++ b/src/modules/booking/dto/cancel-booking.dto.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const cancelBookingBodySchema = z.object({
+  reason: z.string().trim().min(3).max(500).optional(),
+});
+
+export type CancelBookingBodyDto = z.infer<typeof cancelBookingBodySchema>;

--- a/src/modules/booking/dto/update-booking.dto.ts
+++ b/src/modules/booking/dto/update-booking.dto.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+const pickupTimeRegex = /^(1[0-2]|[1-9])(:[0-5]\d)?\s?(AM|PM)$/i;
+
+export const updateBookingBodySchema = z
+  .object({
+    pickupTime: z.string().trim().regex(pickupTimeRegex).optional(),
+    pickupAddress: z.string().trim().min(1).optional(),
+    sameLocation: z.boolean().optional(),
+    dropOffAddress: z.string().trim().min(1).optional(),
+  })
+  .refine(
+    (data) =>
+      data.pickupTime !== undefined ||
+      data.pickupAddress !== undefined ||
+      data.sameLocation !== undefined ||
+      data.dropOffAddress !== undefined,
+    {
+      message: "At least one update field is required",
+      path: ["pickupAddress"],
+    },
+  )
+  .refine((data) => !(data.sameLocation === false && !data.dropOffAddress), {
+    message: "Drop-off address is required when sameLocation is false",
+    path: ["dropOffAddress"],
+  });
+
+export type UpdateBookingBodyDto = z.infer<typeof updateBookingBodySchema>;

--- a/src/modules/notification/notification.const.ts
+++ b/src/modules/notification/notification.const.ts
@@ -1,7 +1,7 @@
 import { NotificationChannel } from "./notification.interface";
 
 export const DEFAULT_CHANNELS = [NotificationChannel.EMAIL, NotificationChannel.WHATSAPP];
-export const STATUS_CHANGE_JOB_OPTIONS = { priority: 1 };
+export const HIGH_PRIORITY_JOB_OPTIONS = { priority: 1 };
 export const SEND_NOTIFICATION_JOB_NAME = "send-notification";
 export {
   CHAUFFEUR_RECIPIENT_TYPE,

--- a/src/modules/notification/notification.interface.ts
+++ b/src/modules/notification/notification.interface.ts
@@ -10,6 +10,7 @@ export enum NotificationType {
   BOOKING_REMINDER_START = "booking-reminder-start",
   BOOKING_REMINDER_END = "booking-reminder-end",
   BOOKING_CONFIRMED = "booking-confirmed",
+  BOOKING_CANCELLED = "booking-cancelled",
   BOOKING_EXTENSION_CONFIRMED = "booking-extension-confirmed",
   FLEET_OWNER_NEW_BOOKING = "fleet-owner-new-booking",
   REVIEW_RECEIVED = "review-received",

--- a/src/modules/notification/template-data.interface.ts
+++ b/src/modules/notification/template-data.interface.ts
@@ -11,6 +11,7 @@ export type RecipientType =
 export const BOOKING_STATUS_TEMPLATE_KIND = "bookingStatusChange" as const;
 export const BOOKING_REMINDER_TEMPLATE_KIND = "bookingReminder" as const;
 export const BOOKING_CONFIRMED_TEMPLATE_KIND = "bookingConfirmed" as const;
+export const BOOKING_CANCELLED_TEMPLATE_KIND = "bookingCancelled" as const;
 export const BOOKING_EXTENSION_CONFIRMED_TEMPLATE_KIND = "bookingExtensionConfirmed" as const;
 export const FLEET_OWNER_NEW_BOOKING_TEMPLATE_KIND = "fleetOwnerNewBooking" as const;
 export const REVIEW_RECEIVED_TEMPLATE_KIND = "reviewReceived" as const;
@@ -18,6 +19,7 @@ export type TemplateKind =
   | typeof BOOKING_STATUS_TEMPLATE_KIND
   | typeof BOOKING_REMINDER_TEMPLATE_KIND
   | typeof BOOKING_CONFIRMED_TEMPLATE_KIND
+  | typeof BOOKING_CANCELLED_TEMPLATE_KIND
   | typeof BOOKING_EXTENSION_CONFIRMED_TEMPLATE_KIND
   | typeof FLEET_OWNER_NEW_BOOKING_TEMPLATE_KIND
   | typeof REVIEW_RECEIVED_TEMPLATE_KIND;
@@ -52,6 +54,11 @@ export interface BookingConfirmedTemplateData extends NormalisedBookingDetails {
 
 export interface FleetOwnerNewBookingTemplateData extends NormalisedBookingDetails {
   templateKind: typeof FLEET_OWNER_NEW_BOOKING_TEMPLATE_KIND;
+  subject: string;
+}
+
+export interface BookingCancelledTemplateData extends NormalisedBookingDetails {
+  templateKind: typeof BOOKING_CANCELLED_TEMPLATE_KIND;
   subject: string;
 }
 
@@ -90,6 +97,7 @@ export type TemplateData =
   | BookingStatusTemplateData
   | BookingReminderTemplateData
   | BookingConfirmedTemplateData
+  | BookingCancelledTemplateData
   | BookingExtensionConfirmedTemplateData
   | FleetOwnerNewBookingTemplateData
   | ReviewReceivedTemplateData;

--- a/src/modules/notification/template-mappers/booking-cancelled-mapper.ts
+++ b/src/modules/notification/template-mappers/booking-cancelled-mapper.ts
@@ -1,0 +1,53 @@
+import { NotificationType } from "../notification.interface";
+import {
+  CLIENT_RECIPIENT_TYPE,
+  FLEET_OWNER_RECIPIENT_TYPE,
+  type TemplateData,
+} from "../template-data.interface";
+import { Template } from "../whatsapp.service";
+import { BaseTemplateMapper } from "./base-template-mapper";
+
+export class BookingCancelledMapper extends BaseTemplateMapper {
+  canHandle(type: NotificationType): boolean {
+    return type === NotificationType.BOOKING_CANCELLED;
+  }
+
+  getTemplateKey(type: NotificationType, recipientType: string): Template | null {
+    if (!this.canHandle(type)) return null;
+
+    if (recipientType === FLEET_OWNER_RECIPIENT_TYPE) {
+      return Template.BookingCancellationFleetOwner;
+    }
+    if (recipientType === CLIENT_RECIPIENT_TYPE) {
+      return Template.BookingCancellationClient;
+    }
+    return null;
+  }
+
+  mapVariables(templateData: TemplateData, recipientType: string): Record<string, string | number> {
+    if (recipientType === FLEET_OWNER_RECIPIENT_TYPE) {
+      return {
+        "1": this.getValue(templateData, "ownerName"),
+        "2": this.getValue(templateData, "carName"),
+        "3": this.getValue(templateData, "cancellationReason"),
+        "4": this.getValue(templateData, "customerName"),
+        "5": this.getValue(templateData, "startDate"),
+        "6": this.getValue(templateData, "endDate"),
+        "7": this.getValue(templateData, "pickupLocation"),
+        "8": this.getValue(templateData, "returnLocation"),
+        "9": this.getValue(templateData, "totalAmount"),
+      };
+    }
+
+    return {
+      "1": this.getValue(templateData, "customerName"),
+      "2": this.getValue(templateData, "carName"),
+      "3": this.getValue(templateData, "totalAmount"),
+      "4": this.getValue(templateData, "cancellationReason"),
+      "5": this.getValue(templateData, "startDate"),
+      "6": this.getValue(templateData, "endDate"),
+      "7": this.getValue(templateData, "pickupLocation"),
+      "8": this.getValue(templateData, "returnLocation"),
+    };
+  }
+}

--- a/src/modules/notification/template-mappers/booking-extension-confirmed-mapper.ts
+++ b/src/modules/notification/template-mappers/booking-extension-confirmed-mapper.ts
@@ -1,0 +1,33 @@
+import { NotificationType } from "../notification.interface";
+import { type TemplateData } from "../template-data.interface";
+import { Template } from "../whatsapp.service";
+import { BaseTemplateMapper } from "./base-template-mapper";
+
+export class BookingExtensionConfirmedMapper extends BaseTemplateMapper {
+  canHandle(type: NotificationType): boolean {
+    return type === NotificationType.BOOKING_EXTENSION_CONFIRMED;
+  }
+
+  getTemplateKey(type: NotificationType, _recipientType: string): Template | null {
+    if (!this.canHandle(type)) return null;
+    return Template.BookingExtensionConfirmation;
+  }
+
+  mapVariables(
+    templateData: TemplateData,
+    _recipientType: string,
+  ): Record<string, string | number> {
+    return {
+      "1": this.getValue(templateData, "customerName"),
+      "2": this.getValue(templateData, "carName"),
+      "3": this.getValue(templateData, "legDate"),
+      "4": this.formatExtensionHours(Number(this.getValue(templateData, "extensionHours", 0))),
+      "5": this.getValue(templateData, "from"),
+      "6": this.getValue(templateData, "to"),
+    };
+  }
+
+  private formatExtensionHours(hours: number): string {
+    return hours === 1 ? "1 hour" : `${hours} hours`;
+  }
+}

--- a/src/modules/notification/template-mappers/index.ts
+++ b/src/modules/notification/template-mappers/index.ts
@@ -1,4 +1,5 @@
 export { BaseTemplateMapper, type TemplateVariableMapper } from "./base-template-mapper";
+export { BookingCancelledMapper } from "./booking-cancelled-mapper";
 export { BookingConfirmedMapper } from "./booking-confirmed-mapper";
 export { BookingReminderEndMapper } from "./booking-reminder-end-mapper";
 export { BookingReminderStartMapper } from "./booking-reminder-start-mapper";

--- a/src/modules/notification/whatsapp.service.ts
+++ b/src/modules/notification/whatsapp.service.ts
@@ -10,7 +10,10 @@ export enum Template {
   ClientBookingLegEndReminder = "clientBookingLegEndReminder",
   ChauffeurBookingLegEndReminder = "chauffeurBookingLegEndReminder",
   BookingConfirmation = "bookingConfirmation",
+  BookingCancellationClient = "bookingCancellationClient",
+  BookingCancellationFleetOwner = "bookingCancellationFleetOwner",
   FleetOwnerBookingNotification = "fleetOwnerBookingNotification",
+  BookingExtensionConfirmation = "bookingExtensionConfirmation",
 }
 
 const contentSidMap: Record<Template, string> = {
@@ -20,7 +23,10 @@ const contentSidMap: Record<Template, string> = {
   [Template.ClientBookingLegEndReminder]: "HX0c8470054c0ff1a0b43c06fe196e2ec3",
   [Template.ChauffeurBookingLegEndReminder]: "HX9faf29432a18e9f8f8283a5e281e5a3c",
   [Template.BookingConfirmation]: "HXac9f0b83ee03d47fe2f2969173dac354",
+  [Template.BookingCancellationClient]: "HXd32930f086ad7e2c3ac976e245c314f9",
+  [Template.BookingCancellationFleetOwner]: "HX5ad3e909d6c011f24e00f4706a78a90e",
   [Template.FleetOwnerBookingNotification]: "HXaeda40fabb6c33f323c1f101e0a10165",
+  [Template.BookingExtensionConfirmation]: "HXaeda40fabb6c33f323c1f101e0a10165",
 };
 
 @Injectable()

--- a/src/modules/payment/charge-completed.handler.ts
+++ b/src/modules/payment/charge-completed.handler.ts
@@ -204,10 +204,10 @@ export class ChargeCompletedHandler {
 
     if (booking) {
       bookingId = booking.id;
-      amountExpected = booking.totalAmount.toNumber() ?? amountExpected;
+      amountExpected = booking.totalAmount.toNumber() || amountExpected;
     } else if (extension) {
       extensionId = extension.id;
-      amountExpected = extension.totalAmount.toNumber() ?? amountExpected;
+      amountExpected = extension.totalAmount.toNumber() || amountExpected;
     } else {
       this.logger.error("No booking or extension found for txRef, cannot create payment record", {
         txRef,

--- a/src/templates/emails.tsx
+++ b/src/templates/emails.tsx
@@ -16,6 +16,7 @@ import { render } from "@react-email/render";
 import { ReactNode } from "react";
 import tailwindConfig from "../email-tailwind.config";
 import type {
+  BookingCancelledTemplateData,
   BookingExtensionConfirmedTemplateData,
   ReviewReceivedTemplateData,
 } from "../modules/notification/template-data.interface";
@@ -310,6 +311,82 @@ export async function renderBookingConfirmationEmail(booking: NormalisedBookingD
         Please be at the pickup location on time. You'll be assigned a chauffeur shortly, and we
         will notify you with their details.
       </Text>
+    </EmailTemplate>,
+  );
+}
+
+export async function renderUserBookingCancellationEmail(booking: BookingCancelledTemplateData) {
+  const previewText = "Your booking has been cancelled";
+
+  return await render(
+    <EmailTemplate previewText={previewText} pageTitle="Booking Cancellation Confirmation">
+      <Heading as="h2" className="text-xl font-semibold mb-4">
+        Your Booking Has Been Cancelled
+      </Heading>
+      <Text className="mb-3">Hello {booking.customerName},</Text>
+
+      <Text className="mb-3">
+        Your booking for the <span className="font-semibold">{booking.carName}</span> has been
+        cancelled.
+      </Text>
+
+      <Text className="mb-3">
+        Your payment of <span className="font-semibold">{booking.totalAmount}</span> will be
+        refunded shortly according to our policy.
+      </Text>
+
+      {booking.cancellationReason && (
+        <Text className="mt-3">
+          <span className="font-semibold">Reason for cancellation:</span>{" "}
+          {booking.cancellationReason}
+        </Text>
+      )}
+
+      <Section className="mt-4 border-t border-gray-200 pt-4">
+        <Text className="font-semibold mb-2 underline">
+          Cancelled Booking Details (Booking Reference: {booking.bookingReference})
+        </Text>
+        <DetailListItem label="Start Date & Time" value={booking.startDate} />
+        <DetailListItem label="End Date & Time" value={booking.endDate} />
+        <DetailListItem label="Pickup Location" value={booking.pickupLocation} />
+        <DetailListItem label="Drop-off Location" value={booking.returnLocation} />
+      </Section>
+    </EmailTemplate>,
+  );
+}
+
+export async function renderFleetOwnerBookingCancellationEmail(
+  booking: BookingCancelledTemplateData,
+) {
+  const previewText = "A booking for your vehicle has been cancelled";
+
+  return await render(
+    <EmailTemplate previewText={previewText} pageTitle="Booking Cancellation Notification">
+      <Heading as="h2" className="text-xl font-semibold mb-4">
+        Booking Cancelled
+      </Heading>
+      <Text className="mb-3">Hello {booking.ownerName},</Text>
+
+      <Text className="mb-3">
+        The booking for your vehicle, <span className="font-semibold">{booking.carName}</span>, has
+        been cancelled by {booking.customerName}.
+      </Text>
+
+      {booking.cancellationReason && (
+        <DetailListItem label="Reason for cancellation" value={booking.cancellationReason} />
+      )}
+
+      <Section className="mt-4 border-t border-gray-200 pt-4">
+        <Text className="font-semibold mb-2 underline">
+          Cancelled Booking Details (Booking Reference: {booking.bookingReference})
+        </Text>
+        <DetailListItem label="Customer" value={booking.customerName} />
+        <DetailListItem label="Start Date & Time" value={booking.startDate} />
+        <DetailListItem label="End Date & Time" value={booking.endDate} />
+        <DetailListItem label="Pickup Location" value={booking.pickupLocation} />
+        <DetailListItem label="Drop-off Location" value={booking.returnLocation} />
+        <DetailListItem label="Booking Amount" value={booking.totalAmount} />
+      </Section>
     </EmailTemplate>,
   );
 }


### PR DESCRIPTION
Wire existing BookingReadService, BookingUpdateService, and BookingCancellationService to GET/PATCH/DELETE routes so web and mobile clients can manage bookings through the Nest API.

Add dedicated BOOKING_CANCELLED notification type with separate email templates for customers and fleet owners, plus WhatsApp support using Twilio content templates ported from hireApp.

- GET /api/bookings — list user bookings grouped by status
- GET /api/bookings/:bookingId — get booking details
- PATCH /api/bookings/:bookingId — update pickup time/addresses
- DELETE /api/bookings/:bookingId — cancel with refund processing
- Remove redundant `type` field from all booking error classes
- Rename STATUS_CHANGE_JOB_OPTIONS to HIGH_PRIORITY_JOB_OPTIONS
- Add e2e tests for all new endpoints (auth, isolation, validation)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core booking mutation paths (update/cancel) and notification delivery, so bugs could impact booking state and customer communications; changes are fairly contained and well-covered by new tests.
> 
> **Overview**
> Adds authenticated booking management endpoints: `GET /api/bookings` (grouped by status), `GET /api/bookings/:bookingId`, `PATCH /api/bookings/:bookingId` (pickup time/address updates with validation + edit window), and `DELETE /api/bookings/:bookingId` (cancels confirmed/pending bookings, marks paid bookings as `REFUND_PROCESSING`, frees the car).
> 
> Introduces a dedicated `BOOKING_CANCELLED` notification flow that queues customer + fleet owner email/WhatsApp messages with new template kinds/mappers and new cancellation email templates; also renames notification queue options to `HIGH_PRIORITY_JOB_OPTIONS`.
> 
> Expands booking error taxonomy (fetch/update/cancel/not-found/not-cancellable) and adds unit + e2e test coverage for the new services/routes, plus a small webhook robustness tweak (`??` to `||`) when deriving expected payment amounts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82eb2b166382c3e9dac666c8c847592cc3e62c52. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->