### PR TITLE
feat(rates): add admin rate management APIs and centralize window validation

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -22,6 +22,7 @@ import { JobModule } from "./modules/job/job.module";
 import { MessagingModule } from "./modules/messaging/messaging.module";
 import { NotificationModule } from "./modules/notification/notification.module";
 import { PaymentModule } from "./modules/payment/payment.module";
+import { RatesModule } from "./modules/rates/rates.module";
 import { ReferralModule } from "./modules/referral/referral.module";
 import { ReminderModule } from "./modules/reminder/reminder.module";
 import { ReviewsModule } from "./modules/reviews/reviews.module";
@@ -165,6 +166,7 @@ import { StatusChangeModule } from "./modules/status-change/status-change.module
     AuthModule,
     CarModule,
     DashboardModule,
+    RatesModule,
   ],
 })
 export class AppModule implements NestModule {

--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -62,17 +62,17 @@ export class DashboardService {
 
   private getBucketStart(date: Date, groupBy: DashboardGroupBy): Date {
     const bucket = new Date(date);
-    bucket.setHours(0, 0, 0, 0);
+    bucket.setUTCHours(0, 0, 0, 0);
 
     if (groupBy === "month") {
-      bucket.setDate(1);
+      bucket.setUTCDate(1);
       return bucket;
     }
 
     if (groupBy === "week") {
-      const day = bucket.getDay();
+      const day = bucket.getUTCDay();
       const diff = day === 0 ? -6 : 1 - day;
-      bucket.setDate(bucket.getDate() + diff);
+      bucket.setUTCDate(bucket.getUTCDate() + diff);
     }
 
     return bucket;

--- a/src/modules/rates/dto/rates-admin.dto.spec.ts
+++ b/src/modules/rates/dto/rates-admin.dto.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  createAddonRateSchema,
+  createPlatformFeeSchema,
+  createVatRateSchema,
+} from "./rates-admin.dto";
+
+describe("rates-admin DTO schemas", () => {
+  it("rejects invalid date range for platform fee schema", () => {
+    const parsed = createPlatformFeeSchema.safeParse({
+      feeType: "PLATFORM_SERVICE_FEE",
+      ratePercent: 10,
+      effectiveSince: "2026-06-01",
+      effectiveUntil: "2026-03-01",
+    });
+
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues[0]?.message).toBe("effectiveSince must be before effectiveUntil");
+    }
+  });
+
+  it("rejects invalid date range for VAT schema", () => {
+    const parsed = createVatRateSchema.safeParse({
+      ratePercent: 7.5,
+      effectiveSince: "2026-06-01",
+      effectiveUntil: "2026-03-01",
+    });
+
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues[0]?.message).toBe("effectiveSince must be before effectiveUntil");
+    }
+  });
+
+  it("rejects invalid date range for addon schema", () => {
+    const parsed = createAddonRateSchema.safeParse({
+      addonType: "SECURITY_DETAIL",
+      rateAmount: 5000,
+      effectiveSince: "2026-06-01",
+      effectiveUntil: "2026-03-01",
+    });
+
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues[0]?.message).toBe("effectiveSince must be before effectiveUntil");
+    }
+  });
+});

--- a/src/modules/rates/dto/rates-admin.dto.spec.ts
+++ b/src/modules/rates/dto/rates-admin.dto.spec.ts
@@ -6,6 +6,17 @@ import {
 } from "./rates-admin.dto";
 
 describe("rates-admin DTO schemas", () => {
+  it("accepts valid date range for platform fee schema", () => {
+    const parsed = createPlatformFeeSchema.safeParse({
+      feeType: "PLATFORM_SERVICE_FEE",
+      ratePercent: 10,
+      effectiveSince: "2026-03-01",
+      effectiveUntil: "2026-06-01",
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
   it("rejects invalid date range for platform fee schema", () => {
     const parsed = createPlatformFeeSchema.safeParse({
       feeType: "PLATFORM_SERVICE_FEE",
@@ -20,6 +31,16 @@ describe("rates-admin DTO schemas", () => {
     }
   });
 
+  it("accepts valid date range for VAT schema", () => {
+    const parsed = createVatRateSchema.safeParse({
+      ratePercent: 7.5,
+      effectiveSince: "2026-03-01",
+      effectiveUntil: "2026-06-01",
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
   it("rejects invalid date range for VAT schema", () => {
     const parsed = createVatRateSchema.safeParse({
       ratePercent: 7.5,
@@ -31,6 +52,17 @@ describe("rates-admin DTO schemas", () => {
     if (!parsed.success) {
       expect(parsed.error.issues[0]?.message).toBe("effectiveSince must be before effectiveUntil");
     }
+  });
+
+  it("accepts valid date range for addon schema", () => {
+    const parsed = createAddonRateSchema.safeParse({
+      addonType: "SECURITY_DETAIL",
+      rateAmount: 5000,
+      effectiveSince: "2026-03-01",
+      effectiveUntil: "2026-06-01",
+    });
+
+    expect(parsed.success).toBe(true);
   });
 
   it("rejects invalid date range for addon schema", () => {

--- a/src/modules/rates/dto/rates-admin.dto.spec.ts
+++ b/src/modules/rates/dto/rates-admin.dto.spec.ts
@@ -31,6 +31,47 @@ describe("rates-admin DTO schemas", () => {
     }
   });
 
+  it("rejects zero-duration date range for rate schemas", () => {
+    const sameDate = "2026-03-01";
+    const platformParsed = createPlatformFeeSchema.safeParse({
+      feeType: "PLATFORM_SERVICE_FEE",
+      ratePercent: 10,
+      effectiveSince: sameDate,
+      effectiveUntil: sameDate,
+    });
+    const vatParsed = createVatRateSchema.safeParse({
+      ratePercent: 7.5,
+      effectiveSince: sameDate,
+      effectiveUntil: sameDate,
+    });
+    const addonParsed = createAddonRateSchema.safeParse({
+      addonType: "SECURITY_DETAIL",
+      rateAmount: 5000,
+      effectiveSince: sameDate,
+      effectiveUntil: sameDate,
+    });
+
+    expect(platformParsed.success).toBe(false);
+    expect(vatParsed.success).toBe(false);
+    expect(addonParsed.success).toBe(false);
+
+    if (!platformParsed.success) {
+      expect(platformParsed.error.issues[0]?.message).toBe(
+        "effectiveSince must be before effectiveUntil",
+      );
+    }
+    if (!vatParsed.success) {
+      expect(vatParsed.error.issues[0]?.message).toBe(
+        "effectiveSince must be before effectiveUntil",
+      );
+    }
+    if (!addonParsed.success) {
+      expect(addonParsed.error.issues[0]?.message).toBe(
+        "effectiveSince must be before effectiveUntil",
+      );
+    }
+  });
+
   it("accepts valid date range for VAT schema", () => {
     const parsed = createVatRateSchema.safeParse({
       ratePercent: 7.5,

--- a/src/modules/rates/dto/rates-admin.dto.ts
+++ b/src/modules/rates/dto/rates-admin.dto.ts
@@ -1,0 +1,55 @@
+import { AddonType, PlatformFeeType } from "@prisma/client";
+import { z } from "zod";
+
+type DateRangeInput = {
+  effectiveSince: Date;
+  effectiveUntil?: Date;
+};
+
+const withValidDateRange = <T extends DateRangeInput>(schema: z.ZodType<T>) =>
+  schema.superRefine((value, ctx) => {
+    if (value.effectiveUntil && value.effectiveSince >= value.effectiveUntil) {
+      ctx.addIssue({
+        code: "custom",
+        message: "effectiveSince must be before effectiveUntil",
+        path: ["effectiveUntil"],
+      });
+    }
+  });
+
+export const createPlatformFeeSchema = withValidDateRange(
+  z.object({
+    feeType: z.enum(PlatformFeeType),
+    ratePercent: z.coerce.number().min(0).max(100),
+    effectiveSince: z.coerce.date(),
+    effectiveUntil: z.coerce.date().optional(),
+    description: z.string().trim().max(500).optional(),
+  }),
+);
+
+export type CreatePlatformFeeDto = z.infer<typeof createPlatformFeeSchema>;
+
+export const createVatRateSchema = withValidDateRange(
+  z.object({
+    ratePercent: z.coerce.number().min(0).max(100),
+    effectiveSince: z.coerce.date(),
+    effectiveUntil: z.coerce.date().optional(),
+    description: z.string().trim().max(500).optional(),
+  }),
+);
+
+export type CreateVatRateDto = z.infer<typeof createVatRateSchema>;
+
+export const createAddonRateSchema = withValidDateRange(
+  z.object({
+    addonType: z.enum(AddonType),
+    rateAmount: z.coerce.number().min(0),
+    effectiveSince: z.coerce.date(),
+    effectiveUntil: z.coerce.date().optional(),
+    description: z.string().trim().max(500).optional(),
+  }),
+);
+
+export type CreateAddonRateDto = z.infer<typeof createAddonRateSchema>;
+
+export const addonRateIdParamSchema = z.cuid();

--- a/src/modules/rates/rates-admin.service.spec.ts
+++ b/src/modules/rates/rates-admin.service.spec.ts
@@ -1,0 +1,268 @@
+import { Test, type TestingModule } from "@nestjs/testing";
+import { Decimal } from "@prisma/client/runtime/library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DatabaseService } from "../database/database.service";
+import {
+  RateAlreadyEndedException,
+  RateDateOverlapException,
+  RateNotFoundException,
+} from "./rates.error";
+import { RatesService } from "./rates.service";
+import { RatesAdminService } from "./rates-admin.service";
+
+describe("RatesAdminService", () => {
+  let service: RatesAdminService;
+  let databaseService: {
+    platformFeeRate: {
+      findMany: ReturnType<typeof vi.fn>;
+      findFirst: ReturnType<typeof vi.fn>;
+      create: ReturnType<typeof vi.fn>;
+    };
+    taxRate: {
+      findMany: ReturnType<typeof vi.fn>;
+      findFirst: ReturnType<typeof vi.fn>;
+      create: ReturnType<typeof vi.fn>;
+    };
+    addonRate: {
+      findMany: ReturnType<typeof vi.fn>;
+      findFirst: ReturnType<typeof vi.fn>;
+      findUnique: ReturnType<typeof vi.fn>;
+      create: ReturnType<typeof vi.fn>;
+      update: ReturnType<typeof vi.fn>;
+    };
+  };
+  let ratesService: { clearCache: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    databaseService = {
+      platformFeeRate: {
+        findMany: vi.fn().mockResolvedValue([]),
+        findFirst: vi.fn().mockResolvedValue(null),
+        create: vi.fn(),
+      },
+      taxRate: {
+        findMany: vi.fn().mockResolvedValue([]),
+        findFirst: vi.fn().mockResolvedValue(null),
+        create: vi.fn(),
+      },
+      addonRate: {
+        findMany: vi.fn().mockResolvedValue([]),
+        findFirst: vi.fn().mockResolvedValue(null),
+        findUnique: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+      },
+    };
+
+    ratesService = { clearCache: vi.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RatesAdminService,
+        { provide: DatabaseService, useValue: databaseService },
+        { provide: RatesService, useValue: ratesService },
+      ],
+    }).compile();
+
+    service = module.get<RatesAdminService>(RatesAdminService);
+  });
+
+  describe("getAllRates", () => {
+    it("should return all rates with active status", async () => {
+      const past = new Date("2024-01-01");
+
+      databaseService.platformFeeRate.findMany.mockResolvedValue([
+        {
+          id: "pf-1",
+          feeType: "PLATFORM_SERVICE_FEE",
+          ratePercent: new Decimal("10.00"),
+          effectiveSince: past,
+          effectiveUntil: null,
+        },
+      ]);
+      databaseService.taxRate.findMany.mockResolvedValue([
+        {
+          id: "vat-1",
+          ratePercent: new Decimal("7.50"),
+          effectiveSince: past,
+          effectiveUntil: null,
+        },
+      ]);
+      databaseService.addonRate.findMany.mockResolvedValue([
+        {
+          id: "addon-1",
+          addonType: "SECURITY_DETAIL",
+          rateAmount: new Decimal("5000.00"),
+          effectiveSince: past,
+          effectiveUntil: null,
+        },
+      ]);
+
+      const result = await service.getAllRates();
+
+      expect(result.platformFeeRates).toHaveLength(1);
+      expect(result.platformFeeRates[0].ratePercent).toBe(10);
+      expect(result.platformFeeRates[0].active).toBe(true);
+      expect(result.taxRates).toHaveLength(1);
+      expect(result.taxRates[0].ratePercent).toBe(7.5);
+      expect(result.addonRates).toHaveLength(1);
+      expect(result.addonRates[0].rateAmount).toBe(5000);
+    });
+
+    it("should mark expired rates as inactive", async () => {
+      const past = new Date("2024-01-01");
+      const expired = new Date("2024-06-01");
+
+      databaseService.platformFeeRate.findMany.mockResolvedValue([
+        {
+          id: "pf-1",
+          feeType: "PLATFORM_SERVICE_FEE",
+          ratePercent: new Decimal("10.00"),
+          effectiveSince: past,
+          effectiveUntil: expired,
+        },
+      ]);
+      databaseService.taxRate.findMany.mockResolvedValue([]);
+      databaseService.addonRate.findMany.mockResolvedValue([]);
+
+      const result = await service.getAllRates();
+
+      expect(result.platformFeeRates[0].active).toBe(false);
+    });
+  });
+
+  describe("createPlatformFeeRate", () => {
+    const validDto = {
+      feeType: "PLATFORM_SERVICE_FEE" as const,
+      ratePercent: 10,
+      effectiveSince: new Date("2026-03-01"),
+      description: "New service fee",
+    };
+
+    it("should create a platform fee rate and clear cache", async () => {
+      databaseService.platformFeeRate.create.mockResolvedValue({
+        id: "pf-new",
+        ...validDto,
+        ratePercent: new Decimal("10.00"),
+        effectiveUntil: null,
+      });
+
+      const result = await service.createPlatformFeeRate(validDto);
+
+      expect(result.id).toBe("pf-new");
+      expect(result.ratePercent).toBe(10);
+      expect(ratesService.clearCache).toHaveBeenCalledOnce();
+    });
+
+    it("should throw on date overlap", async () => {
+      databaseService.platformFeeRate.findFirst.mockResolvedValue({ id: "existing" });
+
+      await expect(service.createPlatformFeeRate(validDto)).rejects.toBeInstanceOf(
+        RateDateOverlapException,
+      );
+    });
+  });
+
+  describe("createVatRate", () => {
+    const validDto = {
+      ratePercent: 7.5,
+      effectiveSince: new Date("2026-03-01"),
+    };
+
+    it("should create a VAT rate and clear cache", async () => {
+      databaseService.taxRate.create.mockResolvedValue({
+        id: "vat-new",
+        ...validDto,
+        ratePercent: new Decimal("7.50"),
+        effectiveUntil: null,
+      });
+
+      const result = await service.createVatRate(validDto);
+
+      expect(result.id).toBe("vat-new");
+      expect(result.ratePercent).toBe(7.5);
+      expect(ratesService.clearCache).toHaveBeenCalledOnce();
+    });
+
+    it("should throw on date overlap", async () => {
+      databaseService.taxRate.findFirst.mockResolvedValue({ id: "existing" });
+
+      await expect(service.createVatRate(validDto)).rejects.toBeInstanceOf(
+        RateDateOverlapException,
+      );
+    });
+  });
+
+  describe("createAddonRate", () => {
+    const validDto = {
+      addonType: "SECURITY_DETAIL" as const,
+      rateAmount: 5000,
+      effectiveSince: new Date("2026-03-01"),
+    };
+
+    it("should create an addon rate and clear cache", async () => {
+      databaseService.addonRate.create.mockResolvedValue({
+        id: "addon-new",
+        ...validDto,
+        rateAmount: new Decimal("5000.00"),
+        effectiveUntil: null,
+      });
+
+      const result = await service.createAddonRate(validDto);
+
+      expect(result.id).toBe("addon-new");
+      expect(result.rateAmount).toBe(5000);
+      expect(ratesService.clearCache).toHaveBeenCalledOnce();
+    });
+
+    it("should throw on date overlap", async () => {
+      databaseService.addonRate.findFirst.mockResolvedValue({ id: "existing" });
+
+      await expect(service.createAddonRate(validDto)).rejects.toBeInstanceOf(
+        RateDateOverlapException,
+      );
+    });
+  });
+
+  describe("endAddonRate", () => {
+    it("should end an active addon rate and clear cache", async () => {
+      databaseService.addonRate.findUnique.mockResolvedValue({
+        id: "addon-1",
+        effectiveUntil: null,
+      });
+      databaseService.addonRate.update.mockResolvedValue({
+        id: "addon-1",
+        rateAmount: new Decimal("5000.00"),
+        effectiveUntil: new Date(),
+      });
+
+      const result = await service.endAddonRate("addon-1");
+
+      expect(result.rateAmount).toBe(5000);
+      expect(databaseService.addonRate.update).toHaveBeenCalledWith({
+        where: { id: "addon-1" },
+        data: { effectiveUntil: expect.any(Date) },
+      });
+      expect(ratesService.clearCache).toHaveBeenCalledOnce();
+    });
+
+    it("should throw RateNotFoundException when addon rate does not exist", async () => {
+      databaseService.addonRate.findUnique.mockResolvedValue(null);
+
+      await expect(service.endAddonRate("nonexistent")).rejects.toBeInstanceOf(
+        RateNotFoundException,
+      );
+    });
+
+    it("should throw RateAlreadyEndedException when addon rate is already ended", async () => {
+      databaseService.addonRate.findUnique.mockResolvedValue({
+        id: "addon-1",
+        effectiveUntil: new Date("2025-01-01"),
+      });
+
+      await expect(service.endAddonRate("addon-1")).rejects.toBeInstanceOf(
+        RateAlreadyEndedException,
+      );
+    });
+  });
+});

--- a/src/modules/rates/rates-admin.service.ts
+++ b/src/modules/rates/rates-admin.service.ts
@@ -1,0 +1,241 @@
+import { Injectable, Logger } from "@nestjs/common";
+import type { AddonType, PlatformFeeType } from "@prisma/client";
+import { DatabaseService } from "../database/database.service";
+import type {
+  CreateAddonRateDto,
+  CreatePlatformFeeDto,
+  CreateVatRateDto,
+} from "./dto/rates-admin.dto";
+import {
+  RateAlreadyEndedException,
+  RateCreateFailedException,
+  RateDateOverlapException,
+  RateNotFoundException,
+  RatesException,
+  RatesFetchFailedException,
+  RateUpdateFailedException,
+} from "./rates.error";
+import { buildOverlapWindowWhere, isRateActive } from "./rates.helper";
+import { RatesService } from "./rates.service";
+
+@Injectable()
+export class RatesAdminService {
+  private readonly logger = new Logger(RatesAdminService.name);
+
+  constructor(
+    private readonly databaseService: DatabaseService,
+    private readonly ratesService: RatesService,
+  ) {}
+
+  async getAllRates() {
+    try {
+      const [platformFeeRates, taxRates, addonRates] = await Promise.all([
+        this.databaseService.platformFeeRate.findMany({
+          orderBy: [{ feeType: "asc" }, { effectiveSince: "desc" }],
+        }),
+        this.databaseService.taxRate.findMany({
+          orderBy: { effectiveSince: "desc" },
+        }),
+        this.databaseService.addonRate.findMany({
+          orderBy: [{ addonType: "asc" }, { effectiveSince: "desc" }],
+        }),
+      ]);
+
+      const now = new Date();
+
+      return {
+        platformFeeRates: platformFeeRates.map((rate) => ({
+          ...rate,
+          ratePercent: rate.ratePercent.toNumber(),
+          active: isRateActive(rate, now),
+        })),
+        taxRates: taxRates.map((rate) => ({
+          ...rate,
+          ratePercent: rate.ratePercent.toNumber(),
+          active: isRateActive(rate, now),
+        })),
+        addonRates: addonRates.map((rate) => ({
+          ...rate,
+          rateAmount: rate.rateAmount.toNumber(),
+          active: isRateActive(rate, now),
+        })),
+      };
+    } catch (error) {
+      if (error instanceof RatesException) {
+        throw error;
+      }
+      this.logger.error("Failed to get all rates", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw new RatesFetchFailedException();
+    }
+  }
+
+  async createPlatformFeeRate(dto: CreatePlatformFeeDto) {
+    try {
+      await this.assertNoPlatformFeeOverlap(dto.feeType, dto.effectiveSince, dto.effectiveUntil);
+
+      const rate = await this.databaseService.platformFeeRate.create({
+        data: {
+          feeType: dto.feeType,
+          ratePercent: dto.ratePercent,
+          effectiveSince: dto.effectiveSince,
+          effectiveUntil: dto.effectiveUntil,
+          description: dto.description,
+        },
+      });
+
+      this.ratesService.clearCache();
+      return { ...rate, ratePercent: rate.ratePercent.toNumber() };
+    } catch (error) {
+      if (error instanceof RatesException) {
+        throw error;
+      }
+      this.logger.error("Failed to create platform fee rate", {
+        dto,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw new RateCreateFailedException();
+    }
+  }
+
+  async createVatRate(dto: CreateVatRateDto) {
+    try {
+      await this.assertNoVatRateOverlap(dto.effectiveSince, dto.effectiveUntil);
+
+      const rate = await this.databaseService.taxRate.create({
+        data: {
+          ratePercent: dto.ratePercent,
+          effectiveSince: dto.effectiveSince,
+          effectiveUntil: dto.effectiveUntil,
+          description: dto.description,
+        },
+      });
+
+      this.ratesService.clearCache();
+      return { ...rate, ratePercent: rate.ratePercent.toNumber() };
+    } catch (error) {
+      if (error instanceof RatesException) {
+        throw error;
+      }
+      this.logger.error("Failed to create VAT rate", {
+        dto,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw new RateCreateFailedException();
+    }
+  }
+
+  async createAddonRate(dto: CreateAddonRateDto) {
+    try {
+      await this.assertNoAddonRateOverlap(dto.addonType, dto.effectiveSince, dto.effectiveUntil);
+
+      const rate = await this.databaseService.addonRate.create({
+        data: {
+          addonType: dto.addonType,
+          rateAmount: dto.rateAmount,
+          effectiveSince: dto.effectiveSince,
+          effectiveUntil: dto.effectiveUntil,
+          description: dto.description,
+        },
+      });
+
+      this.ratesService.clearCache();
+      return { ...rate, rateAmount: rate.rateAmount.toNumber() };
+    } catch (error) {
+      if (error instanceof RatesException) {
+        throw error;
+      }
+      this.logger.error("Failed to create addon rate", {
+        dto,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw new RateCreateFailedException();
+    }
+  }
+
+  async endAddonRate(addonRateId: string) {
+    try {
+      const existing = await this.databaseService.addonRate.findUnique({
+        where: { id: addonRateId },
+      });
+
+      if (!existing) {
+        throw new RateNotFoundException();
+      }
+
+      if (existing.effectiveUntil !== null) {
+        throw new RateAlreadyEndedException();
+      }
+
+      const rate = await this.databaseService.addonRate.update({
+        where: { id: addonRateId },
+        data: { effectiveUntil: new Date() },
+      });
+
+      this.ratesService.clearCache();
+      return { ...rate, rateAmount: rate.rateAmount.toNumber() };
+    } catch (error) {
+      if (error instanceof RatesException) {
+        throw error;
+      }
+      this.logger.error("Failed to end addon rate", {
+        addonRateId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw new RateUpdateFailedException();
+    }
+  }
+
+  private async assertNoPlatformFeeOverlap(
+    feeType: PlatformFeeType,
+    effectiveSince: Date,
+    effectiveUntil?: Date,
+  ): Promise<void> {
+    const overlapping = await this.databaseService.platformFeeRate.findFirst({
+      where: {
+        feeType,
+        ...buildOverlapWindowWhere(effectiveSince, effectiveUntil),
+      },
+    });
+
+    if (overlapping) {
+      throw new RateDateOverlapException(
+        `A ${feeType} rate already exists that overlaps with this date range`,
+      );
+    }
+  }
+
+  private async assertNoVatRateOverlap(effectiveSince: Date, effectiveUntil?: Date): Promise<void> {
+    const overlapping = await this.databaseService.taxRate.findFirst({
+      where: {
+        ...buildOverlapWindowWhere(effectiveSince, effectiveUntil),
+      },
+    });
+
+    if (overlapping) {
+      throw new RateDateOverlapException(
+        "A VAT rate already exists that overlaps with this date range",
+      );
+    }
+  }
+
+  private async assertNoAddonRateOverlap(
+    addonType: AddonType,
+    effectiveSince: Date,
+    effectiveUntil?: Date,
+  ): Promise<void> {
+    const overlapping = await this.databaseService.addonRate.findFirst({
+      where: {
+        addonType,
+        ...buildOverlapWindowWhere(effectiveSince, effectiveUntil),
+      },
+    });
+
+    if (overlapping) {
+      throw new RateDateOverlapException(
+        `A ${addonType} addon rate already exists that overlaps with this date range`,
+      );
+    }
+  }
+}

--- a/src/modules/rates/rates.controller.spec.ts
+++ b/src/modules/rates/rates.controller.spec.ts
@@ -1,0 +1,118 @@
+import { Reflector } from "@nestjs/core";
+import { Test, type TestingModule } from "@nestjs/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthService } from "../auth/auth.service";
+import { RatesController } from "./rates.controller";
+import { RatesAdminService } from "./rates-admin.service";
+
+describe("RatesController", () => {
+  let controller: RatesController;
+  let adminService: {
+    getAllRates: ReturnType<typeof vi.fn>;
+    createPlatformFeeRate: ReturnType<typeof vi.fn>;
+    createVatRate: ReturnType<typeof vi.fn>;
+    createAddonRate: ReturnType<typeof vi.fn>;
+    endAddonRate: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(async () => {
+    adminService = {
+      getAllRates: vi.fn(),
+      createPlatformFeeRate: vi.fn(),
+      createVatRate: vi.fn(),
+      createAddonRate: vi.fn(),
+      endAddonRate: vi.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [RatesController],
+      providers: [
+        { provide: RatesAdminService, useValue: adminService },
+        {
+          provide: AuthService,
+          useValue: {
+            isInitialized: true,
+            auth: {
+              api: { getSession: vi.fn().mockResolvedValue(null) },
+            },
+            getUserRoles: vi.fn().mockResolvedValue(["admin"]),
+          },
+        },
+        Reflector,
+      ],
+    }).compile();
+
+    controller = module.get<RatesController>(RatesController);
+  });
+
+  describe("getAllRates", () => {
+    it("should delegate to admin service", async () => {
+      const mockResult = { platformFeeRates: [], taxRates: [], addonRates: [] };
+      adminService.getAllRates.mockResolvedValue(mockResult);
+
+      const result = await controller.getAllRates();
+
+      expect(result).toEqual(mockResult);
+      expect(adminService.getAllRates).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("createPlatformFeeRate", () => {
+    it("should delegate to admin service with dto", async () => {
+      const dto = {
+        feeType: "PLATFORM_SERVICE_FEE" as const,
+        ratePercent: 10,
+        effectiveSince: new Date(),
+      };
+      const mockResult = { id: "pf-1", ...dto };
+      adminService.createPlatformFeeRate.mockResolvedValue(mockResult);
+
+      const result = await controller.createPlatformFeeRate(dto);
+
+      expect(result).toEqual(mockResult);
+      expect(adminService.createPlatformFeeRate).toHaveBeenCalledWith(dto);
+    });
+  });
+
+  describe("createVatRate", () => {
+    it("should delegate to admin service with dto", async () => {
+      const dto = { ratePercent: 7.5, effectiveSince: new Date() };
+      const mockResult = { id: "vat-1", ...dto };
+      adminService.createVatRate.mockResolvedValue(mockResult);
+
+      const result = await controller.createVatRate(dto);
+
+      expect(result).toEqual(mockResult);
+      expect(adminService.createVatRate).toHaveBeenCalledWith(dto);
+    });
+  });
+
+  describe("createAddonRate", () => {
+    it("should delegate to admin service with dto", async () => {
+      const dto = {
+        addonType: "SECURITY_DETAIL" as const,
+        rateAmount: 5000,
+        effectiveSince: new Date(),
+      };
+      const mockResult = { id: "addon-1", ...dto };
+      adminService.createAddonRate.mockResolvedValue(mockResult);
+
+      const result = await controller.createAddonRate(dto);
+
+      expect(result).toEqual(mockResult);
+      expect(adminService.createAddonRate).toHaveBeenCalledWith(dto);
+    });
+  });
+
+  describe("endAddonRate", () => {
+    it("should delegate to admin service with rate id", async () => {
+      const mockResult = { id: "addon-1", effectiveUntil: new Date() };
+      adminService.endAddonRate.mockResolvedValue(mockResult);
+
+      const result = await controller.endAddonRate("addon-1");
+
+      expect(result).toEqual(mockResult);
+      expect(adminService.endAddonRate).toHaveBeenCalledWith("addon-1");
+    });
+  });
+});

--- a/src/modules/rates/rates.controller.ts
+++ b/src/modules/rates/rates.controller.ts
@@ -1,0 +1,51 @@
+import { Controller, Get, HttpCode, HttpStatus, Patch, Post, UseGuards } from "@nestjs/common";
+import { ZodBody, ZodParam } from "../../common/decorators/zod-validation.decorator";
+import { ADMIN } from "../auth/auth.types";
+import { Roles } from "../auth/decorators/roles.decorator";
+import { RoleGuard } from "../auth/guards/role.guard";
+import { SessionGuard } from "../auth/guards/session.guard";
+import {
+  addonRateIdParamSchema,
+  type CreateAddonRateDto,
+  type CreatePlatformFeeDto,
+  type CreateVatRateDto,
+  createAddonRateSchema,
+  createPlatformFeeSchema,
+  createVatRateSchema,
+} from "./dto/rates-admin.dto";
+import { RatesAdminService } from "./rates-admin.service";
+
+@Controller("api/rates")
+@UseGuards(SessionGuard, RoleGuard)
+@Roles(ADMIN)
+export class RatesController {
+  constructor(private readonly ratesAdminService: RatesAdminService) {}
+
+  @Get()
+  async getAllRates() {
+    return this.ratesAdminService.getAllRates();
+  }
+
+  @Post("platform-fee")
+  @HttpCode(HttpStatus.CREATED)
+  async createPlatformFeeRate(@ZodBody(createPlatformFeeSchema) dto: CreatePlatformFeeDto) {
+    return this.ratesAdminService.createPlatformFeeRate(dto);
+  }
+
+  @Post("vat")
+  @HttpCode(HttpStatus.CREATED)
+  async createVatRate(@ZodBody(createVatRateSchema) dto: CreateVatRateDto) {
+    return this.ratesAdminService.createVatRate(dto);
+  }
+
+  @Post("addon")
+  @HttpCode(HttpStatus.CREATED)
+  async createAddonRate(@ZodBody(createAddonRateSchema) dto: CreateAddonRateDto) {
+    return this.ratesAdminService.createAddonRate(dto);
+  }
+
+  @Patch("addon/:addonRateId/end")
+  async endAddonRate(@ZodParam("addonRateId", addonRateIdParamSchema) addonRateId: string) {
+    return this.ratesAdminService.endAddonRate(addonRateId);
+  }
+}

--- a/src/modules/rates/rates.error.ts
+++ b/src/modules/rates/rates.error.ts
@@ -1,0 +1,82 @@
+import { HttpStatus } from "@nestjs/common";
+import { AppException } from "../../common/errors/app.exception";
+
+export const RatesErrorCode = {
+  RATES_FETCH_FAILED: "RATES_FETCH_FAILED",
+  RATE_NOT_FOUND: "RATE_NOT_FOUND",
+  RATE_CREATE_FAILED: "RATE_CREATE_FAILED",
+  RATE_UPDATE_FAILED: "RATE_UPDATE_FAILED",
+  RATE_DATE_OVERLAP: "RATE_DATE_OVERLAP",
+  RATE_ALREADY_ENDED: "RATE_ALREADY_ENDED",
+  RATE_VALIDATION_ERROR: "RATE_VALIDATION_ERROR",
+} as const;
+
+export class RatesException extends AppException {}
+
+export class RatesFetchFailedException extends RatesException {
+  constructor() {
+    super(
+      RatesErrorCode.RATES_FETCH_FAILED,
+      "An unexpected error occurred while fetching rates",
+      HttpStatus.INTERNAL_SERVER_ERROR,
+      { title: "Rates Fetch Failed" },
+    );
+  }
+}
+
+export class RateNotFoundException extends RatesException {
+  constructor() {
+    super(RatesErrorCode.RATE_NOT_FOUND, "Rate not found", HttpStatus.NOT_FOUND, {
+      title: "Rate Not Found",
+    });
+  }
+}
+
+export class RateCreateFailedException extends RatesException {
+  constructor() {
+    super(
+      RatesErrorCode.RATE_CREATE_FAILED,
+      "An unexpected error occurred while creating the rate",
+      HttpStatus.INTERNAL_SERVER_ERROR,
+      { title: "Rate Create Failed" },
+    );
+  }
+}
+
+export class RateUpdateFailedException extends RatesException {
+  constructor() {
+    super(
+      RatesErrorCode.RATE_UPDATE_FAILED,
+      "An unexpected error occurred while updating the rate",
+      HttpStatus.INTERNAL_SERVER_ERROR,
+      { title: "Rate Update Failed" },
+    );
+  }
+}
+
+export class RateDateOverlapException extends RatesException {
+  constructor(detail: string) {
+    super(RatesErrorCode.RATE_DATE_OVERLAP, detail, HttpStatus.CONFLICT, {
+      title: "Rate Date Overlap",
+    });
+  }
+}
+
+export class RateAlreadyEndedException extends RatesException {
+  constructor() {
+    super(
+      RatesErrorCode.RATE_ALREADY_ENDED,
+      "This rate has already been ended",
+      HttpStatus.CONFLICT,
+      { title: "Rate Already Ended" },
+    );
+  }
+}
+
+export class RateValidationException extends RatesException {
+  constructor(detail: string) {
+    super(RatesErrorCode.RATE_VALIDATION_ERROR, detail, HttpStatus.BAD_REQUEST, {
+      title: "Rate Validation Failed",
+    });
+  }
+}

--- a/src/modules/rates/rates.error.ts
+++ b/src/modules/rates/rates.error.ts
@@ -9,7 +9,6 @@ export const RatesErrorCode = {
   RATE_DATE_OVERLAP: "RATE_DATE_OVERLAP",
   RATE_ALREADY_ENDED: "RATE_ALREADY_ENDED",
   RATE_NOT_YET_ACTIVE: "RATE_NOT_YET_ACTIVE",
-  RATE_VALIDATION_ERROR: "RATE_VALIDATION_ERROR",
 } as const;
 
 export class RatesException extends AppException {}

--- a/src/modules/rates/rates.error.ts
+++ b/src/modules/rates/rates.error.ts
@@ -8,6 +8,7 @@ export const RatesErrorCode = {
   RATE_UPDATE_FAILED: "RATE_UPDATE_FAILED",
   RATE_DATE_OVERLAP: "RATE_DATE_OVERLAP",
   RATE_ALREADY_ENDED: "RATE_ALREADY_ENDED",
+  RATE_NOT_YET_ACTIVE: "RATE_NOT_YET_ACTIVE",
   RATE_VALIDATION_ERROR: "RATE_VALIDATION_ERROR",
 } as const;
 
@@ -73,10 +74,13 @@ export class RateAlreadyEndedException extends RatesException {
   }
 }
 
-export class RateValidationException extends RatesException {
-  constructor(detail: string) {
-    super(RatesErrorCode.RATE_VALIDATION_ERROR, detail, HttpStatus.BAD_REQUEST, {
-      title: "Rate Validation Failed",
-    });
+export class RateNotYetActiveException extends RatesException {
+  constructor() {
+    super(
+      RatesErrorCode.RATE_NOT_YET_ACTIVE,
+      "Cannot end a rate that has not started yet",
+      HttpStatus.CONFLICT,
+      { title: "Rate Not Yet Active" },
+    );
   }
 }

--- a/src/modules/rates/rates.helper.spec.ts
+++ b/src/modules/rates/rates.helper.spec.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { buildActiveWindowWhere, buildOverlapWindowWhere, isRateActive } from "./rates.helper";
+
+describe("rates.helper", () => {
+  describe("buildActiveWindowWhere", () => {
+    it("builds active predicate with inclusive since and exclusive until", () => {
+      const at = new Date("2026-03-01T00:00:00.000Z");
+      const where = buildActiveWindowWhere(at);
+
+      expect(where).toEqual({
+        effectiveSince: { lte: at },
+        OR: [{ effectiveUntil: { gt: at } }, { effectiveUntil: null }],
+      });
+    });
+  });
+
+  describe("buildOverlapWindowWhere", () => {
+    it("builds overlap predicate with provided end date and lt/gt comparisons", () => {
+      const since = new Date("2026-03-01T00:00:00.000Z");
+      const until = new Date("2026-06-01T00:00:00.000Z");
+      const where = buildOverlapWindowWhere(since, until);
+
+      expect(where).toEqual({
+        effectiveSince: { lt: until },
+        OR: [{ effectiveUntil: { gt: since } }, { effectiveUntil: null }],
+      });
+    });
+
+    it("uses far future date when effectiveUntil is undefined", () => {
+      const since = new Date("2026-03-01T00:00:00.000Z");
+      const where = buildOverlapWindowWhere(since);
+
+      expect(where.effectiveSince).toEqual({ lt: new Date("9999-12-31T00:00:00.000Z") });
+      expect(where.OR).toEqual([{ effectiveUntil: { gt: since } }, { effectiveUntil: null }]);
+    });
+
+    it("builds predicates that exclude adjacent non-overlapping windows", () => {
+      const since = new Date("2026-03-01T00:00:00.000Z");
+      const until = new Date("2026-06-01T00:00:00.000Z");
+      const adjacentExisting = {
+        effectiveSince: until,
+        effectiveUntil: new Date("2026-09-01T00:00:00.000Z"),
+      };
+      const where = buildOverlapWindowWhere(since, until);
+
+      const leftSide = adjacentExisting.effectiveSince < (where.effectiveSince.lt as Date);
+      const rightSide =
+        (adjacentExisting.effectiveUntil !== null &&
+          adjacentExisting.effectiveUntil >
+            (where.OR[0] as { effectiveUntil: { gt: Date } }).effectiveUntil.gt) ||
+        adjacentExisting.effectiveUntil === null;
+
+      expect(leftSide).toBe(false);
+      expect(rightSide).toBe(true);
+      expect(leftSide && rightSide).toBe(false);
+    });
+
+    it("builds predicates that include truly overlapping windows", () => {
+      const since = new Date("2026-03-01T00:00:00.000Z");
+      const until = new Date("2026-06-01T00:00:00.000Z");
+      const overlappingExisting = {
+        effectiveSince: new Date("2026-05-15T00:00:00.000Z"),
+        effectiveUntil: new Date("2026-07-01T00:00:00.000Z"),
+      };
+      const where = buildOverlapWindowWhere(since, until);
+
+      const leftSide = overlappingExisting.effectiveSince < (where.effectiveSince.lt as Date);
+      const rightSide =
+        (overlappingExisting.effectiveUntil !== null &&
+          overlappingExisting.effectiveUntil >
+            (where.OR[0] as { effectiveUntil: { gt: Date } }).effectiveUntil.gt) ||
+        overlappingExisting.effectiveUntil === null;
+
+      expect(leftSide).toBe(true);
+      expect(rightSide).toBe(true);
+      expect(leftSide && rightSide).toBe(true);
+    });
+
+    it("OR branch matches open-ended existing windows", () => {
+      const since = new Date("2026-03-01T00:00:00.000Z");
+      const where = buildOverlapWindowWhere(since, new Date("2026-06-01T00:00:00.000Z"));
+
+      expect(where.OR[1]).toEqual({ effectiveUntil: null });
+    });
+  });
+
+  describe("isRateActive", () => {
+    it("treats rates starting exactly at query time as active", () => {
+      const at = new Date("2026-03-01T00:00:00.000Z");
+      const active = isRateActive({ effectiveSince: at, effectiveUntil: null }, at);
+
+      expect(active).toBe(true);
+    });
+
+    it("treats rates ending exactly at query time as inactive", () => {
+      const at = new Date("2026-03-01T00:00:00.000Z");
+      const active = isRateActive(
+        { effectiveSince: new Date("2026-02-01T00:00:00.000Z"), effectiveUntil: at },
+        at,
+      );
+
+      expect(active).toBe(false);
+    });
+
+    it("treats open-ended rates as active for times after effectiveSince", () => {
+      const since = new Date("2026-03-01T00:00:00.000Z");
+      const at = new Date("2026-04-01T00:00:00.000Z");
+      const active = isRateActive({ effectiveSince: since, effectiveUntil: null }, at);
+
+      expect(active).toBe(true);
+    });
+  });
+});

--- a/src/modules/rates/rates.helper.ts
+++ b/src/modules/rates/rates.helper.ts
@@ -1,0 +1,21 @@
+import { EffectiveWindowRate } from "./rates.interface";
+
+const FAR_FUTURE_DATE_ISO = "9999-12-31T00:00:00.000Z";
+
+export function buildActiveWindowWhere(at: Date) {
+  return {
+    effectiveSince: { lte: at },
+    OR: [{ effectiveUntil: { gt: at } }, { effectiveUntil: null }],
+  };
+}
+
+export function buildOverlapWindowWhere(effectiveSince: Date, effectiveUntil?: Date) {
+  return {
+    effectiveSince: { lt: effectiveUntil ?? new Date(FAR_FUTURE_DATE_ISO) },
+    OR: [{ effectiveUntil: { gt: effectiveSince } }, { effectiveUntil: null }],
+  };
+}
+
+export function isRateActive(rate: EffectiveWindowRate, at: Date): boolean {
+  return rate.effectiveSince <= at && (rate.effectiveUntil === null || rate.effectiveUntil > at);
+}

--- a/src/modules/rates/rates.interface.ts
+++ b/src/modules/rates/rates.interface.ts
@@ -14,3 +14,8 @@ export interface PlatformRates {
   /** Security detail addon rate (flat amount per leg) */
   securityDetailRate: Decimal;
 }
+
+export interface EffectiveWindowRate {
+  effectiveSince: Date;
+  effectiveUntil: Date | null;
+}

--- a/src/modules/rates/rates.module.ts
+++ b/src/modules/rates/rates.module.ts
@@ -1,10 +1,14 @@
 import { Module } from "@nestjs/common";
+import { AuthModule } from "../auth/auth.module";
 import { DatabaseModule } from "../database/database.module";
+import { RatesController } from "./rates.controller";
 import { RatesService } from "./rates.service";
+import { RatesAdminService } from "./rates-admin.service";
 
 @Module({
-  imports: [DatabaseModule],
-  providers: [RatesService],
+  imports: [DatabaseModule, AuthModule],
+  controllers: [RatesController],
+  providers: [RatesService, RatesAdminService],
   exports: [RatesService],
 })
 export class RatesModule {}

--- a/src/modules/rates/rates.service.spec.ts
+++ b/src/modules/rates/rates.service.spec.ts
@@ -144,14 +144,11 @@ describe("RatesService", () => {
     it("should re-fetch rates after cache TTL expires", async () => {
       vi.useFakeTimers();
 
-      // First call - fetches from database
       await service.getRates();
       expect(databaseService.platformFeeRate.findMany).toHaveBeenCalledTimes(1);
 
-      // Advance time past TTL (5 minutes + 1ms)
       vi.advanceTimersByTime(5 * 60 * 1000 + 1);
 
-      // Third call - should re-fetch due to TTL expiration
       await service.getRates();
       expect(databaseService.platformFeeRate.findMany).toHaveBeenCalledTimes(2);
 
@@ -161,14 +158,11 @@ describe("RatesService", () => {
 
   describe("clearCache", () => {
     it("should clear the cache and force re-fetch on next getRates call", async () => {
-      // First call - fetches from database
       await service.getRates();
       expect(databaseService.platformFeeRate.findMany).toHaveBeenCalledTimes(1);
 
-      // Clear cache
       service.clearCache();
 
-      // Second call - should fetch again
       await service.getRates();
       expect(databaseService.platformFeeRate.findMany).toHaveBeenCalledTimes(2);
     });

--- a/src/modules/rates/rates.service.ts
+++ b/src/modules/rates/rates.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { DatabaseService } from "../database/database.service";
+import { buildActiveWindowWhere } from "./rates.helper";
 import type { PlatformRates } from "./rates.interface";
 
 /**
@@ -48,16 +49,14 @@ export class RatesService {
       this.databaseService.platformFeeRate.findMany({
         where: {
           feeType: { in: ["PLATFORM_SERVICE_FEE", "FLEET_OWNER_COMMISSION"] },
-          effectiveSince: { lte: currentDate },
-          OR: [{ effectiveUntil: { gt: currentDate } }, { effectiveUntil: null }],
+          ...buildActiveWindowWhere(currentDate),
         },
         orderBy: { effectiveSince: "desc" },
       }),
       // Get VAT rate
       this.databaseService.taxRate.findFirst({
         where: {
-          effectiveSince: { lte: currentDate },
-          OR: [{ effectiveUntil: { gt: currentDate } }, { effectiveUntil: null }],
+          ...buildActiveWindowWhere(currentDate),
         },
         orderBy: { effectiveSince: "desc" },
       }),
@@ -65,8 +64,7 @@ export class RatesService {
       this.databaseService.addonRate.findFirst({
         where: {
           addonType: "SECURITY_DETAIL",
-          effectiveSince: { lte: currentDate },
-          OR: [{ effectiveUntil: { gt: currentDate } }, { effectiveUntil: null }],
+          ...buildActiveWindowWhere(currentDate),
         },
         orderBy: { effectiveSince: "desc" },
       }),

--- a/test/rates.e2e-spec.ts
+++ b/test/rates.e2e-spec.ts
@@ -1,0 +1,268 @@
+import { HttpStatus, type INestApplication } from "@nestjs/common";
+import { HttpAdapterHost } from "@nestjs/core";
+import { Test, type TestingModule } from "@nestjs/testing";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { AppModule } from "../src/app.module";
+import { GlobalExceptionFilter } from "../src/common/filters/global-exception.filter";
+import { AuthEmailService } from "../src/modules/auth/auth-email.service";
+import { DatabaseService } from "../src/modules/database/database.service";
+import { TestDataFactory, uniqueEmail } from "./helpers";
+
+describe("Rates Admin E2E Tests", () => {
+  let app: INestApplication;
+  let databaseService: DatabaseService;
+  let factory: TestDataFactory;
+  let adminCookie: string;
+  let nonAdminCookie: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(AuthEmailService)
+      .useValue({ sendOTPEmail: async () => undefined })
+      .compile();
+
+    app = moduleFixture.createNestApplication({ logger: false });
+    const httpAdapterHost = app.get(HttpAdapterHost);
+    app.useGlobalFilters(new GlobalExceptionFilter(httpAdapterHost));
+    await app.init();
+
+    databaseService = app.get(DatabaseService);
+    factory = new TestDataFactory(databaseService, app);
+
+    const adminAuth = await factory.createAuthenticatedAdmin(uniqueEmail("rates-admin"));
+    adminCookie = adminAuth.cookie;
+
+    const nonAdminAuth = await factory.authenticateAndGetUser(
+      uniqueEmail("rates-nonadmin"),
+      "user",
+    );
+    nonAdminCookie = nonAdminAuth.cookie;
+
+    await factory.createPlatformRates();
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  describe("GET /api/rates", () => {
+    it("should reject unauthenticated requests", async () => {
+      const response = await request(app.getHttpServer()).get("/api/rates");
+      expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+    });
+
+    it("should reject non-admin users", async () => {
+      const response = await request(app.getHttpServer())
+        .get("/api/rates")
+        .set("Cookie", nonAdminCookie);
+      expect(response.status).toBe(HttpStatus.FORBIDDEN);
+    });
+
+    it("should return all rates for admin", async () => {
+      const response = await request(app.getHttpServer())
+        .get("/api/rates")
+        .set("Cookie", adminCookie);
+
+      expect(response.status).toBe(HttpStatus.OK);
+      expect(response.body).toHaveProperty("platformFeeRates");
+      expect(response.body).toHaveProperty("taxRates");
+      expect(response.body).toHaveProperty("addonRates");
+      expect(response.body.platformFeeRates.length).toBeGreaterThanOrEqual(2);
+      expect(response.body.taxRates.length).toBeGreaterThanOrEqual(1);
+      expect(response.body.addonRates.length).toBeGreaterThanOrEqual(1);
+
+      const activeServiceFee = response.body.platformFeeRates.find(
+        (r: { feeType: string; active: boolean }) =>
+          r.feeType === "PLATFORM_SERVICE_FEE" && r.active,
+      );
+      expect(activeServiceFee).toBeDefined();
+      expect(activeServiceFee.ratePercent).toBe(10);
+    });
+  });
+
+  describe("POST /api/rates/platform-fee", () => {
+    it("should reject non-admin users", async () => {
+      const response = await request(app.getHttpServer())
+        .post("/api/rates/platform-fee")
+        .set("Cookie", nonAdminCookie)
+        .send({
+          feeType: "PLATFORM_SERVICE_FEE",
+          ratePercent: 12,
+          effectiveSince: "2030-01-01",
+        });
+      expect(response.status).toBe(HttpStatus.FORBIDDEN);
+    });
+
+    it("should reject invalid date ranges", async () => {
+      const response = await request(app.getHttpServer())
+        .post("/api/rates/platform-fee")
+        .set("Cookie", adminCookie)
+        .send({
+          feeType: "PLATFORM_SERVICE_FEE",
+          ratePercent: 12,
+          effectiveSince: "2030-06-01",
+          effectiveUntil: "2030-01-01",
+        });
+      expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+    });
+
+    it("should reject overlapping platform fee rates", async () => {
+      const response = await request(app.getHttpServer())
+        .post("/api/rates/platform-fee")
+        .set("Cookie", adminCookie)
+        .send({
+          feeType: "PLATFORM_SERVICE_FEE",
+          ratePercent: 12,
+          effectiveSince: "2021-01-01",
+        });
+      expect(response.status).toBe(HttpStatus.CONFLICT);
+    });
+
+    it("should create a new platform fee rate for a future window", async () => {
+      await databaseService.platformFeeRate.updateMany({
+        where: { feeType: "PLATFORM_SERVICE_FEE", effectiveUntil: null },
+        data: { effectiveUntil: new Date("2039-12-31") },
+      });
+
+      const response = await request(app.getHttpServer())
+        .post("/api/rates/platform-fee")
+        .set("Cookie", adminCookie)
+        .send({
+          feeType: "PLATFORM_SERVICE_FEE",
+          ratePercent: 12,
+          effectiveSince: "2040-01-01",
+          effectiveUntil: "2040-06-01",
+          description: "Temporary fee increase",
+        });
+
+      expect(response.status).toBe(HttpStatus.CREATED);
+      expect(response.body.feeType).toBe("PLATFORM_SERVICE_FEE");
+      expect(response.body.ratePercent).toBe(12);
+      expect(response.body.description).toBe("Temporary fee increase");
+    });
+  });
+
+  describe("POST /api/rates/vat", () => {
+    it("should reject overlapping VAT rates", async () => {
+      const response = await request(app.getHttpServer())
+        .post("/api/rates/vat")
+        .set("Cookie", adminCookie)
+        .send({
+          ratePercent: 10,
+          effectiveSince: "2021-01-01",
+        });
+      expect(response.status).toBe(HttpStatus.CONFLICT);
+    });
+
+    it("should create a new VAT rate for a future window", async () => {
+      await databaseService.taxRate.updateMany({
+        where: { effectiveUntil: null },
+        data: { effectiveUntil: new Date("2040-12-31") },
+      });
+
+      const response = await request(app.getHttpServer())
+        .post("/api/rates/vat")
+        .set("Cookie", adminCookie)
+        .send({
+          ratePercent: 10,
+          effectiveSince: "2041-01-01",
+          effectiveUntil: "2041-12-31",
+          description: "New VAT rate",
+        });
+
+      expect(response.status).toBe(HttpStatus.CREATED);
+      expect(response.body.ratePercent).toBe(10);
+    });
+  });
+
+  describe("POST /api/rates/addon", () => {
+    it("should reject overlapping addon rates", async () => {
+      const response = await request(app.getHttpServer())
+        .post("/api/rates/addon")
+        .set("Cookie", adminCookie)
+        .send({
+          addonType: "SECURITY_DETAIL",
+          rateAmount: 20000,
+          effectiveSince: "2021-01-01",
+        });
+      expect(response.status).toBe(HttpStatus.CONFLICT);
+    });
+
+    it("should create a new addon rate for a future window", async () => {
+      await databaseService.addonRate.updateMany({
+        where: { addonType: "SECURITY_DETAIL", effectiveUntil: null },
+        data: { effectiveUntil: new Date("2041-12-31") },
+      });
+
+      const response = await request(app.getHttpServer())
+        .post("/api/rates/addon")
+        .set("Cookie", adminCookie)
+        .send({
+          addonType: "SECURITY_DETAIL",
+          rateAmount: 20000,
+          effectiveSince: "2042-01-01",
+          effectiveUntil: "2042-12-31",
+          description: "New security detail rate",
+        });
+
+      expect(response.status).toBe(HttpStatus.CREATED);
+      expect(response.body.rateAmount).toBe(20000);
+      expect(response.body.addonType).toBe("SECURITY_DETAIL");
+    });
+  });
+
+  describe("PATCH /api/rates/addon/:addonRateId/end", () => {
+    it("should reject non-admin users", async () => {
+      const response = await request(app.getHttpServer())
+        .patch("/api/rates/addon/nonexistent/end")
+        .set("Cookie", nonAdminCookie);
+      expect(response.status).toBe(HttpStatus.FORBIDDEN);
+    });
+
+    it("should return 404 for non-existent addon rate", async () => {
+      const fakeId = "cm00000000000000000000000";
+      const response = await request(app.getHttpServer())
+        .patch(`/api/rates/addon/${fakeId}/end`)
+        .set("Cookie", adminCookie);
+      expect(response.status).toBe(HttpStatus.NOT_FOUND);
+    });
+
+    it("should end an active addon rate", async () => {
+      const addonRate = await databaseService.addonRate.create({
+        data: {
+          addonType: "SECURITY_DETAIL",
+          rateAmount: 25000,
+          effectiveSince: new Date("2043-01-01"),
+          effectiveUntil: null,
+        },
+      });
+
+      const response = await request(app.getHttpServer())
+        .patch(`/api/rates/addon/${addonRate.id}/end`)
+        .set("Cookie", adminCookie);
+
+      expect(response.status).toBe(HttpStatus.OK);
+      expect(response.body.effectiveUntil).toBeDefined();
+    });
+
+    it("should reject ending an already-ended addon rate", async () => {
+      const addonRate = await databaseService.addonRate.create({
+        data: {
+          addonType: "SECURITY_DETAIL",
+          rateAmount: 30000,
+          effectiveSince: new Date("2044-01-01"),
+          effectiveUntil: new Date("2044-06-01"),
+        },
+      });
+
+      const response = await request(app.getHttpServer())
+        .patch(`/api/rates/addon/${addonRate.id}/end`)
+        .set("Cookie", adminCookie);
+
+      expect(response.status).toBe(HttpStatus.CONFLICT);
+    });
+  });
+});


### PR DESCRIPTION
Introduces admin-only rates endpoints for listing historical/current rates, creating platform/VAT/addon rates, and ending addon rates with overlap protection and cache invalidation. Moves date-order validation into Zod DTO refinements, extracts shared effective-window helpers to prevent drift, and expands unit/e2e coverage; also normalizes dashboard earnings bucket boundaries to UTC with regression tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches pricing/tax configuration and introduces new admin write endpoints; overlap checks and cache invalidation reduce risk, but mistakes could affect fee calculations across bookings.
> 
> **Overview**
> **Adds admin-only rate management APIs** under `api/rates` to list all historical/current platform/VAT/addon rates (with an `active` flag), create new rates, and end an addon rate early; all writes run in serializable transactions, prevent effective-window overlaps, and clear the `RatesService` cache.
> 
> Centralizes effective-window logic by extracting shared helpers for “active” and “overlap” predicates and moving date-range ordering validation into Zod DTO refinements, plus wires `RatesModule` into `AppModule` and expands unit + e2e coverage.
> 
> Separately, dashboard earnings bucketing now uses **UTC** day/week/month boundaries (with new regression tests) to avoid timezone-dependent grouping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fde95bb3c086a27fbc66dd293e927d0c72867a68. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->