### PR TITLE
feat(car): implement fleet-owner car APIs, asset uploads, validation, & shared storage abstraction

### DIFF
--- a/.env.e2e
+++ b/.env.e2e
@@ -30,3 +30,7 @@ HMAC_KEY=flutterwave-webhook-comparison-e2e
 FLIGHTAWARE_API_KEY=flightaware-api-key
 GOOGLE_DISTANCE_MATRIX_API_KEY=google-mapa-api-key
 SENDER_NAME=Yomide
+AWS_REGION=us-east-1
+AWS_ACCESS_KEY_ID=test-access-key-id
+AWS_SECRET_ACCESS_KEY=test-secret-access-key
+AWS_BUCKET_NAME=test-car-uploads-bucket

--- a/.env.e2e
+++ b/.env.e2e
@@ -27,10 +27,10 @@ AUTH_BASE_URL=http://localhost:3001
 TRUSTED_ORIGINS=http://localhost:3001,http://localhost:3000
 HMAC_KEY=flutterwave-webhook-comparison-e2e
 
+AWS_ACCESS_KEY_ID=test-access-key-id
+AWS_BUCKET_NAME=test-car-uploads-bucket
+AWS_REGION=us-east-1
+AWS_SECRET_ACCESS_KEY=test-secret-access-key
 FLIGHTAWARE_API_KEY=flightaware-api-key
 GOOGLE_DISTANCE_MATRIX_API_KEY=google-mapa-api-key
 SENDER_NAME=Yomide
-AWS_REGION=us-east-1
-AWS_ACCESS_KEY_ID=test-access-key-id
-AWS_SECRET_ACCESS_KEY=test-secret-access-key
-AWS_BUCKET_NAME=test-car-uploads-bucket

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.994.0",
     "@bull-board/api": "^6.14.0",
     "@bull-board/express": "^6.14.0",
     "@bull-board/nestjs": "^6.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.994.0
+        version: 3.994.0
       '@bull-board/api':
         specifier: ^6.14.0
         version: 6.14.0(@bull-board/ui@6.14.0)
@@ -231,6 +234,173 @@ packages:
   '@angular-devkit/schematics@17.3.11':
     resolution: {integrity: sha512-I5wviiIqiFwar9Pdk30Lujk8FczEEc18i22A5c6Z9lbmhPQdTroDnEQdsfXjy404wPe8H62s0I15o4pmMGfTYQ==}
     engines: {node: ^18.13.0 || >=20.9.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/crc32c@5.2.0':
+    resolution: {integrity: sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==}
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-s3@3.994.0':
+    resolution: {integrity: sha512-zIVQt/XfE2zTFrcPEf8R+KRaRD1++XHMPRhxXM2kVA6NA6Aq/cFCUyYOYYwSbWLF/XeToaX1auYGn3IoZKruPQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-sso@3.993.0':
+    resolution: {integrity: sha512-VLUN+wIeNX24fg12SCbzTUBnBENlL014yMKZvRhPkcn4wHR6LKgNrjsG3fZ03Xs0XoKaGtNFi1VVrq666sGBoQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.973.11':
+    resolution: {integrity: sha512-wdQ8vrvHkKIV7yNUKXyjPWKCdYEUrZTHJ8Ojd5uJxXp9vqPCkUR1dpi1NtOLcrDgueJH7MUH5lQZxshjFPSbDA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/crc64-nvme@3.972.0':
+    resolution: {integrity: sha512-ThlLhTqX68jvoIVv+pryOdb5coP1cX1/MaTbB9xkGDCbWbsqQcLqzPxuSoW1DCnAAIacmXCWpzUNOB9pv+xXQw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.9':
+    resolution: {integrity: sha512-ZptrOwQynfupubvcngLkbdIq/aXvl/czdpEG8XJ8mN8Nb19BR0jaK0bR+tfuMU36Ez9q4xv7GGkHFqEEP2hUUQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.11':
+    resolution: {integrity: sha512-hECWoOoH386bGr89NQc9vA/abkGf5TJrMREt+lhNcnSNmoBS04fK7vc3LrJBSQAUGGVj0Tz3f4dHB3w5veovig==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.9':
+    resolution: {integrity: sha512-zr1csEu9n4eDiHMTYJabX1mDGuGLgjgUnNckIivvk43DocJC9/f6DefFrnUPZXE+GHtbW50YuXb+JIxKykU74A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.9':
+    resolution: {integrity: sha512-m4RIpVgZChv0vWS/HKChg1xLgZPpx8Z+ly9Fv7FwA8SOfuC6I3htcSaBz2Ch4bneRIiBUhwP4ziUo0UZgtJStQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.10':
+    resolution: {integrity: sha512-70nCESlvnzjo4LjJ8By8MYIiBogkYPSXl3WmMZfH9RZcB/Nt9qVWbFpYj6Fk1vLa4Vk8qagFVeXgxdieMxG1QA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.9':
+    resolution: {integrity: sha512-gOWl0Fe2gETj5Bk151+LYKpeGi2lBDLNu+NMNpHRlIrKHdBmVun8/AalwMK8ci4uRfG5a3/+zvZBMpuen1SZ0A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.9':
+    resolution: {integrity: sha512-ey7S686foGTArvFhi3ifQXmgptKYvLSGE2250BAQceMSXZddz7sUSNERGJT2S7u5KIe/kgugxrt01hntXVln6w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.9':
+    resolution: {integrity: sha512-8LnfS76nHXoEc9aRRiMMpxZxJeDG0yusdyo3NvPhCgESmBUgpMa4luhGbClW5NoX/qRcGxxM6Z/esqANSNMTow==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.3':
+    resolution: {integrity: sha512-fmbgWYirF67YF1GfD7cg5N6HHQ96EyRNx/rDIrTF277/zTWVuPI2qS/ZHgofwR1NZPe/NWvoppflQY01LrbVLg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-expect-continue@3.972.3':
+    resolution: {integrity: sha512-4msC33RZsXQpUKR5QR4HnvBSNCPLGHmB55oDiROqqgyOc+TOfVu2xgi5goA7ms6MdZLeEh2905UfWMnMMF4mRg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-flexible-checksums@3.972.9':
+    resolution: {integrity: sha512-E663+r/UQpvF3aJkD40p5ZANVQFsUcbE39jifMtN7wc0t1M0+2gJJp3i75R49aY9OiSX5lfVyPUNjN/BNRCCZA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-host-header@3.972.3':
+    resolution: {integrity: sha512-aknPTb2M+G3s+0qLCx4Li/qGZH8IIYjugHMv15JTYMe6mgZO8VBpYgeGYsNMGCqCZOcWzuf900jFBG5bopfzmA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-location-constraint@3.972.3':
+    resolution: {integrity: sha512-nIg64CVrsXp67vbK0U1/Is8rik3huS3QkRHn2DRDx4NldrEFMgdkZGI/+cZMKD9k4YOS110Dfu21KZLHrFA/1g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-logger@3.972.3':
+    resolution: {integrity: sha512-Ftg09xNNRqaz9QNzlfdQWfpqMCJbsQdnZVJP55jfhbKi1+FTWxGuvfPoBhDHIovqWKjqbuiew3HuhxbJ0+OjgA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.972.3':
+    resolution: {integrity: sha512-PY57QhzNuXHnwbJgbWYTrqIDHYSeOlhfYERTAuc16LKZpTZRJUjzBFokp9hF7u1fuGeE3D70ERXzdbMBOqQz7Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.11':
+    resolution: {integrity: sha512-Qr0T7ZQTRMOuR6ahxEoJR1thPVovfWrKB2a6KBGR+a8/ELrFodrgHwhq50n+5VMaGuLtGhHiISU3XGsZmtmVXQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-ssec@3.972.3':
+    resolution: {integrity: sha512-dU6kDuULN3o3jEHcjm0c4zWJlY1zWVkjG9NPe9qxYLLpcbdj5kRYBS2DdWYD+1B9f910DezRuws7xDEqKkHQIg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-user-agent@3.972.11':
+    resolution: {integrity: sha512-R8CvPsPHXwzIHCAza+bllY6PrctEk4lYq/SkHJz9NLoBHCcKQrbOcsfXxO6xmipSbUNIbNIUhH0lBsJGgsRdiw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.993.0':
+    resolution: {integrity: sha512-iOq86f2H67924kQUIPOAvlmMaOAvOLoDOIb66I2YqSUpMYB6ufiuJW3RlREgskxv86S5qKzMnfy/X6CqMjK6XQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/region-config-resolver@3.972.3':
+    resolution: {integrity: sha512-v4J8qYAWfOMcZ4MJUyatntOicTzEMaU7j3OpkRCGGFSL2NgXQ5VbxauIyORA+pxdKZ0qQG2tCQjQjZDlXEC3Ow==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.994.0':
+    resolution: {integrity: sha512-8y04Lv497KKd7f2TVlm2RaKQaNfnY17ZH8d3m+7sW/3R3BhZvHgWQZyqTb/vcN2ERz1YAnWx6woJyB3ZNFvakw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.993.0':
+    resolution: {integrity: sha512-+35g4c+8r7sB9Sjp1KPdM8qxGn6B/shBjJtEUN4e+Edw9UEQlZKIzioOGu3UAbyE0a/s450LdLZr4wbJChtmww==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.1':
+    resolution: {integrity: sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-arn-parser@3.972.2':
+    resolution: {integrity: sha512-VkykWbqMjlSgBFDyrY3nOSqupMc6ivXuGmvci6Q3NnLq5kC+mKQe2QBZ4nrWRE/jqOxeFP2uYzLtwncYYcvQDg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.993.0':
+    resolution: {integrity: sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.994.0':
+    resolution: {integrity: sha512-L2obUBw4ACMMd1F/SG5LdfPyZ0xJNs9Maifwr3w0uWO+4YvHmk9FfRskfSfE/SLZ9S387oSZ+1xiP7BfVCP/Og==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.4':
+    resolution: {integrity: sha512-H1onv5SkgPBK2P6JR2MjGgbOnttoNzSPIRoeZTNPZYyaplwGg50zS3amXvXqF0/qfXpWEC9rLWU564QTB9bSog==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-user-agent-browser@3.972.3':
+    resolution: {integrity: sha512-JurOwkRUcXD/5MTDBcqdyQ9eVedtAsZgw5rBwktsPTN7QtPiS2Ld1jkJepNgYoCufz1Wcut9iup7GJDoIHp8Fw==}
+
+  '@aws-sdk/util-user-agent-node@3.972.9':
+    resolution: {integrity: sha512-JNswdsLdQemxqaSIBL2HRhsHPUBBziAgoi5RQv6/9avmE5g5RSdt1hWr3mHJ7OxqRYf+KeB11ExWbiqfrnoeaA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
+  '@aws-sdk/xml-builder@3.972.5':
+    resolution: {integrity: sha512-mCae5Ys6Qm1LDu0qdGwx2UQ63ONUe+FHw908fJzLDqFKTDBK4LDZUqKWm4OkTCNFq19bftjsBSESIGLD/s3/rA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.3':
+    resolution: {integrity: sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -1837,6 +2007,222 @@ packages:
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
 
+  '@smithy/abort-controller@4.2.8':
+    resolution: {integrity: sha512-peuVfkYHAmS5ybKxWcfraK7WBBP0J+rkfUcbHJJKQ4ir3UAUNQI+Y4Vt/PqSzGqgloJ5O1dk7+WzNL8wcCSXbw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/chunked-blob-reader-native@4.2.1':
+    resolution: {integrity: sha512-lX9Ay+6LisTfpLid2zZtIhSEjHMZoAR5hHCR4H7tBz/Zkfr5ea8RcQ7Tk4mi0P76p4cN+Btz16Ffno7YHpKXnQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/chunked-blob-reader@5.2.0':
+    resolution: {integrity: sha512-WmU0TnhEAJLWvfSeMxBNe5xtbselEO8+4wG0NtZeL8oR21WgH1xiO37El+/Y+H/Ie4SCwBy3MxYWmOYaGgZueA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/config-resolver@4.4.6':
+    resolution: {integrity: sha512-qJpzYC64kaj3S0fueiu3kXm8xPrR3PcXDPEgnaNMRn0EjNSZFoFjvbUp0YUDsRhN1CB90EnHJtbxWKevnH99UQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/core@3.23.2':
+    resolution: {integrity: sha512-HaaH4VbGie4t0+9nY3tNBRSxVTr96wzIqexUa6C2qx3MPePAuz7lIxPxYtt1Wc//SPfJLNoZJzfdt0B6ksj2jA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.2.8':
+    resolution: {integrity: sha512-FNT0xHS1c/CPN8upqbMFP83+ul5YgdisfCfkZ86Jh2NSmnqw/AJ6x5pEogVCTVvSm7j9MopRU89bmDelxuDMYw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-codec@4.2.8':
+    resolution: {integrity: sha512-jS/O5Q14UsufqoGhov7dHLOPCzkYJl9QDzusI2Psh4wyYx/izhzvX9P4D69aTxcdfVhEPhjK+wYyn/PzLjKbbw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-browser@4.2.8':
+    resolution: {integrity: sha512-MTfQT/CRQz5g24ayXdjg53V0mhucZth4PESoA5IhvaWVDTOQLfo8qI9vzqHcPsdd2v6sqfTYqF5L/l+pea5Uyw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-config-resolver@4.3.8':
+    resolution: {integrity: sha512-ah12+luBiDGzBruhu3efNy1IlbwSEdNiw8fOZksoKoWW1ZHvO/04MQsdnws/9Aj+5b0YXSSN2JXKy/ClIsW8MQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-node@4.2.8':
+    resolution: {integrity: sha512-cYpCpp29z6EJHa5T9WL0KAlq3SOKUQkcgSoeRfRVwjGgSFl7Uh32eYGt7IDYCX20skiEdRffyDpvF2efEZPC0A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-universal@4.2.8':
+    resolution: {integrity: sha512-iJ6YNJd0bntJYnX6s52NC4WFYcZeKrPUr1Kmmr5AwZcwCSzVpS7oavAmxMR7pMq7V+D1G4s9F5NJK0xwOsKAlQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.3.9':
+    resolution: {integrity: sha512-I4UhmcTYXBrct03rwzQX1Y/iqQlzVQaPxWjCjula++5EmWq9YGBrx6bbGqluGc1f0XEfhSkiY4jhLgbsJUMKRA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-blob-browser@4.2.9':
+    resolution: {integrity: sha512-m80d/iicI7DlBDxyQP6Th7BW/ejDGiF0bgI754+tiwK0lgMkcaIBgvwwVc7OFbY4eUzpGtnig52MhPAEJ7iNYg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-node@4.2.8':
+    resolution: {integrity: sha512-7ZIlPbmaDGxVoxErDZnuFG18WekhbA/g2/i97wGj+wUBeS6pcUeAym8u4BXh/75RXWhgIJhyC11hBzig6MljwA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-stream-node@4.2.8':
+    resolution: {integrity: sha512-v0FLTXgHrTeheYZFGhR+ehX5qUm4IQsjAiL9qehad2cyjMWcN2QG6/4mSwbSgEQzI7jwfoXj7z4fxZUx/Mhj2w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/invalid-dependency@4.2.8':
+    resolution: {integrity: sha512-N9iozRybwAQ2dn9Fot9kI6/w9vos2oTXLhtK7ovGqwZjlOcxu6XhPlpLpC+INsxktqHinn5gS2DXDjDF2kG5sQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/is-array-buffer@4.2.0':
+    resolution: {integrity: sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/md5-js@4.2.8':
+    resolution: {integrity: sha512-oGMaLj4tVZzLi3itBa9TCswgMBr7k9b+qKYowQ6x1rTyTuO1IU2YHdHUa+891OsOH+wCsH7aTPRsTJO3RMQmjQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-content-length@4.2.8':
+    resolution: {integrity: sha512-RO0jeoaYAB1qBRhfVyq0pMgBoUK34YEJxVxyjOWYZiOKOq2yMZ4MnVXMZCUDenpozHue207+9P5ilTV1zeda0A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-endpoint@4.4.16':
+    resolution: {integrity: sha512-L5GICFCSsNhbJ5JSKeWFGFy16Q2OhoBizb3X2DrxaJwXSEujVvjG9Jt386dpQn2t7jINglQl0b4K/Su69BdbMA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-retry@4.4.33':
+    resolution: {integrity: sha512-jLqZOdJhtIL4lnA9hXnAG6GgnJlo1sD3FqsTxm9wSfjviqgWesY/TMBVnT84yr4O0Vfe0jWoXlfFbzsBVph3WA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-serde@4.2.9':
+    resolution: {integrity: sha512-eMNiej0u/snzDvlqRGSN3Vl0ESn3838+nKyVfF2FKNXFbi4SERYT6PR392D39iczngbqqGG0Jl1DlCnp7tBbXQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-stack@4.2.8':
+    resolution: {integrity: sha512-w6LCfOviTYQjBctOKSwy6A8FIkQy7ICvglrZFl6Bw4FmcQ1Z420fUtIhxaUZZshRe0VCq4kvDiPiXrPZAe8oRA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-config-provider@4.3.8':
+    resolution: {integrity: sha512-aFP1ai4lrbVlWjfpAfRSL8KFcnJQYfTl5QxLJXY32vghJrDuFyPZ6LtUL+JEGYiFRG1PfPLHLoxj107ulncLIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.4.10':
+    resolution: {integrity: sha512-u4YeUwOWRZaHbWaebvrs3UhwQwj+2VNmcVCwXcYTvPIuVyM7Ex1ftAj+fdbG/P4AkBwLq/+SKn+ydOI4ZJE9PA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/property-provider@4.2.8':
+    resolution: {integrity: sha512-EtCTbyIveCKeOXDSWSdze3k612yCPq1YbXsbqX3UHhkOSW8zKsM9NOJG5gTIya0vbY2DIaieG8pKo1rITHYL0w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/protocol-http@5.3.8':
+    resolution: {integrity: sha512-QNINVDhxpZ5QnP3aviNHQFlRogQZDfYlCkQT+7tJnErPQbDhysondEjhikuANxgMsZrkGeiAxXy4jguEGsDrWQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-builder@4.2.8':
+    resolution: {integrity: sha512-Xr83r31+DrE8CP3MqPgMJl+pQlLLmOfiEUnoyAlGzzJIrEsbKsPy1hqH0qySaQm4oWrCBlUqRt+idEgunKB+iw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-parser@4.2.8':
+    resolution: {integrity: sha512-vUurovluVy50CUlazOiXkPq40KGvGWSdmusa3130MwrR1UNnNgKAlj58wlOe61XSHRpUfIIh6cE0zZ8mzKaDPA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/service-error-classification@4.2.8':
+    resolution: {integrity: sha512-mZ5xddodpJhEt3RkCjbmUQuXUOaPNTkbMGR0bcS8FE0bJDLMZlhmpgrvPNCYglVw5rsYTpSnv19womw9WWXKQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/shared-ini-file-loader@4.4.3':
+    resolution: {integrity: sha512-DfQjxXQnzC5UbCUPeC3Ie8u+rIWZTvuDPAGU/BxzrOGhRvgUanaP68kDZA+jaT3ZI+djOf+4dERGlm9mWfFDrg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.3.8':
+    resolution: {integrity: sha512-6A4vdGj7qKNRF16UIcO8HhHjKW27thsxYci+5r/uVRkdcBEkOEiY8OMPuydLX4QHSrJqGHPJzPRwwVTqbLZJhg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/smithy-client@4.11.5':
+    resolution: {integrity: sha512-xixwBRqoeP2IUgcAl3U9dvJXc+qJum4lzo3maaJxifsZxKUYLfVfCXvhT4/jD01sRrHg5zjd1cw2Zmjr4/SuKQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.12.0':
+    resolution: {integrity: sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/url-parser@4.2.8':
+    resolution: {integrity: sha512-NQho9U68TGMEU639YkXnVMV3GEFFULmmaWdlu1E9qzyIePOHsoSnagTGSDv1Zi8DCNN6btxOSdgmy5E/hsZwhA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-base64@4.3.0':
+    resolution: {integrity: sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-browser@4.2.0':
+    resolution: {integrity: sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-node@4.2.1':
+    resolution: {integrity: sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-buffer-from@4.2.0':
+    resolution: {integrity: sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-config-provider@4.2.0':
+    resolution: {integrity: sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-browser@4.3.32':
+    resolution: {integrity: sha512-092sjYfFMQ/iaPH798LY/OJFBcYu0sSK34Oy9vdixhsU36zlZu8OcYjF3TD4e2ARupyK7xaxPXl+T0VIJTEkkg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-node@4.2.35':
+    resolution: {integrity: sha512-miz/ggz87M8VuM29y7jJZMYkn7+IErM5p5UgKIf8OtqVs/h2bXr1Bt3uTsREsI/4nK8a0PQERbAPsVPVNIsG7Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-endpoints@3.2.8':
+    resolution: {integrity: sha512-8JaVTn3pBDkhZgHQ8R0epwWt+BqPSLCjdjXXusK1onwJlRuN69fbvSK66aIKKO7SwVFM6x2J2ox5X8pOaWcUEw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-hex-encoding@4.2.0':
+    resolution: {integrity: sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-middleware@4.2.8':
+    resolution: {integrity: sha512-PMqfeJxLcNPMDgvPbbLl/2Vpin+luxqTGPpW3NAQVLbRrFRzTa4rNAASYeIGjRV9Ytuhzny39SpyU04EQreF+A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-retry@4.2.8':
+    resolution: {integrity: sha512-CfJqwvoRY0kTGe5AkQokpURNCT1u/MkRzMTASWMPPo2hNSnKtF1D45dQl3DE2LKLr4m+PW9mCeBMJr5mCAVThg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-stream@4.5.12':
+    resolution: {integrity: sha512-D8tgkrmhAX/UNeCZbqbEO3uqyghUnEmmoO9YEvRuwxjlkKKUE7FOgCJnqpTlQPe9MApdWPky58mNQQHbnCzoNg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-uri-escape@4.2.0':
+    resolution: {integrity: sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@4.2.0':
+    resolution: {integrity: sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-waiter@4.2.8':
+    resolution: {integrity: sha512-n+lahlMWk+aejGuax7DPWtqav8HYnWxQwR+LCG2BgCUmaGcTe9qZCFsmw8TMg9iG75HOwhrJCX9TCJRLH+Yzqg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/uuid@1.1.0':
+    resolution: {integrity: sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==}
+    engines: {node: '>=18.0.0'}
+
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
@@ -2424,6 +2810,9 @@ packages:
   body-parser@2.2.0:
     resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
     engines: {node: '>=18'}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   boxen@5.1.2:
     resolution: {integrity: sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==}
@@ -3034,6 +3423,10 @@ packages:
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-xml-parser@5.3.6:
+    resolution: {integrity: sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==}
+    hasBin: true
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -4323,6 +4716,9 @@ packages:
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
+  strnum@2.1.2:
+    resolution: {integrity: sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==}
+
   strtok3@10.3.4:
     resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
     engines: {node: '>=18'}
@@ -4809,6 +5205,499 @@ snapshots:
       rxjs: 7.8.1
     transitivePeerDependencies:
       - chokidar
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.1
+      tslib: 2.8.1
+
+  '@aws-crypto/crc32c@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.1
+      tslib: 2.8.1
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-locate-window': 3.965.4
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-locate-window': 3.965.4
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.1
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.994.0':
+    dependencies:
+      '@aws-crypto/sha1-browser': 5.2.0
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/credential-provider-node': 3.972.10
+      '@aws-sdk/middleware-bucket-endpoint': 3.972.3
+      '@aws-sdk/middleware-expect-continue': 3.972.3
+      '@aws-sdk/middleware-flexible-checksums': 3.972.9
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-location-constraint': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-sdk-s3': 3.972.11
+      '@aws-sdk/middleware-ssec': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.11
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/signature-v4-multi-region': 3.994.0
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.994.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.9
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.23.2
+      '@smithy/eventstream-serde-browser': 4.2.8
+      '@smithy/eventstream-serde-config-resolver': 4.3.8
+      '@smithy/eventstream-serde-node': 4.2.8
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-blob-browser': 4.2.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/hash-stream-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/md5-js': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.16
+      '@smithy/middleware-retry': 4.4.33
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.32
+      '@smithy/util-defaults-mode-node': 4.2.35
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-stream': 4.5.12
+      '@smithy/util-utf8': 4.2.0
+      '@smithy/util-waiter': 4.2.8
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/client-sso@3.993.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.11
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.993.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.9
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.23.2
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.16
+      '@smithy/middleware-retry': 4.4.33
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.32
+      '@smithy/util-defaults-mode-node': 4.2.35
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/core@3.973.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/xml-builder': 3.972.5
+      '@smithy/core': 3.23.2
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/signature-v4': 5.3.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@aws-sdk/crc64-nvme@3.972.0':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.9':
+    dependencies:
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.11':
+    dependencies:
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/types': 3.973.1
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/property-provider': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      '@smithy/util-stream': 4.5.12
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.9':
+    dependencies:
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/credential-provider-env': 3.972.9
+      '@aws-sdk/credential-provider-http': 3.972.11
+      '@aws-sdk/credential-provider-login': 3.972.9
+      '@aws-sdk/credential-provider-process': 3.972.9
+      '@aws-sdk/credential-provider-sso': 3.972.9
+      '@aws-sdk/credential-provider-web-identity': 3.972.9
+      '@aws-sdk/nested-clients': 3.993.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/credential-provider-imds': 4.2.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.9':
+    dependencies:
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/nested-clients': 3.993.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-node@3.972.10':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.9
+      '@aws-sdk/credential-provider-http': 3.972.11
+      '@aws-sdk/credential-provider-ini': 3.972.9
+      '@aws-sdk/credential-provider-process': 3.972.9
+      '@aws-sdk/credential-provider-sso': 3.972.9
+      '@aws-sdk/credential-provider-web-identity': 3.972.9
+      '@aws-sdk/types': 3.973.1
+      '@smithy/credential-provider-imds': 4.2.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-process@3.972.9':
+    dependencies:
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.9':
+    dependencies:
+      '@aws-sdk/client-sso': 3.993.0
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/token-providers': 3.993.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.9':
+    dependencies:
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/nested-clients': 3.993.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-arn-parser': 3.972.2
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-config-provider': 4.2.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-expect-continue@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-flexible-checksums@3.972.9':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@aws-crypto/crc32c': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/crc64-nvme': 3.972.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/is-array-buffer': 4.2.0
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-stream': 4.5.12
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-host-header@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-location-constraint@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-logger@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-recursion-detection@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@aws/lambda-invoke-store': 0.2.3
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.11':
+    dependencies:
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-arn-parser': 3.972.2
+      '@smithy/core': 3.23.2
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/signature-v4': 5.3.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      '@smithy/util-config-provider': 4.2.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-stream': 4.5.12
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-ssec@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-user-agent@3.972.11':
+    dependencies:
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.993.0
+      '@smithy/core': 3.23.2
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.993.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.11
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.993.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.9
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.23.2
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.16
+      '@smithy/middleware-retry': 4.4.33
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.32
+      '@smithy/util-defaults-mode-node': 4.2.35
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/region-config-resolver@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.994.0':
+    dependencies:
+      '@aws-sdk/middleware-sdk-s3': 3.972.11
+      '@aws-sdk/types': 3.973.1
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/signature-v4': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.993.0':
+    dependencies:
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/nested-clients': 3.993.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/types@3.973.1':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/util-arn-parser@3.972.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.993.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-endpoints': 3.2.8
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.994.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-endpoints': 3.2.8
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.4':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-browser@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-node@3.972.9':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.972.11
+      '@aws-sdk/types': 3.973.1
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.5':
+    dependencies:
+      '@smithy/types': 4.12.0
+      fast-xml-parser: 5.3.6
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.3': {}
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -6519,6 +7408,344 @@ snapshots:
       domhandler: 5.0.3
       selderee: 0.11.0
 
+  '@smithy/abort-controller@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/chunked-blob-reader-native@4.2.1':
+    dependencies:
+      '@smithy/util-base64': 4.3.0
+      tslib: 2.8.1
+
+  '@smithy/chunked-blob-reader@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/config-resolver@4.4.6':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-config-provider': 4.2.0
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      tslib: 2.8.1
+
+  '@smithy/core@3.23.2':
+    dependencies:
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-stream': 4.5.12
+      '@smithy/util-utf8': 4.2.0
+      '@smithy/uuid': 1.1.0
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.2.8':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      tslib: 2.8.1
+
+  '@smithy/eventstream-codec@4.2.8':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.12.0
+      '@smithy/util-hex-encoding': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-browser@4.2.8':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-config-resolver@4.3.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-node@4.2.8':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-universal@4.2.8':
+    dependencies:
+      '@smithy/eventstream-codec': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.3.9':
+    dependencies:
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/querystring-builder': 4.2.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      tslib: 2.8.1
+
+  '@smithy/hash-blob-browser@4.2.9':
+    dependencies:
+      '@smithy/chunked-blob-reader': 5.2.0
+      '@smithy/chunked-blob-reader-native': 4.2.1
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/hash-node@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/hash-stream-node@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/invalid-dependency@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/md5-js@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-content-length@4.2.8':
+    dependencies:
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-endpoint@4.4.16':
+    dependencies:
+      '@smithy/core': 3.23.2
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-middleware': 4.2.8
+      tslib: 2.8.1
+
+  '@smithy/middleware-retry@4.4.33':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/service-error-classification': 4.2.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/uuid': 1.1.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-serde@4.2.9':
+    dependencies:
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-stack@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/node-config-provider@4.3.8':
+    dependencies:
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.4.10':
+    dependencies:
+      '@smithy/abort-controller': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/querystring-builder': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/property-provider@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/protocol-http@5.3.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/querystring-builder@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      '@smithy/util-uri-escape': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/querystring-parser@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/service-error-classification@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+
+  '@smithy/shared-ini-file-loader@4.4.3':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.3.8':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.0
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-hex-encoding': 4.2.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-uri-escape': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/smithy-client@4.11.5':
+    dependencies:
+      '@smithy/core': 3.23.2
+      '@smithy/middleware-endpoint': 4.4.16
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-stream': 4.5.12
+      tslib: 2.8.1
+
+  '@smithy/types@4.12.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/url-parser@4.2.8':
+    dependencies:
+      '@smithy/querystring-parser': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-base64@4.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-browser@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-node@4.2.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@4.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-config-provider@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-browser@4.3.32':
+    dependencies:
+      '@smithy/property-provider': 4.2.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-node@4.2.35':
+    dependencies:
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/credential-provider-imds': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-endpoints@3.2.8':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-hex-encoding@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-middleware@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-retry@4.2.8':
+    dependencies:
+      '@smithy/service-error-classification': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-stream@4.5.12':
+    dependencies:
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/util-hex-encoding': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-uri-escape@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@4.2.0':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-waiter@4.2.8':
+    dependencies:
+      '@smithy/abort-controller': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/uuid@1.1.0':
+    dependencies:
+      tslib: 2.8.1
+
   '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.0.0': {}
@@ -7164,6 +8391,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  bowser@2.14.1: {}
+
   boxen@5.1.2:
     dependencies:
       ansi-align: 3.0.1
@@ -7797,6 +9026,10 @@ snapshots:
   fast-sha256@1.3.0: {}
 
   fast-uri@3.1.0: {}
+
+  fast-xml-parser@5.3.6:
+    dependencies:
+      strnum: 2.1.2
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -9182,6 +10415,8 @@ snapshots:
   strip-literal@3.1.0:
     dependencies:
       js-tokens: 9.0.1
+
+  strnum@2.1.2: {}
 
   strtok3@10.3.4:
     dependencies:

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,6 +11,7 @@ import { EnvConfig, validateEnvironment } from "./config/env.config";
 import { parseOtlpHeaders } from "./config/tracing.config";
 import { AccountModule } from "./modules/account/account.module";
 import { AuthModule } from "./modules/auth/auth.module";
+import { CarModule } from "./modules/car/car.module";
 import { DatabaseModule } from "./modules/database/database.module";
 import { DocumentsModule } from "./modules/documents/documents.module";
 import { FlutterwaveModule } from "./modules/flutterwave/flutterwave.module";
@@ -161,6 +162,7 @@ import { StatusChangeModule } from "./modules/status-change/status-change.module
     ReferralModule,
     ReviewsModule,
     AuthModule,
+    CarModule,
   ],
 })
 export class AppModule implements NestModule {

--- a/src/config/env.config.ts
+++ b/src/config/env.config.ts
@@ -85,6 +85,12 @@ export const envSchema = z.object({
         .min(1, "At least one valid TRUSTED_ORIGIN is required"),
     ),
   SENDER_NAME: z.string().min(2, "SENDER_NAME is required"),
+
+  // S3 storage configuration (for car uploads)
+  AWS_REGION: z.string().min(1, "AWS_REGION is required for S3 uploads"),
+  AWS_ACCESS_KEY_ID: z.string().min(1, "AWS_ACCESS_KEY_ID is required for S3 uploads"),
+  AWS_SECRET_ACCESS_KEY: z.string().min(1, "AWS_SECRET_ACCESS_KEY is required for S3 uploads"),
+  AWS_BUCKET_NAME: z.string().min(1, "AWS_BUCKET_NAME is required for S3 uploads"),
 });
 
 export type EnvConfig = z.infer<typeof envSchema>;

--- a/src/modules/booking/booking-cancellation.service.spec.ts
+++ b/src/modules/booking/booking-cancellation.service.spec.ts
@@ -94,30 +94,6 @@ describe("BookingCancellationService", () => {
     );
   });
 
-  it("queues cancellation notification for unpaid booking", async () => {
-    txMock.booking.findUnique.mockResolvedValueOnce({
-      id: "booking-2",
-      userId: "user-1",
-      status: BookingStatus.PENDING,
-      paymentStatus: PaymentStatus.UNPAID,
-      carId: "car-1",
-    });
-    txMock.booking.update.mockResolvedValueOnce({
-      id: "booking-2",
-      status: BookingStatus.CANCELLED,
-      car: { owner: {} },
-      user: {},
-      legs: [],
-    });
-    txMock.car.update.mockResolvedValueOnce({ id: "car-1", status: "AVAILABLE" });
-
-    await service.cancelBooking("booking-2", "user-1", "User requested cancellation");
-
-    expect(notificationServiceMock.queueBookingCancellationNotifications).toHaveBeenCalledWith(
-      expect.objectContaining({ id: "booking-2", status: BookingStatus.CANCELLED }),
-    );
-  });
-
   it("throws BookingNotFoundException when booking is missing or not owned by user", async () => {
     txMock.booking.findUnique.mockResolvedValueOnce(null);
 

--- a/src/modules/booking/booking-cancellation.service.ts
+++ b/src/modules/booking/booking-cancellation.service.ts
@@ -37,11 +37,11 @@ export class BookingCancellationService {
           throw new BookingNotFoundException();
         }
 
-        const isCancellableStatus =
-          existingBooking.status === BookingStatus.CONFIRMED ||
-          existingBooking.status === BookingStatus.PENDING;
+        const canCancelBooking =
+          existingBooking.status === BookingStatus.CONFIRMED &&
+          existingBooking.paymentStatus === PaymentStatus.PAID;
 
-        if (!isCancellableStatus) {
+        if (!canCancelBooking) {
           throw new BookingNotCancellableException();
         }
 

--- a/src/modules/booking/booking-cancellation.service.ts
+++ b/src/modules/booking/booking-cancellation.service.ts
@@ -49,16 +49,11 @@ export class BookingCancellationService {
           where: { id: bookingId },
           data: {
             status: BookingStatus.CANCELLED,
-            paymentStatus:
-              existingBooking.paymentStatus === PaymentStatus.PAID
-                ? PaymentStatus.REFUND_PROCESSING
-                : existingBooking.paymentStatus,
+            paymentStatus: PaymentStatus.REFUND_PROCESSING,
             cancelledAt: new Date(),
             cancellationReason: reason,
             referralCreditsReserved: 0,
-            ...(existingBooking.paymentStatus === PaymentStatus.PAID
-              ? { referralCreditsUsed: 0 }
-              : {}),
+            referralCreditsUsed: 0,
           },
           include: {
             user: true,

--- a/src/modules/booking/booking.controller.ts
+++ b/src/modules/booking/booking.controller.ts
@@ -1,6 +1,5 @@
 import {
   Controller,
-  Delete,
   Get,
   HttpCode,
   HttpStatus,
@@ -108,7 +107,7 @@ export class BookingController {
     return this.bookingUpdateService.updateBooking(bookingId, sessionUser.id, body);
   }
 
-  @Delete(":bookingId")
+  @Patch(":bookingId/cancel")
   @UseGuards(SessionGuard)
   async cancelBooking(
     @ZodParam("bookingId", bookingIdParamSchema) bookingId: string,

--- a/src/modules/car/car-create-files.pipe.ts
+++ b/src/modules/car/car-create-files.pipe.ts
@@ -1,0 +1,63 @@
+import { Injectable, PipeTransform } from "@nestjs/common";
+import {
+  IMAGE_MIME_TYPES_SET,
+  MAX_FILE_SIZE_BYTES,
+  MAX_IMAGE_COUNT,
+  PDF_MIME_TYPE,
+} from "./car.const";
+import { CarValidationException } from "./car.error";
+import type { CarCreateFiles, CarUploadFields } from "./car.interface";
+
+@Injectable()
+export class CarCreateFilesPipe implements PipeTransform<CarUploadFields, CarCreateFiles> {
+  transform(files: CarUploadFields): CarCreateFiles {
+    const images = files.images ?? [];
+    const motCertificate = files.motCertificate?.[0];
+    const insuranceCertificate = files.insuranceCertificate?.[0];
+
+    if (images.length === 0) {
+      throw new CarValidationException("At least one image is required");
+    }
+
+    if (images.length > MAX_IMAGE_COUNT) {
+      throw new CarValidationException(`You can upload up to ${MAX_IMAGE_COUNT} images`);
+    }
+
+    if (!motCertificate) {
+      throw new CarValidationException("MOT certificate is required");
+    }
+
+    if (!insuranceCertificate) {
+      throw new CarValidationException("Insurance certificate is required");
+    }
+
+    for (const image of images) {
+      if (!IMAGE_MIME_TYPES_SET.has(image.mimetype)) {
+        throw new CarValidationException("Images must be JPEG, PNG or WebP");
+      }
+
+      if (image.size > MAX_FILE_SIZE_BYTES) {
+        throw new CarValidationException("Each image must be less than 5MB");
+      }
+    }
+
+    if (
+      motCertificate.mimetype !== PDF_MIME_TYPE ||
+      insuranceCertificate.mimetype !== PDF_MIME_TYPE
+    ) {
+      throw new CarValidationException("MOT and insurance certificates must be PDF files");
+    }
+    if (
+      motCertificate.size > MAX_FILE_SIZE_BYTES ||
+      insuranceCertificate.size > MAX_FILE_SIZE_BYTES
+    ) {
+      throw new CarValidationException("Certificate files must be less than 5MB");
+    }
+
+    return {
+      images,
+      motCertificate,
+      insuranceCertificate,
+    };
+  }
+}

--- a/src/modules/car/car.const.ts
+++ b/src/modules/car/car.const.ts
@@ -1,0 +1,15 @@
+export const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024;
+export const MAX_IMAGE_COUNT = 5;
+
+export const IMAGE_MIME_TYPES = ["image/jpeg", "image/png", "image/webp"] as const;
+export const IMAGE_MIME_TYPES_SET = new Set<string>(IMAGE_MIME_TYPES);
+export const PDF_MIME_TYPE = "application/pdf";
+
+export const CAR_UPLOAD_FIELD_CONFIG = [
+  { name: "images", maxCount: MAX_IMAGE_COUNT },
+  { name: "motCertificate", maxCount: 1 },
+  { name: "insuranceCertificate", maxCount: 1 },
+] as const;
+
+export const CAR_S3_CATEGORY_IMAGES = "images";
+export const CAR_S3_CATEGORY_DOCUMENTS = "documents";

--- a/src/modules/car/car.controller.spec.ts
+++ b/src/modules/car/car.controller.spec.ts
@@ -1,0 +1,132 @@
+import { Reflector } from "@nestjs/core";
+import { Test, type TestingModule } from "@nestjs/testing";
+import { ServiceTier, VehicleType } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthService } from "../auth/auth.service";
+import { CarController } from "./car.controller";
+import type { CarCreateFiles } from "./car.interface";
+import { CarService } from "./car.service";
+import type { CreateCarMultipartBodyDto } from "./dto/create-car.dto";
+
+describe("CarController", () => {
+  let controller: CarController;
+  let carService: CarService;
+
+  const mockUser = {
+    id: "owner-1",
+    name: "Fleet Owner",
+    emailVerified: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    roles: ["fleetOwner" as const],
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CarController],
+      providers: [
+        {
+          provide: CarService,
+          useValue: {
+            listOwnerCars: vi.fn(),
+            getOwnerCarById: vi.fn(),
+            createCar: vi.fn(),
+            updateCar: vi.fn(),
+          },
+        },
+        {
+          provide: AuthService,
+          useValue: {
+            isInitialized: true,
+            auth: {
+              api: {
+                getSession: vi.fn().mockResolvedValue(null),
+              },
+            },
+            getUserRoles: vi.fn().mockResolvedValue(["fleetOwner"]),
+          },
+        },
+        Reflector,
+      ],
+    }).compile();
+
+    controller = module.get<CarController>(CarController);
+    carService = module.get<CarService>(CarService);
+  });
+
+  it("lists owner cars", async () => {
+    vi.mocked(carService.listOwnerCars).mockResolvedValueOnce([{ id: "car-1" }] as never);
+
+    const result = await controller.listOwnerCars(mockUser);
+
+    expect(result).toEqual([{ id: "car-1" }]);
+    expect(carService.listOwnerCars).toHaveBeenCalledWith("owner-1");
+  });
+
+  it("returns owner car detail", async () => {
+    vi.mocked(carService.getOwnerCarById).mockResolvedValueOnce({ id: "car-1" } as never);
+
+    const result = await controller.getOwnerCarById("car-1", mockUser);
+
+    expect(result).toEqual({ id: "car-1" });
+    expect(carService.getOwnerCarById).toHaveBeenCalledWith("car-1", "owner-1");
+  });
+
+  it("creates a car for authenticated fleet owner", async () => {
+    const body: CreateCarMultipartBodyDto = {
+      make: "Toyota",
+      model: "Camry",
+      year: 2022,
+      color: "",
+      registrationNumber: "ABC-123XY",
+      dayRate: 50000,
+      hourlyRate: 5000,
+      nightRate: 60000,
+      fullDayRate: 100000,
+      airportPickupRate: 30000,
+      pricingIncludesFuel: false,
+      fuelUpgradeRate: 10000,
+      vehicleType: VehicleType.SEDAN,
+      serviceTier: ServiceTier.STANDARD,
+      passengerCapacity: 4,
+    };
+    const files: CarCreateFiles = {
+      images: [
+        {
+          originalname: "car-1.jpg",
+          mimetype: "image/jpeg",
+          buffer: Buffer.from("image"),
+          size: 5,
+        },
+      ],
+      motCertificate: {
+        originalname: "mot.pdf",
+        mimetype: "application/pdf",
+        buffer: Buffer.from("pdf"),
+        size: 3,
+      },
+      insuranceCertificate: {
+        originalname: "insurance.pdf",
+        mimetype: "application/pdf",
+        buffer: Buffer.from("pdf"),
+        size: 3,
+      },
+    };
+
+    vi.mocked(carService.createCar).mockResolvedValueOnce({ id: "car-1" } as never);
+
+    const result = await controller.createCar(body, files, mockUser);
+
+    expect(result).toEqual({ id: "car-1" });
+    expect(carService.createCar).toHaveBeenCalledWith("owner-1", body, files);
+  });
+
+  it("updates owner car", async () => {
+    vi.mocked(carService.updateCar).mockResolvedValueOnce({ id: "car-1", status: "HOLD" } as never);
+
+    const result = await controller.updateCar("car-1", { status: "HOLD" }, mockUser);
+
+    expect(result).toEqual({ id: "car-1", status: "HOLD" });
+    expect(carService.updateCar).toHaveBeenCalledWith("car-1", "owner-1", { status: "HOLD" });
+  });
+});

--- a/src/modules/car/car.controller.ts
+++ b/src/modules/car/car.controller.ts
@@ -1,0 +1,62 @@
+import {
+  Controller,
+  Get,
+  Patch,
+  Post,
+  UploadedFiles,
+  UseGuards,
+  UseInterceptors,
+} from "@nestjs/common";
+import { FileFieldsInterceptor } from "@nestjs/platform-express";
+import { ZodBody, ZodParam } from "../../common/decorators/zod-validation.decorator";
+import { FLEET_OWNER } from "../auth/auth.types";
+import { CurrentUser } from "../auth/decorators/current-user.decorator";
+import { Roles } from "../auth/decorators/roles.decorator";
+import { RoleGuard } from "../auth/guards/role.guard";
+import type { AuthSession } from "../auth/guards/session.guard";
+import { SessionGuard } from "../auth/guards/session.guard";
+import { CAR_UPLOAD_FIELD_CONFIG } from "./car.const";
+import type { CarCreateFiles } from "./car.interface";
+import { CarService } from "./car.service";
+import { CarCreateFilesPipe } from "./car-create-files.pipe";
+import { type CreateCarMultipartBodyDto, createCarMultipartBodySchema } from "./dto/create-car.dto";
+import { carIdParamSchema, type UpdateCarBodyDto, updateCarBodySchema } from "./dto/update-car.dto";
+
+@Controller("api/cars")
+@UseGuards(SessionGuard, RoleGuard)
+@Roles(FLEET_OWNER)
+export class CarController {
+  constructor(private readonly carService: CarService) {}
+
+  @Get()
+  async listOwnerCars(@CurrentUser() sessionUser: AuthSession["user"]) {
+    return this.carService.listOwnerCars(sessionUser.id);
+  }
+
+  @Get(":carId")
+  async getOwnerCarById(
+    @ZodParam("carId", carIdParamSchema) carId: string,
+    @CurrentUser() sessionUser: AuthSession["user"],
+  ) {
+    return this.carService.getOwnerCarById(carId, sessionUser.id);
+  }
+
+  @Post()
+  @UseInterceptors(FileFieldsInterceptor([...CAR_UPLOAD_FIELD_CONFIG]))
+  async createCar(
+    @ZodBody(createCarMultipartBodySchema) body: CreateCarMultipartBodyDto,
+    @UploadedFiles(new CarCreateFilesPipe()) files: CarCreateFiles,
+    @CurrentUser() sessionUser: AuthSession["user"],
+  ) {
+    return this.carService.createCar(sessionUser.id, body, files);
+  }
+
+  @Patch(":carId")
+  async updateCar(
+    @ZodParam("carId", carIdParamSchema) carId: string,
+    @ZodBody(updateCarBodySchema) body: UpdateCarBodyDto,
+    @CurrentUser() sessionUser: AuthSession["user"],
+  ) {
+    return this.carService.updateCar(carId, sessionUser.id, body);
+  }
+}

--- a/src/modules/car/car.error.ts
+++ b/src/modules/car/car.error.ts
@@ -1,0 +1,100 @@
+import { HttpStatus } from "@nestjs/common";
+import { AppException } from "../../common/errors/app.exception";
+
+export const CarErrorCode = {
+  VALIDATION_ERROR: "VALIDATION_ERROR",
+  FLEET_OWNER_NOT_FOUND: "FLEET_OWNER_NOT_FOUND",
+  CAR_NOT_FOUND: "CAR_NOT_FOUND",
+  CAR_FETCH_FAILED: "CAR_FETCH_FAILED",
+  CAR_CREATE_FAILED: "CAR_CREATE_FAILED",
+  CAR_UPDATE_FAILED: "CAR_UPDATE_FAILED",
+  OWNER_DRIVER_CAR_LIMIT_REACHED: "OWNER_DRIVER_CAR_LIMIT_REACHED",
+  REGISTRATION_NUMBER_ALREADY_EXISTS: "REGISTRATION_NUMBER_ALREADY_EXISTS",
+} as const;
+
+export class CarException extends AppException {}
+
+export class CarValidationException extends CarException {
+  constructor(detail: string) {
+    super(CarErrorCode.VALIDATION_ERROR, detail, HttpStatus.BAD_REQUEST, {
+      title: "Validation Failed",
+    });
+  }
+}
+
+export class FleetOwnerNotFoundException extends CarException {
+  constructor() {
+    super(
+      CarErrorCode.FLEET_OWNER_NOT_FOUND,
+      "Fleet owner account not found",
+      HttpStatus.INTERNAL_SERVER_ERROR,
+      { title: "Fleet Owner Not Found" },
+    );
+  }
+}
+
+export class CarNotFoundException extends CarException {
+  constructor() {
+    super(
+      CarErrorCode.CAR_NOT_FOUND,
+      "Car not found or you do not have access to it",
+      HttpStatus.NOT_FOUND,
+      { title: "Car Not Found" },
+    );
+  }
+}
+
+export class CarFetchFailedException extends CarException {
+  constructor() {
+    super(
+      CarErrorCode.CAR_FETCH_FAILED,
+      "An unexpected error occurred while fetching cars",
+      HttpStatus.INTERNAL_SERVER_ERROR,
+      { title: "Car Fetch Failed" },
+    );
+  }
+}
+
+export class CarCreateFailedException extends CarException {
+  constructor() {
+    super(
+      CarErrorCode.CAR_CREATE_FAILED,
+      "An unexpected error occurred while creating the car",
+      HttpStatus.INTERNAL_SERVER_ERROR,
+      { title: "Car Create Failed" },
+    );
+  }
+}
+
+export class CarUpdateFailedException extends CarException {
+  constructor() {
+    super(
+      CarErrorCode.CAR_UPDATE_FAILED,
+      "An unexpected error occurred while updating the car",
+      HttpStatus.INTERNAL_SERVER_ERROR,
+      { title: "Car Update Failed" },
+    );
+  }
+}
+
+export class OwnerDriverCarLimitReachedException extends CarException {
+  constructor() {
+    super(
+      CarErrorCode.OWNER_DRIVER_CAR_LIMIT_REACHED,
+      "Owner-drivers can only have 1 car. Delete your existing car first or contact support to upgrade to a fleet owner account.",
+      HttpStatus.CONFLICT,
+      { title: "Owner Driver Car Limit Reached" },
+    );
+  }
+}
+
+export class RegistrationNumberAlreadyExistsException extends CarException {
+  constructor(registrationNumber: string) {
+    super(
+      CarErrorCode.REGISTRATION_NUMBER_ALREADY_EXISTS,
+      `A car with registration number ${registrationNumber} already exists in your fleet`,
+      HttpStatus.CONFLICT,
+      { title: "Registration Number Already Exists" },
+    );
+  }
+}

--- a/src/modules/car/car.error.ts
+++ b/src/modules/car/car.error.ts
@@ -27,7 +27,7 @@ export class FleetOwnerNotFoundException extends CarException {
     super(
       CarErrorCode.FLEET_OWNER_NOT_FOUND,
       "Fleet owner account not found",
-      HttpStatus.INTERNAL_SERVER_ERROR,
+      HttpStatus.NOT_FOUND,
       { title: "Fleet Owner Not Found" },
     );
   }

--- a/src/modules/car/car.interface.ts
+++ b/src/modules/car/car.interface.ts
@@ -16,3 +16,10 @@ export interface CarCreateFiles {
   motCertificate: UploadedCarFile;
   insuranceCertificate: UploadedCarFile;
 }
+
+export interface UploadedFiles {
+  imageUrls: string[];
+  motCertificateUrl: string;
+  insuranceCertificateUrl: string;
+  uploadedKeys: string[];
+}

--- a/src/modules/car/car.interface.ts
+++ b/src/modules/car/car.interface.ts
@@ -1,0 +1,18 @@
+export interface UploadedCarFile {
+  originalname: string;
+  mimetype: string;
+  size: number;
+  buffer: Buffer;
+}
+
+export interface CarUploadFields {
+  images?: UploadedCarFile[];
+  motCertificate?: UploadedCarFile[];
+  insuranceCertificate?: UploadedCarFile[];
+}
+
+export interface CarCreateFiles {
+  images: UploadedCarFile[];
+  motCertificate: UploadedCarFile;
+  insuranceCertificate: UploadedCarFile;
+}

--- a/src/modules/car/car.module.ts
+++ b/src/modules/car/car.module.ts
@@ -1,0 +1,13 @@
+import { Module } from "@nestjs/common";
+import { AuthModule } from "../auth/auth.module";
+import { StorageModule } from "../storage/storage.module";
+import { CarController } from "./car.controller";
+import { CarService } from "./car.service";
+
+@Module({
+  imports: [AuthModule, StorageModule],
+  controllers: [CarController],
+  providers: [CarService],
+  exports: [CarService],
+})
+export class CarModule {}

--- a/src/modules/car/car.service.spec.ts
+++ b/src/modules/car/car.service.spec.ts
@@ -1,0 +1,222 @@
+import { Test, type TestingModule } from "@nestjs/testing";
+import { ServiceTier, Status, VehicleType } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DatabaseService } from "../database/database.service";
+import { StorageService } from "../storage/storage.service";
+import {
+  CarFetchFailedException,
+  CarNotFoundException,
+  OwnerDriverCarLimitReachedException,
+  RegistrationNumberAlreadyExistsException,
+} from "./car.error";
+import { CarService } from "./car.service";
+
+describe("CarService", () => {
+  let service: CarService;
+  const createMockFile = (name: string, mimetype: string, content = "file") => ({
+    fieldname: "file",
+    originalname: name,
+    encoding: "7bit",
+    mimetype,
+    buffer: Buffer.from(content),
+    size: Buffer.byteLength(content),
+  });
+
+  const databaseServiceMock = {
+    car: {
+      findMany: vi.fn(),
+      findFirst: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      delete: vi.fn(),
+      update: vi.fn(),
+      count: vi.fn(),
+    },
+    user: {
+      findUnique: vi.fn(),
+    },
+    vehicleImage: {
+      createMany: vi.fn(),
+    },
+    documentApproval: {
+      createMany: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  };
+  const storageServiceMock = {
+    uploadBuffer: vi.fn(),
+    deleteObjectByKey: vi.fn(),
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CarService,
+        { provide: DatabaseService, useValue: databaseServiceMock },
+        { provide: StorageService, useValue: storageServiceMock },
+      ],
+    }).compile();
+
+    service = module.get<CarService>(CarService);
+  });
+
+  it("lists owner cars ordered by latest updates", async () => {
+    databaseServiceMock.car.findMany.mockResolvedValueOnce([{ id: "car-1" }, { id: "car-2" }]);
+
+    const result = await service.listOwnerCars("owner-1");
+
+    expect(result).toEqual([{ id: "car-1" }, { id: "car-2" }]);
+    expect(databaseServiceMock.car.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { ownerId: "owner-1" }, orderBy: { updatedAt: "desc" } }),
+    );
+  });
+
+  it("returns owner car detail", async () => {
+    databaseServiceMock.car.findFirst.mockResolvedValueOnce({ id: "car-1", ownerId: "owner-1" });
+
+    const result = await service.getOwnerCarById("car-1", "owner-1");
+
+    expect(result).toEqual({ id: "car-1", ownerId: "owner-1" });
+  });
+
+  it("throws CarNotFoundException for unknown owner car", async () => {
+    databaseServiceMock.car.findFirst.mockResolvedValueOnce(null);
+
+    await expect(service.getOwnerCarById("missing", "owner-1")).rejects.toBeInstanceOf(
+      CarNotFoundException,
+    );
+  });
+
+  it("enforces owner-driver single-car limit during create", async () => {
+    databaseServiceMock.user.findUnique.mockResolvedValueOnce({ isOwnerDriver: true });
+    databaseServiceMock.car.count.mockResolvedValueOnce(1);
+
+    await expect(
+      service.createCar(
+        "owner-1",
+        {
+          make: "Toyota",
+          model: "Camry",
+          year: 2022,
+          color: "",
+          registrationNumber: "ABC-123XY",
+          dayRate: 50000,
+          hourlyRate: 5000,
+          nightRate: 60000,
+          fullDayRate: 100000,
+          airportPickupRate: 30000,
+          pricingIncludesFuel: false,
+          fuelUpgradeRate: 10000,
+          vehicleType: VehicleType.SEDAN,
+          serviceTier: ServiceTier.STANDARD,
+          passengerCapacity: 4,
+        },
+        {
+          images: [createMockFile("car.jpg", "image/jpeg")],
+          motCertificate: createMockFile("mot.pdf", "application/pdf"),
+          insuranceCertificate: createMockFile("insurance.pdf", "application/pdf"),
+        },
+      ),
+    ).rejects.toBeInstanceOf(OwnerDriverCarLimitReachedException);
+  });
+
+  it("rejects duplicate registration number for same owner", async () => {
+    databaseServiceMock.user.findUnique.mockResolvedValueOnce({ isOwnerDriver: false });
+    databaseServiceMock.car.findFirst.mockResolvedValueOnce({ id: "existing-car" });
+
+    await expect(
+      service.createCar(
+        "owner-1",
+        {
+          make: "Toyota",
+          model: "Camry",
+          year: 2022,
+          color: "",
+          registrationNumber: "ABC-123XY",
+          dayRate: 50000,
+          hourlyRate: 5000,
+          nightRate: 60000,
+          fullDayRate: 100000,
+          airportPickupRate: 30000,
+          pricingIncludesFuel: false,
+          fuelUpgradeRate: 10000,
+          vehicleType: VehicleType.SEDAN,
+          serviceTier: ServiceTier.STANDARD,
+          passengerCapacity: 4,
+        },
+        {
+          images: [createMockFile("car.jpg", "image/jpeg")],
+          motCertificate: createMockFile("mot.pdf", "application/pdf"),
+          insuranceCertificate: createMockFile("insurance.pdf", "application/pdf"),
+        },
+      ),
+    ).rejects.toBeInstanceOf(RegistrationNumberAlreadyExistsException);
+  });
+
+  it("creates car and related images/documents in transaction", async () => {
+    databaseServiceMock.user.findUnique.mockResolvedValueOnce({ isOwnerDriver: false });
+    databaseServiceMock.car.findFirst.mockResolvedValueOnce(null);
+    databaseServiceMock.car.create.mockResolvedValueOnce({ id: "car-1" });
+    storageServiceMock.uploadBuffer
+      .mockResolvedValueOnce("https://cdn.example.com/car-1.jpg")
+      .mockResolvedValueOnce("https://cdn.example.com/mot.pdf")
+      .mockResolvedValueOnce("https://cdn.example.com/insurance.pdf");
+    databaseServiceMock.$transaction.mockImplementationOnce(async (callback) =>
+      callback({
+        car: { findUnique: vi.fn().mockResolvedValue({ id: "car-1", ownerId: "owner-1" }) },
+        vehicleImage: { createMany: vi.fn().mockResolvedValue({ count: 1 }) },
+        documentApproval: { createMany: vi.fn().mockResolvedValue({ count: 2 }) },
+      }),
+    );
+
+    const result = await service.createCar(
+      "owner-1",
+      {
+        make: "Toyota",
+        model: "Camry",
+        year: 2022,
+        color: "",
+        registrationNumber: "ABC-123XY",
+        dayRate: 50000,
+        hourlyRate: 5000,
+        nightRate: 60000,
+        fullDayRate: 100000,
+        airportPickupRate: 30000,
+        pricingIncludesFuel: false,
+        fuelUpgradeRate: 10000,
+        vehicleType: VehicleType.SEDAN,
+        serviceTier: ServiceTier.STANDARD,
+        passengerCapacity: 4,
+      },
+      {
+        images: [createMockFile("car.jpg", "image/jpeg")],
+        motCertificate: createMockFile("mot.pdf", "application/pdf"),
+        insuranceCertificate: createMockFile("insurance.pdf", "application/pdf"),
+      },
+    );
+
+    expect(result).toEqual({ id: "car-1", ownerId: "owner-1" });
+  });
+
+  it("updates owner car", async () => {
+    databaseServiceMock.car.findFirst.mockResolvedValueOnce({
+      id: "car-1",
+      registrationNumber: "ABC-123XY",
+    });
+    databaseServiceMock.car.update.mockResolvedValueOnce({
+      id: "car-1",
+      status: Status.HOLD,
+    });
+
+    const result = await service.updateCar("car-1", "owner-1", { status: Status.HOLD });
+
+    expect(result).toEqual({ id: "car-1", status: Status.HOLD });
+  });
+
+  it("throws CarFetchFailedException when list query fails unexpectedly", async () => {
+    databaseServiceMock.car.findMany.mockRejectedValueOnce(new Error("db down"));
+
+    await expect(service.listOwnerCars("owner-1")).rejects.toBeInstanceOf(CarFetchFailedException);
+  });
+});

--- a/src/modules/car/car.service.ts
+++ b/src/modules/car/car.service.ts
@@ -1,0 +1,344 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { CarApprovalStatus, DocumentStatus, DocumentType, Prisma, Status } from "@prisma/client";
+import { DatabaseService } from "../database/database.service";
+import { StorageService } from "../storage/storage.service";
+import { CAR_S3_CATEGORY_DOCUMENTS, CAR_S3_CATEGORY_IMAGES } from "./car.const";
+import {
+  CarCreateFailedException,
+  CarException,
+  CarFetchFailedException,
+  CarNotFoundException,
+  CarUpdateFailedException,
+  FleetOwnerNotFoundException,
+  OwnerDriverCarLimitReachedException,
+  RegistrationNumberAlreadyExistsException,
+} from "./car.error";
+import type { CarCreateFiles, UploadedCarFile } from "./car.interface";
+import type { CreateCarMultipartBodyDto } from "./dto/create-car.dto";
+import type { UpdateCarBodyDto } from "./dto/update-car.dto";
+
+@Injectable()
+export class CarService {
+  private readonly logger = new Logger(CarService.name);
+  private readonly carDetailsInclude = Prisma.validator<Prisma.CarInclude>()({
+    owner: {
+      select: {
+        id: true,
+        name: true,
+        username: true,
+        email: true,
+      },
+    },
+    images: {
+      select: {
+        id: true,
+        url: true,
+        status: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+      orderBy: {
+        createdAt: "asc",
+      },
+    },
+    documents: {
+      orderBy: {
+        createdAt: "asc",
+      },
+    },
+  });
+
+  constructor(
+    private readonly databaseService: DatabaseService,
+    private readonly storageService: StorageService,
+  ) {}
+
+  private getObjectKey(ownerId: string, carId: string, fileName: string, category: string): string {
+    const timestamp = Date.now();
+    const safeFilename = `${timestamp}-${fileName.replaceAll(/[^a-zA-Z0-9.-]/g, "_")}`;
+    return `${ownerId}/${carId}/${category}/${safeFilename}`;
+  }
+
+  private async assertOwnerCanCreateCar(ownerId: string): Promise<void> {
+    const fleetOwnerUser = await this.databaseService.user.findUnique({
+      where: { id: ownerId },
+      select: { isOwnerDriver: true },
+    });
+
+    if (!fleetOwnerUser) {
+      throw new FleetOwnerNotFoundException();
+    }
+
+    if (!fleetOwnerUser.isOwnerDriver) {
+      return;
+    }
+
+    const existingCarsCount = await this.databaseService.car.count({
+      where: { ownerId },
+    });
+
+    if (existingCarsCount >= 1) {
+      throw new OwnerDriverCarLimitReachedException();
+    }
+  }
+
+  private async assertRegistrationNumberUnique(
+    ownerId: string,
+    registrationNumber: string,
+  ): Promise<void> {
+    const existingCar = await this.databaseService.car.findFirst({
+      where: {
+        ownerId,
+        registrationNumber: {
+          equals: registrationNumber.trim(),
+          mode: "insensitive",
+        },
+      },
+      select: { id: true },
+    });
+
+    if (existingCar) {
+      throw new RegistrationNumberAlreadyExistsException(registrationNumber);
+    }
+  }
+
+  private async createCarShell(
+    ownerId: string,
+    dto: CreateCarMultipartBodyDto,
+  ): Promise<{ id: string }> {
+    return this.databaseService.car.create({
+      data: {
+        make: dto.make,
+        model: dto.model,
+        year: dto.year,
+        color: dto.color,
+        ownerId,
+        registrationNumber: dto.registrationNumber,
+        status: dto.status ?? Status.AVAILABLE,
+        approvalStatus: CarApprovalStatus.PENDING,
+        hourlyRate: dto.hourlyRate,
+        dayRate: dto.dayRate,
+        nightRate: dto.nightRate,
+        fuelUpgradeRate: dto.fuelUpgradeRate ?? null,
+        fullDayRate: dto.fullDayRate,
+        airportPickupRate: dto.airportPickupRate,
+        pricingIncludesFuel: dto.pricingIncludesFuel,
+        vehicleType: dto.vehicleType,
+        serviceTier: dto.serviceTier,
+        passengerCapacity: dto.passengerCapacity,
+      },
+      select: { id: true },
+    });
+  }
+
+  private async uploadCarFiles(
+    ownerId: string,
+    carId: string,
+    files: CarCreateFiles,
+  ): Promise<{
+    imageUrls: string[];
+    motCertificateUrl: string;
+    insuranceCertificateUrl: string;
+    uploadedKeys: string[];
+  }> {
+    const uploadedKeys: string[] = [];
+    const trackUpload = async (file: UploadedCarFile, category: string): Promise<string> => {
+      const key = this.getObjectKey(ownerId, carId, file.originalname, category);
+      const url = await this.storageService.uploadBuffer(file.buffer, key, file.mimetype);
+      uploadedKeys.push(key);
+      return url;
+    };
+
+    const [imageUrls, motCertificateUrl, insuranceCertificateUrl] = await Promise.all([
+      Promise.all(files.images.map((image) => trackUpload(image, CAR_S3_CATEGORY_IMAGES))),
+      trackUpload(files.motCertificate, CAR_S3_CATEGORY_DOCUMENTS),
+      trackUpload(files.insuranceCertificate, CAR_S3_CATEGORY_DOCUMENTS),
+    ]);
+
+    return { imageUrls, motCertificateUrl, insuranceCertificateUrl, uploadedKeys };
+  }
+
+  private async persistUploadedCarAssets(
+    carId: string,
+    uploaded: {
+      imageUrls: string[];
+      motCertificateUrl: string;
+      insuranceCertificateUrl: string;
+    },
+  ) {
+    const car = await this.databaseService.$transaction(async (tx) => {
+      await tx.vehicleImage.createMany({
+        data: uploaded.imageUrls.map((url) => ({
+          url,
+          carId,
+          status: DocumentStatus.PENDING,
+        })),
+      });
+
+      await tx.documentApproval.createMany({
+        data: [
+          {
+            documentType: DocumentType.MOT_CERTIFICATE,
+            documentUrl: uploaded.motCertificateUrl,
+            carId,
+            status: DocumentStatus.PENDING,
+          },
+          {
+            documentType: DocumentType.INSURANCE_CERTIFICATE,
+            documentUrl: uploaded.insuranceCertificateUrl,
+            carId,
+            status: DocumentStatus.PENDING,
+          },
+        ],
+      });
+
+      return tx.car.findUnique({
+        where: { id: carId },
+        include: this.carDetailsInclude,
+      });
+    });
+
+    if (!car) {
+      throw new CarCreateFailedException();
+    }
+
+    return car;
+  }
+
+  private async cleanupFailedCreate(carId: string, uploadedKeys: string[]): Promise<void> {
+    await this.databaseService.car.delete({
+      where: { id: carId },
+    });
+
+    for (const key of uploadedKeys) {
+      try {
+        await this.storageService.deleteObjectByKey(key);
+      } catch (deleteError) {
+        this.logger.error("Failed to delete uploaded car asset", {
+          key,
+          error: deleteError instanceof Error ? deleteError.message : String(deleteError),
+        });
+      }
+    }
+  }
+
+  async listOwnerCars(ownerId: string) {
+    try {
+      return await this.databaseService.car.findMany({
+        where: { ownerId },
+        include: this.carDetailsInclude,
+        orderBy: { updatedAt: "desc" },
+      });
+    } catch (error) {
+      if (error instanceof CarException) {
+        throw error;
+      }
+      this.logger.error("Failed to list owner cars", {
+        ownerId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw new CarFetchFailedException();
+    }
+  }
+
+  async getOwnerCarById(carId: string, ownerId: string) {
+    try {
+      const car = await this.databaseService.car.findFirst({
+        where: { id: carId, ownerId },
+        include: this.carDetailsInclude,
+      });
+
+      if (!car) {
+        throw new CarNotFoundException();
+      }
+
+      return car;
+    } catch (error) {
+      if (error instanceof CarException) {
+        throw error;
+      }
+      this.logger.error("Failed to fetch owner car", {
+        carId,
+        ownerId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw new CarFetchFailedException();
+    }
+  }
+
+  async createCar(ownerId: string, dto: CreateCarMultipartBodyDto, files: CarCreateFiles) {
+    try {
+      await this.assertOwnerCanCreateCar(ownerId);
+      await this.assertRegistrationNumberUnique(ownerId, dto.registrationNumber);
+
+      const createdCar = await this.createCarShell(ownerId, dto);
+      const uploaded = await this.uploadCarFiles(ownerId, createdCar.id, files);
+
+      try {
+        return await this.persistUploadedCarAssets(createdCar.id, uploaded);
+      } catch (error) {
+        await this.cleanupFailedCreate(createdCar.id, uploaded.uploadedKeys);
+        throw error;
+      }
+    } catch (error) {
+      if (error instanceof CarException) {
+        throw error;
+      }
+      this.logger.error("Failed to create car", {
+        ownerId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw new CarCreateFailedException();
+    }
+  }
+
+  async updateCar(carId: string, ownerId: string, dto: UpdateCarBodyDto) {
+    try {
+      const existingCar = await this.databaseService.car.findFirst({
+        where: { id: carId, ownerId },
+        select: { id: true, registrationNumber: true },
+      });
+
+      if (!existingCar) {
+        throw new CarNotFoundException();
+      }
+
+      if (dto.registrationNumber && dto.registrationNumber !== existingCar.registrationNumber) {
+        const duplicate = await this.databaseService.car.findFirst({
+          where: {
+            ownerId,
+            id: { not: carId },
+            registrationNumber: {
+              equals: dto.registrationNumber.trim(),
+              mode: "insensitive",
+            },
+          },
+          select: { id: true },
+        });
+        if (duplicate) {
+          throw new RegistrationNumberAlreadyExistsException(dto.registrationNumber);
+        }
+      }
+
+      return await this.databaseService.car.update({
+        where: { id: carId },
+        data: {
+          ...dto,
+          fuelUpgradeRate:
+            dto.pricingIncludesFuel === true ? null : (dto.fuelUpgradeRate ?? undefined),
+        },
+        include: this.carDetailsInclude,
+      });
+    } catch (error) {
+      if (error instanceof CarException) {
+        throw error;
+      }
+      this.logger.error("Failed to update car", {
+        carId,
+        ownerId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw new CarUpdateFailedException();
+    }
+  }
+}

--- a/src/modules/car/dto/create-car.dto.ts
+++ b/src/modules/car/dto/create-car.dto.ts
@@ -1,0 +1,122 @@
+import { ServiceTier, Status, VehicleType } from "@prisma/client";
+import { z } from "zod";
+
+const registrationNumberSchema = z
+  .string()
+  .trim()
+  .min(1, "Registration number is required")
+  .transform((value) => value.toUpperCase())
+  .pipe(
+    z.string().refine(
+      (value) => {
+        const plate = value.replaceAll(/\s+/g, "");
+        const stateFormat = /^[A-Z]{3}-?\d{3}[A-Z]{2}$/;
+        const federalFormat = /^[A-Z]{2}\d{3}[A-Z]{2}$/;
+        return stateFormat.test(plate) || federalFormat.test(plate);
+      },
+      {
+        message:
+          "Invalid Nigerian number plate format. Use formats like 'ABC-123XX', 'ABC123XX', or 'XX123XX'",
+      },
+    ),
+  );
+
+const carBaseSchema = z
+  .object({
+    make: z.string().trim().min(1),
+    model: z.string().trim().min(1),
+    year: z
+      .number()
+      .int()
+      .min(2015)
+      .max(new Date().getFullYear() + 1),
+    color: z.string().trim().default(""),
+    registrationNumber: registrationNumberSchema,
+    status: z.enum([Status.AVAILABLE, Status.HOLD, Status.IN_SERVICE]).optional(),
+    dayRate: z.number().int().positive(),
+    hourlyRate: z.number().int().positive(),
+    nightRate: z.number().int().positive(),
+    fullDayRate: z.number().int().positive(),
+    airportPickupRate: z.number().int().positive(),
+    fuelUpgradeRate: z.number().int().positive().nullable().optional(),
+    pricingIncludesFuel: z.boolean(),
+    vehicleType: z.enum(VehicleType),
+    serviceTier: z.enum(ServiceTier),
+    passengerCapacity: z.number().int().min(1).max(15),
+  })
+  .superRefine((data, ctx) => {
+    if (
+      !data.pricingIncludesFuel &&
+      (data.fuelUpgradeRate === null || data.fuelUpgradeRate === undefined)
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Fuel upgrade rate is required when pricing does not include fuel",
+        path: ["fuelUpgradeRate"],
+      });
+    }
+  });
+
+const parseBoolean = (value: unknown): unknown => {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "true" || normalized === "on") return true;
+    if (normalized === "false" || normalized === "off" || normalized === "") return false;
+  }
+  return value;
+};
+
+const parseNullableInt = (value: unknown): unknown => {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
+  return value;
+};
+
+export const createCarBodySchema = carBaseSchema;
+
+export const createCarMultipartBodySchema = z
+  .object({
+    make: z.string().trim().min(1),
+    model: z.string().trim().min(1),
+    year: z.coerce
+      .number()
+      .int()
+      .min(2015)
+      .max(new Date().getFullYear() + 1),
+    color: z.string().trim().default(""),
+    registrationNumber: registrationNumberSchema,
+    status: z
+      .string()
+      .optional()
+      .transform((value) => value ?? undefined)
+      .pipe(z.enum([Status.AVAILABLE, Status.HOLD, Status.IN_SERVICE]).optional()),
+    dayRate: z.coerce.number().int().positive(),
+    hourlyRate: z.coerce.number().int().positive(),
+    nightRate: z.coerce.number().int().positive(),
+    fullDayRate: z.coerce.number().int().positive(),
+    airportPickupRate: z.coerce.number().int().positive(),
+    fuelUpgradeRate: z.preprocess(
+      parseNullableInt,
+      z.coerce.number().int().positive().nullable().optional(),
+    ),
+    pricingIncludesFuel: z.preprocess(parseBoolean, z.boolean()),
+    vehicleType: z.enum(VehicleType),
+    serviceTier: z.enum(ServiceTier),
+    passengerCapacity: z.coerce.number().int().min(1).max(15),
+  })
+  .superRefine((data, ctx) => {
+    if (
+      !data.pricingIncludesFuel &&
+      (data.fuelUpgradeRate === null || data.fuelUpgradeRate === undefined)
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Fuel upgrade rate is required when pricing does not include fuel",
+        path: ["fuelUpgradeRate"],
+      });
+    }
+  });
+
+export type CreateCarBodyDto = z.infer<typeof createCarBodySchema>;
+export type CreateCarMultipartBodyDto = z.infer<typeof createCarMultipartBodySchema>;

--- a/src/modules/car/dto/update-car.dto.ts
+++ b/src/modules/car/dto/update-car.dto.ts
@@ -1,0 +1,29 @@
+import { Status } from "@prisma/client";
+import { z } from "zod";
+import { createCarBodySchema } from "./create-car.dto";
+
+export const carIdParamSchema = z.cuid();
+
+export const updateCarBodySchema = createCarBodySchema
+  .partial()
+  .extend({
+    status: z.enum([Status.AVAILABLE, Status.HOLD, Status.IN_SERVICE]).optional(),
+  })
+  .refine((data) => Object.keys(data).length > 0, {
+    message: "At least one update field is required",
+    path: ["make"],
+  })
+  .superRefine((data, ctx) => {
+    if (
+      data.pricingIncludesFuel === false &&
+      (data.fuelUpgradeRate === null || data.fuelUpgradeRate === undefined)
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Fuel upgrade rate is required when pricing does not include fuel",
+        path: ["fuelUpgradeRate"],
+      });
+    }
+  });
+
+export type UpdateCarBodyDto = z.infer<typeof updateCarBodySchema>;

--- a/src/modules/storage/storage.module.ts
+++ b/src/modules/storage/storage.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { StorageService } from "./storage.service";
+
+@Module({
+  providers: [StorageService],
+  exports: [StorageService],
+})
+export class StorageModule {}

--- a/src/modules/storage/storage.service.ts
+++ b/src/modules/storage/storage.service.ts
@@ -1,0 +1,50 @@
+import { DeleteObjectCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { Injectable } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import type { EnvConfig } from "../../config/env.config";
+
+@Injectable()
+export class StorageService {
+  private readonly bucketName: string;
+  private readonly region: string;
+  private readonly accessKeyId: string;
+  private readonly secretAccessKey: string;
+  private readonly s3Client: S3Client;
+
+  constructor(private readonly configService: ConfigService<EnvConfig>) {
+    this.bucketName = this.configService.get("AWS_BUCKET_NAME", { infer: true });
+    this.region = this.configService.get("AWS_REGION", { infer: true });
+    this.accessKeyId = this.configService.get("AWS_ACCESS_KEY_ID", { infer: true });
+    this.secretAccessKey = this.configService.get("AWS_SECRET_ACCESS_KEY", { infer: true });
+    this.s3Client = new S3Client({
+      region: this.region,
+      credentials: {
+        accessKeyId: this.accessKeyId,
+        secretAccessKey: this.secretAccessKey,
+      },
+    });
+  }
+
+  async uploadBuffer(buffer: Buffer, key: string, contentType: string): Promise<string> {
+    await this.s3Client.send(
+      new PutObjectCommand({
+        Bucket: this.bucketName,
+        Key: key,
+        Body: buffer,
+        ContentType: contentType,
+        CacheControl: "public, max-age=31536000, immutable",
+      }),
+    );
+
+    return `https://${this.bucketName}.s3.${this.region}.amazonaws.com/${key}`;
+  }
+
+  async deleteObjectByKey(key: string): Promise<void> {
+    await this.s3Client.send(
+      new DeleteObjectCommand({
+        Bucket: this.bucketName,
+        Key: key,
+      }),
+    );
+  }
+}

--- a/test/bookings.e2e-spec.ts
+++ b/test/bookings.e2e-spec.ts
@@ -324,10 +324,10 @@ describe("Bookings E2E Tests", () => {
     });
   });
 
-  describe("DELETE /api/bookings/:bookingId", () => {
+  describe("PATCH /api/bookings/:bookingId/cancel", () => {
     it("should return 401 without authentication", async () => {
       const response = await request(app.getHttpServer())
-        .delete("/api/bookings/some-id")
+        .patch("/api/bookings/some-id/cancel")
         .send({ reason: "test" });
 
       expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
@@ -340,7 +340,7 @@ describe("Bookings E2E Tests", () => {
       });
 
       const response = await request(app.getHttpServer())
-        .delete(`/api/bookings/${booking.id}`)
+        .patch(`/api/bookings/${booking.id}/cancel`)
         .set("Cookie", testUserCookie)
         .send({ reason: "Plans changed" });
 
@@ -358,7 +358,7 @@ describe("Bookings E2E Tests", () => {
       });
 
       const response = await request(app.getHttpServer())
-        .delete(`/api/bookings/${otherBooking.id}`)
+        .patch(`/api/bookings/${otherBooking.id}/cancel`)
         .set("Cookie", testUserCookie)
         .send({ reason: "Hijack attempt" });
 

--- a/test/cars.e2e-spec.ts
+++ b/test/cars.e2e-spec.ts
@@ -1,0 +1,190 @@
+import { HttpStatus, type INestApplication } from "@nestjs/common";
+import { HttpAdapterHost } from "@nestjs/core";
+import { Test, type TestingModule } from "@nestjs/testing";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { AppModule } from "../src/app.module";
+import { GlobalExceptionFilter } from "../src/common/filters/global-exception.filter";
+import { AuthEmailService } from "../src/modules/auth/auth-email.service";
+import { DatabaseService } from "../src/modules/database/database.service";
+import { StorageService } from "../src/modules/storage/storage.service";
+import { TestDataFactory, uniqueEmail } from "./helpers";
+
+describe("Cars E2E Tests", () => {
+  let app: INestApplication;
+  let databaseService: DatabaseService;
+  let factory: TestDataFactory;
+  let ownerCookie: string;
+  let ownerId: string;
+  let secondOwnerCookie: string;
+  let secondOwnerId: string;
+  let userCookie: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(AuthEmailService)
+      .useValue({ sendOTPEmail: vi.fn().mockResolvedValue(undefined) })
+      .overrideProvider(StorageService)
+      .useValue({
+        uploadBuffer: vi.fn().mockImplementation(async (_buffer: Buffer, key: string) => {
+          return `https://cdn.tripdly.test/${key}`;
+        }),
+        deleteObjectByKey: vi.fn().mockResolvedValue(undefined),
+      })
+      .compile();
+
+    app = moduleFixture.createNestApplication({ logger: false });
+    const httpAdapterHost = app.get(HttpAdapterHost);
+    app.useGlobalFilters(new GlobalExceptionFilter(httpAdapterHost));
+
+    databaseService = app.get(DatabaseService);
+    factory = new TestDataFactory(databaseService, app);
+    await app.init();
+
+    const ownerAuth = await factory.authenticateAndGetUser(
+      uniqueEmail("cars-owner"),
+      "fleetOwner",
+      "web",
+    );
+    ownerCookie = ownerAuth.cookie;
+    ownerId = ownerAuth.user.id;
+
+    const secondOwnerAuth = await factory.authenticateAndGetUser(
+      uniqueEmail("cars-owner-2"),
+      "fleetOwner",
+      "web",
+    );
+    secondOwnerCookie = secondOwnerAuth.cookie;
+    secondOwnerId = secondOwnerAuth.user.id;
+
+    const userAuth = await factory.authenticateAndGetUser(uniqueEmail("cars-user"), "user");
+    userCookie = userAuth.cookie;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("GET /api/cars returns 401 when unauthenticated", async () => {
+    const response = await request(app.getHttpServer()).get("/api/cars");
+    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+  });
+
+  it("GET /api/cars returns 403 when authenticated as non-fleet owner", async () => {
+    const response = await request(app.getHttpServer()).get("/api/cars").set("Cookie", userCookie);
+    expect(response.status).toBe(HttpStatus.FORBIDDEN);
+  });
+
+  it("POST /api/cars creates car for fleet owner", async () => {
+    const response = await request(app.getHttpServer())
+      .post("/api/cars")
+      .set("Cookie", ownerCookie)
+      .field("make", "Toyota")
+      .field("model", "Camry")
+      .field("year", "2022")
+      .field("color", "Black")
+      .field("registrationNumber", "KJA-123AB")
+      .field("dayRate", "50000")
+      .field("hourlyRate", "5000")
+      .field("nightRate", "60000")
+      .field("fullDayRate", "100000")
+      .field("airportPickupRate", "30000")
+      .field("pricingIncludesFuel", "false")
+      .field("fuelUpgradeRate", "10000")
+      .field("vehicleType", "SEDAN")
+      .field("serviceTier", "STANDARD")
+      .field("passengerCapacity", "4")
+      .attach("images", Buffer.from("fake-image"), {
+        filename: "car.jpg",
+        contentType: "image/jpeg",
+      })
+      .attach("motCertificate", Buffer.from("%PDF-1.4 test"), {
+        filename: "mot.pdf",
+        contentType: "application/pdf",
+      })
+      .attach("insuranceCertificate", Buffer.from("%PDF-1.4 insurance"), {
+        filename: "insurance.pdf",
+        contentType: "application/pdf",
+      });
+
+    expect(response.status).toBe(HttpStatus.CREATED);
+    expect(response.body.ownerId).toBe(ownerId);
+    expect(response.body.registrationNumber).toBe("KJA-123AB");
+    expect(response.body.images).toHaveLength(1);
+    expect(response.body.documents).toHaveLength(2);
+  });
+
+  it("GET /api/cars lists only requesting fleet owner's cars", async () => {
+    await factory.createCar(secondOwnerId, { registrationNumber: "ABC-987ZZ" });
+
+    const response = await request(app.getHttpServer()).get("/api/cars").set("Cookie", ownerCookie);
+
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(Array.isArray(response.body)).toBe(true);
+    expect(response.body.length).toBeGreaterThan(0);
+    expect(response.body.every((car: { ownerId: string }) => car.ownerId === ownerId)).toBe(true);
+  });
+
+  it("GET /api/cars/:carId returns car detail for owner", async () => {
+    const ownerCar = await databaseService.car.findFirstOrThrow({
+      where: { ownerId, registrationNumber: "KJA-123AB" },
+      select: { id: true },
+    });
+
+    const response = await request(app.getHttpServer())
+      .get(`/api/cars/${ownerCar.id}`)
+      .set("Cookie", ownerCookie);
+
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(response.body.id).toBe(ownerCar.id);
+    expect(response.body.ownerId).toBe(ownerId);
+  });
+
+  it("GET /api/cars/:carId returns 404 for other fleet owner's car", async () => {
+    const ownerCar = await databaseService.car.findFirstOrThrow({
+      where: { ownerId, registrationNumber: "KJA-123AB" },
+      select: { id: true },
+    });
+
+    const response = await request(app.getHttpServer())
+      .get(`/api/cars/${ownerCar.id}`)
+      .set("Cookie", secondOwnerCookie);
+
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+  });
+
+  it("PATCH /api/cars/:carId updates owner car", async () => {
+    const ownerCar = await databaseService.car.findFirstOrThrow({
+      where: { ownerId, registrationNumber: "KJA-123AB" },
+      select: { id: true },
+    });
+
+    const response = await request(app.getHttpServer())
+      .patch(`/api/cars/${ownerCar.id}`)
+      .set("Cookie", ownerCookie)
+      .send({
+        dayRate: 55000,
+        status: "HOLD",
+      });
+
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(response.body.dayRate).toBe(55000);
+    expect(response.body.status).toBe("HOLD");
+  });
+
+  it("PATCH /api/cars/:carId returns 404 when updating another owner's car", async () => {
+    const ownerCar = await databaseService.car.findFirstOrThrow({
+      where: { ownerId, registrationNumber: "KJA-123AB" },
+      select: { id: true },
+    });
+
+    const response = await request(app.getHttpServer())
+      .patch(`/api/cars/${ownerCar.id}`)
+      .set("Cookie", secondOwnerCookie)
+      .send({ status: "AVAILABLE" });
+
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+  });
+});


### PR DESCRIPTION
Add fleet management endpoints (list/detail/create/update), multipart file handling, S3-backed storage module, and car API test coverage

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new externally facing endpoints and S3 upload/delete behavior plus new required environment variables; also changes booking cancellation semantics and route, which could break clients and alter refund flow.
> 
> **Overview**
> **Adds fleet-owner car management APIs with file uploads.** Introduces a new `CarModule` with `GET /api/cars`, `GET /api/cars/:carId`, `POST /api/cars` (multipart), and `PATCH /api/cars/:carId`, gated by session + `fleetOwner` role, plus Zod validation for car fields (including Nigerian plate format and fuel pricing rules) and strict upload validation (1–5 images + required PDF MOT/insurance, size/type limits).
> 
> **Adds S3-backed storage abstraction and wires it into car creation.** Adds `StorageService` using AWS S3 SDK and new required env vars (`AWS_*`), uploads assets on create and persists image/document records transactionally with cleanup on failure; includes unit + e2e coverage for car APIs and updates booking cancellation by changing the endpoint to `PATCH /api/bookings/:bookingId/cancel` and restricting cancellation to *paid confirmed* bookings (always setting `REFUND_PROCESSING`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed34e04ce999ecff9e6c524b50496de18e5c0b55. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->