### PR TITLE
feat: filling in the blanks

### DIFF
--- a/.env.e2e
+++ b/.env.e2e
@@ -33,4 +33,5 @@ AWS_REGION=us-east-1
 AWS_SECRET_ACCESS_KEY=test-secret-access-key
 FLIGHTAWARE_API_KEY=flightaware-api-key
 GOOGLE_DISTANCE_MATRIX_API_KEY=google-mapa-api-key
+OPENAI_API_KEY=test-openai-api-key
 SENDER_NAME=Yomide

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "helmet": "^8.1.0",
     "ioredis": "^5.7.0",
     "nestjs-pino": "^4.5.0",
+    "openai": "^6.22.0",
     "pino-http": "^11.0.0",
     "pino-opentelemetry-transport": "^2.0.0",
     "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -102,16 +102,16 @@
     "overrides": {
       "body-parser": "2.2.1",
       "lodash": "4.17.23",
-      "minimatch": "10.2.2",
+      "minimatch": "10.2.3",
       "qs": "6.14.2",
-      "rollup": "4.53.5"
+      "rollup": "4.59.0"
     }
   },
   "overrides": {
     "body-parser": "2.2.1",
     "lodash": "4.17.23",
-    "minimatch": "10.2.2",
+    "minimatch": "10.2.3",
     "qs": "6.14.2",
-    "rollup": "4.53.5"
+    "rollup": "4.59.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -100,7 +100,18 @@
   },
   "pnpm": {
     "overrides": {
-      "minimatch": "10.2.1"
+      "body-parser": "2.2.1",
+      "lodash": "4.17.23",
+      "minimatch": "10.2.2",
+      "qs": "6.14.2",
+      "rollup": "4.53.5"
     }
+  },
+  "overrides": {
+    "body-parser": "2.2.1",
+    "lodash": "4.17.23",
+    "minimatch": "10.2.2",
+    "qs": "6.14.2",
+    "rollup": "4.53.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,9 +7,9 @@ settings:
 overrides:
   body-parser: 2.2.1
   lodash: 4.17.23
-  minimatch: 10.2.2
+  minimatch: 10.2.3
   qs: 6.14.2
-  rollup: 4.53.5
+  rollup: 4.59.0
 
 importers:
 
@@ -210,7 +210,7 @@ importers:
         version: 5.9.3
       unplugin-swc:
         specifier: ^1.5.7
-        version: 1.5.8(@swc/core@1.15.0)(rollup@4.53.5)
+        version: 1.5.8(@swc/core@1.15.0)(rollup@4.59.0)
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@5.9.3)(vite@7.2.1(@types/node@20.19.24)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.1))
@@ -1896,118 +1896,133 @@ packages:
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      rollup: 4.53.5
+      rollup: 4.59.0
     peerDependenciesMeta:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.53.5':
-    resolution: {integrity: sha512-iDGS/h7D8t7tvZ1t6+WPK04KD0MwzLZrG0se1hzBjSi5fyxlsiggoJHwh18PCFNn7tG43OWb6pdZ6Y+rMlmyNQ==}
+  '@rollup/rollup-android-arm-eabi@4.59.0':
+    resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.53.5':
-    resolution: {integrity: sha512-wrSAViWvZHBMMlWk6EJhvg8/rjxzyEhEdgfMMjREHEq11EtJ6IP6yfcCH57YAEca2Oe3FNCE9DSTgU70EIGmVw==}
+  '@rollup/rollup-android-arm64@4.59.0':
+    resolution: {integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.53.5':
-    resolution: {integrity: sha512-S87zZPBmRO6u1YXQLwpveZm4JfPpAa6oHBX7/ghSiGH3rz/KDgAu1rKdGutV+WUI6tKDMbaBJomhnT30Y2t4VQ==}
+  '@rollup/rollup-darwin-arm64@4.59.0':
+    resolution: {integrity: sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.53.5':
-    resolution: {integrity: sha512-YTbnsAaHo6VrAczISxgpTva8EkfQus0VPEVJCEaboHtZRIb6h6j0BNxRBOwnDciFTZLDPW5r+ZBmhL/+YpTZgA==}
+  '@rollup/rollup-darwin-x64@4.59.0':
+    resolution: {integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.53.5':
-    resolution: {integrity: sha512-1T8eY2J8rKJWzaznV7zedfdhD1BqVs1iqILhmHDq/bqCUZsrMt+j8VCTHhP0vdfbHK3e1IQ7VYx3jlKqwlf+vw==}
+  '@rollup/rollup-freebsd-arm64@4.59.0':
+    resolution: {integrity: sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.53.5':
-    resolution: {integrity: sha512-sHTiuXyBJApxRn+VFMaw1U+Qsz4kcNlxQ742snICYPrY+DDL8/ZbaC4DVIB7vgZmp3jiDaKA0WpBdP0aqPJoBQ==}
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    resolution: {integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.53.5':
-    resolution: {integrity: sha512-dV3T9MyAf0w8zPVLVBptVlzaXxka6xg1f16VAQmjg+4KMSTWDvhimI/Y6mp8oHwNrmnmVl9XxJ/w/mO4uIQONA==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.53.5':
-    resolution: {integrity: sha512-wIGYC1x/hyjP+KAu9+ewDI+fi5XSNiUi9Bvg6KGAh2TsNMA3tSEs+Sh6jJ/r4BV/bx/CyWu2ue9kDnIdRyafcQ==}
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.53.5':
-    resolution: {integrity: sha512-Y+qVA0D9d0y2FRNiG9oM3Hut/DgODZbU9I8pLLPwAsU0tUKZ49cyV1tzmB/qRbSzGvY8lpgGkJuMyuhH7Ma+Vg==}
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.53.5':
-    resolution: {integrity: sha512-juaC4bEgJsyFVfqhtGLz8mbopaWD+WeSOYr5E16y+1of6KQjc0BpwZLuxkClqY1i8sco+MdyoXPNiCkQou09+g==}
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-gnu@4.53.5':
-    resolution: {integrity: sha512-rIEC0hZ17A42iXtHX+EPJVL/CakHo+tT7W0pbzdAGuWOt2jxDFh7A/lRhsNHBcqL4T36+UiAgwO8pbmn3dE8wA==}
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.53.5':
-    resolution: {integrity: sha512-T7l409NhUE552RcAOcmJHj3xyZ2h7vMWzcwQI0hvn5tqHh3oSoclf9WgTl+0QqffWFG8MEVZZP1/OBglKZx52Q==}
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
+    resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.53.5':
-    resolution: {integrity: sha512-7OK5/GhxbnrMcxIFoYfhV/TkknarkYC1hqUw1wU2xUN3TVRLNT5FmBv4KkheSG2xZ6IEbRAhTooTV2+R5Tk0lQ==}
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-musl@4.53.5':
-    resolution: {integrity: sha512-GwuDBE/PsXaTa76lO5eLJTyr2k8QkPipAyOrs4V/KJufHCZBJ495VCGJol35grx9xryk4V+2zd3Ri+3v7NPh+w==}
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.53.5':
-    resolution: {integrity: sha512-IAE1Ziyr1qNfnmiQLHBURAD+eh/zH1pIeJjeShleII7Vj8kyEm2PF77o+lf3WTHDpNJcu4IXJxNO0Zluro8bOw==}
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.53.5':
-    resolution: {integrity: sha512-Pg6E+oP7GvZ4XwgRJBuSXZjcqpIW3yCBhK4BcsANvb47qMvAbCjR6E+1a/U2WXz1JJxp9/4Dno3/iSJLcm5auw==}
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.53.5':
-    resolution: {integrity: sha512-txGtluxDKTxaMDzUduGP0wdfng24y1rygUMnmlUJ88fzCCULCLn7oE5kb2+tRB+MWq1QDZT6ObT5RrR8HFRKqg==}
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-openharmony-arm64@4.53.5':
-    resolution: {integrity: sha512-3DFiLPnTxiOQV993fMc+KO8zXHTcIjgaInrqlG8zDp1TlhYl6WgrOHuJkJQ6M8zHEcntSJsUp1XFZSY8C1DYbg==}
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.59.0':
+    resolution: {integrity: sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.53.5':
-    resolution: {integrity: sha512-nggc/wPpNTgjGg75hu+Q/3i32R00Lq1B6N1DO7MCU340MRKL3WZJMjA9U4K4gzy3dkZPXm9E1Nc81FItBVGRlA==}
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    resolution: {integrity: sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.53.5':
-    resolution: {integrity: sha512-U/54pTbdQpPLBdEzCT6NBCFAfSZMvmjr0twhnD9f4EIvlm9wy3jjQ38yQj1AGznrNO65EWQMgm/QUjuIVrYF9w==}
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    resolution: {integrity: sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.53.5':
-    resolution: {integrity: sha512-2NqKgZSuLH9SXBBV2dWNRCZmocgSOx8OJSdpRaEcRlIfX8YrKxUT6z0F1NpvDVhOsl190UFTRh2F2WDWWCYp3A==}
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.53.5':
-    resolution: {integrity: sha512-JRpZUhCfhZ4keB5v0fe02gQJy05GqboPOaxvjugW04RLSYYoB/9t2lx2u/tMs/Na/1NXfY8QYjgRljRpN+MjTQ==}
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
+    resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
     cpu: [x64]
     os: [win32]
 
@@ -4024,8 +4039,8 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
-  minimatch@10.2.2:
-    resolution: {integrity: sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==}
+  minimatch@10.2.3:
+    resolution: {integrity: sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==}
     engines: {node: 18 || 20 || >=22}
 
   minimist@1.2.8:
@@ -4500,8 +4515,8 @@ packages:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
 
-  rollup@4.53.5:
-    resolution: {integrity: sha512-iTNAbFSlRpcHeeWu73ywU/8KuU/LZmNCSxp6fjQkJBD3ivUb8tpDrXhIxEzA05HlYMEwmtaUnb3RP+YNv162OQ==}
+  rollup@4.59.0:
+    resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -7341,78 +7356,87 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  '@rollup/pluginutils@5.3.0(rollup@4.53.5)':
+  '@rollup/pluginutils@5.3.0(rollup@4.59.0)':
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.3
     optionalDependencies:
-      rollup: 4.53.5
+      rollup: 4.59.0
 
-  '@rollup/rollup-android-arm-eabi@4.53.5':
+  '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.53.5':
+  '@rollup/rollup-android-arm64@4.59.0':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.53.5':
+  '@rollup/rollup-darwin-arm64@4.59.0':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.53.5':
+  '@rollup/rollup-darwin-x64@4.59.0':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.53.5':
+  '@rollup/rollup-freebsd-arm64@4.59.0':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.53.5':
+  '@rollup/rollup-freebsd-x64@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.53.5':
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.53.5':
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.53.5':
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.53.5':
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.53.5':
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.53.5':
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.53.5':
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.53.5':
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.53.5':
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.53.5':
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.53.5':
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.53.5':
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.53.5':
+  '@rollup/rollup-linux-x64-musl@4.59.0':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.53.5':
+  '@rollup/rollup-openbsd-x64@4.59.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.53.5':
+  '@rollup/rollup-openharmony-arm64@4.59.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.53.5':
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
   '@selderee/plugin-htmlparser2@0.11.0':
@@ -9064,7 +9088,7 @@ snapshots:
 
   filelist@1.0.4:
     dependencies:
-      minimatch: 10.2.2
+      minimatch: 10.2.3
 
   fill-range@7.1.1:
     dependencies:
@@ -9099,7 +9123,7 @@ snapshots:
       deepmerge: 4.3.1
       fs-extra: 10.1.0
       memfs: 3.5.3
-      minimatch: 10.2.2
+      minimatch: 10.2.3
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
       semver: 7.7.3
@@ -9222,7 +9246,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
-      minimatch: 10.2.2
+      minimatch: 10.2.3
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
@@ -9653,7 +9677,7 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
-  minimatch@10.2.2:
+  minimatch@10.2.3:
     dependencies:
       brace-expansion: 5.0.2
 
@@ -10096,7 +10120,7 @@ snapshots:
 
   readdir-glob@1.1.3:
     dependencies:
-      minimatch: 10.2.2
+      minimatch: 10.2.3
 
   readdirp@3.6.0:
     dependencies:
@@ -10150,32 +10174,35 @@ snapshots:
 
   retry@0.12.0: {}
 
-  rollup@4.53.5:
+  rollup@4.59.0:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.53.5
-      '@rollup/rollup-android-arm64': 4.53.5
-      '@rollup/rollup-darwin-arm64': 4.53.5
-      '@rollup/rollup-darwin-x64': 4.53.5
-      '@rollup/rollup-freebsd-arm64': 4.53.5
-      '@rollup/rollup-freebsd-x64': 4.53.5
-      '@rollup/rollup-linux-arm-gnueabihf': 4.53.5
-      '@rollup/rollup-linux-arm-musleabihf': 4.53.5
-      '@rollup/rollup-linux-arm64-gnu': 4.53.5
-      '@rollup/rollup-linux-arm64-musl': 4.53.5
-      '@rollup/rollup-linux-loong64-gnu': 4.53.5
-      '@rollup/rollup-linux-ppc64-gnu': 4.53.5
-      '@rollup/rollup-linux-riscv64-gnu': 4.53.5
-      '@rollup/rollup-linux-riscv64-musl': 4.53.5
-      '@rollup/rollup-linux-s390x-gnu': 4.53.5
-      '@rollup/rollup-linux-x64-gnu': 4.53.5
-      '@rollup/rollup-linux-x64-musl': 4.53.5
-      '@rollup/rollup-openharmony-arm64': 4.53.5
-      '@rollup/rollup-win32-arm64-msvc': 4.53.5
-      '@rollup/rollup-win32-ia32-msvc': 4.53.5
-      '@rollup/rollup-win32-x64-gnu': 4.53.5
-      '@rollup/rollup-win32-x64-msvc': 4.53.5
+      '@rollup/rollup-android-arm-eabi': 4.59.0
+      '@rollup/rollup-android-arm64': 4.59.0
+      '@rollup/rollup-darwin-arm64': 4.59.0
+      '@rollup/rollup-darwin-x64': 4.59.0
+      '@rollup/rollup-freebsd-arm64': 4.59.0
+      '@rollup/rollup-freebsd-x64': 4.59.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.59.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.59.0
+      '@rollup/rollup-linux-arm64-gnu': 4.59.0
+      '@rollup/rollup-linux-arm64-musl': 4.59.0
+      '@rollup/rollup-linux-loong64-gnu': 4.59.0
+      '@rollup/rollup-linux-loong64-musl': 4.59.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.59.0
+      '@rollup/rollup-linux-ppc64-musl': 4.59.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.59.0
+      '@rollup/rollup-linux-riscv64-musl': 4.59.0
+      '@rollup/rollup-linux-s390x-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-musl': 4.59.0
+      '@rollup/rollup-openbsd-x64': 4.59.0
+      '@rollup/rollup-openharmony-arm64': 4.59.0
+      '@rollup/rollup-win32-arm64-msvc': 4.59.0
+      '@rollup/rollup-win32-ia32-msvc': 4.59.0
+      '@rollup/rollup-win32-x64-gnu': 4.59.0
+      '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
   rou3@0.7.12: {}
@@ -10532,7 +10559,7 @@ snapshots:
     dependencies:
       '@istanbuljs/schema': 0.1.3
       glob: 10.4.5
-      minimatch: 10.2.2
+      minimatch: 10.2.3
 
   testcontainers@11.8.0:
     dependencies:
@@ -10681,9 +10708,9 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-swc@1.5.8(@swc/core@1.15.0)(rollup@4.53.5):
+  unplugin-swc@1.5.8(@swc/core@1.15.0)(rollup@4.59.0):
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.53.5)
+      '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
       '@swc/core': 1.15.0
       load-tsconfig: 0.2.5
       unplugin: 2.3.10
@@ -10760,7 +10787,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
-      rollup: 4.53.5
+      rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 20.19.24

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       nestjs-pino:
         specifier: ^4.5.0
         version: 4.5.0(@nestjs/common@11.1.8(reflect-metadata@0.1.14)(rxjs@7.8.2))(pino-http@11.0.0)(pino@10.3.0)(rxjs@7.8.2)
+      openai:
+        specifier: ^6.22.0
+        version: 6.22.0(zod@4.1.12)
       pino-http:
         specifier: ^11.0.0
         version: 11.0.0
@@ -4170,6 +4173,18 @@ packages:
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
+
+  openai@6.22.0:
+    resolution: {integrity: sha512-7Yvy17F33Bi9RutWbsaYt5hJEEJ/krRPOrwan+f9aCPuMat1WVsb2VNSII5W1EksKT6fF69TG/xj4XzodK3JZw==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   ora@5.4.1:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
@@ -9783,6 +9798,10 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
+
+  openai@6.22.0(zod@4.1.12):
+    optionalDependencies:
+      zod: 4.1.12
 
   ora@5.4.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,11 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  minimatch: 10.2.1
+  body-parser: 2.2.1
+  lodash: 4.17.23
+  minimatch: 10.2.2
+  qs: 6.14.2
+  rollup: 4.53.5
 
 importers:
 
@@ -206,7 +210,7 @@ importers:
         version: 5.9.3
       unplugin-swc:
         specifier: ^1.5.7
-        version: 1.5.8(@swc/core@1.15.0)(rollup@4.52.5)
+        version: 1.5.8(@swc/core@1.15.0)(rollup@4.53.5)
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@5.9.3)(vite@7.2.1(@types/node@20.19.24)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.1))
@@ -1892,118 +1896,118 @@ packages:
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+      rollup: 4.53.5
     peerDependenciesMeta:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.52.5':
-    resolution: {integrity: sha512-8c1vW4ocv3UOMp9K+gToY5zL2XiiVw3k7f1ksf4yO1FlDFQ1C2u72iACFnSOceJFsWskc2WZNqeRhFRPzv+wtQ==}
+  '@rollup/rollup-android-arm-eabi@4.53.5':
+    resolution: {integrity: sha512-iDGS/h7D8t7tvZ1t6+WPK04KD0MwzLZrG0se1hzBjSi5fyxlsiggoJHwh18PCFNn7tG43OWb6pdZ6Y+rMlmyNQ==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.52.5':
-    resolution: {integrity: sha512-mQGfsIEFcu21mvqkEKKu2dYmtuSZOBMmAl5CFlPGLY94Vlcm+zWApK7F/eocsNzp8tKmbeBP8yXyAbx0XHsFNA==}
+  '@rollup/rollup-android-arm64@4.53.5':
+    resolution: {integrity: sha512-wrSAViWvZHBMMlWk6EJhvg8/rjxzyEhEdgfMMjREHEq11EtJ6IP6yfcCH57YAEca2Oe3FNCE9DSTgU70EIGmVw==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.52.5':
-    resolution: {integrity: sha512-takF3CR71mCAGA+v794QUZ0b6ZSrgJkArC+gUiG6LB6TQty9T0Mqh3m2ImRBOxS2IeYBo4lKWIieSvnEk2OQWA==}
+  '@rollup/rollup-darwin-arm64@4.53.5':
+    resolution: {integrity: sha512-S87zZPBmRO6u1YXQLwpveZm4JfPpAa6oHBX7/ghSiGH3rz/KDgAu1rKdGutV+WUI6tKDMbaBJomhnT30Y2t4VQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.52.5':
-    resolution: {integrity: sha512-W901Pla8Ya95WpxDn//VF9K9u2JbocwV/v75TE0YIHNTbhqUTv9w4VuQ9MaWlNOkkEfFwkdNhXgcLqPSmHy0fA==}
+  '@rollup/rollup-darwin-x64@4.53.5':
+    resolution: {integrity: sha512-YTbnsAaHo6VrAczISxgpTva8EkfQus0VPEVJCEaboHtZRIb6h6j0BNxRBOwnDciFTZLDPW5r+ZBmhL/+YpTZgA==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.52.5':
-    resolution: {integrity: sha512-QofO7i7JycsYOWxe0GFqhLmF6l1TqBswJMvICnRUjqCx8b47MTo46W8AoeQwiokAx3zVryVnxtBMcGcnX12LvA==}
+  '@rollup/rollup-freebsd-arm64@4.53.5':
+    resolution: {integrity: sha512-1T8eY2J8rKJWzaznV7zedfdhD1BqVs1iqILhmHDq/bqCUZsrMt+j8VCTHhP0vdfbHK3e1IQ7VYx3jlKqwlf+vw==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.52.5':
-    resolution: {integrity: sha512-jr21b/99ew8ujZubPo9skbrItHEIE50WdV86cdSoRkKtmWa+DDr6fu2c/xyRT0F/WazZpam6kk7IHBerSL7LDQ==}
+  '@rollup/rollup-freebsd-x64@4.53.5':
+    resolution: {integrity: sha512-sHTiuXyBJApxRn+VFMaw1U+Qsz4kcNlxQ742snICYPrY+DDL8/ZbaC4DVIB7vgZmp3jiDaKA0WpBdP0aqPJoBQ==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.52.5':
-    resolution: {integrity: sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.53.5':
+    resolution: {integrity: sha512-dV3T9MyAf0w8zPVLVBptVlzaXxka6xg1f16VAQmjg+4KMSTWDvhimI/Y6mp8oHwNrmnmVl9XxJ/w/mO4uIQONA==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.52.5':
-    resolution: {integrity: sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==}
+  '@rollup/rollup-linux-arm-musleabihf@4.53.5':
+    resolution: {integrity: sha512-wIGYC1x/hyjP+KAu9+ewDI+fi5XSNiUi9Bvg6KGAh2TsNMA3tSEs+Sh6jJ/r4BV/bx/CyWu2ue9kDnIdRyafcQ==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.52.5':
-    resolution: {integrity: sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==}
+  '@rollup/rollup-linux-arm64-gnu@4.53.5':
+    resolution: {integrity: sha512-Y+qVA0D9d0y2FRNiG9oM3Hut/DgODZbU9I8pLLPwAsU0tUKZ49cyV1tzmB/qRbSzGvY8lpgGkJuMyuhH7Ma+Vg==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.52.5':
-    resolution: {integrity: sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==}
+  '@rollup/rollup-linux-arm64-musl@4.53.5':
+    resolution: {integrity: sha512-juaC4bEgJsyFVfqhtGLz8mbopaWD+WeSOYr5E16y+1of6KQjc0BpwZLuxkClqY1i8sco+MdyoXPNiCkQou09+g==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-gnu@4.52.5':
-    resolution: {integrity: sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==}
+  '@rollup/rollup-linux-loong64-gnu@4.53.5':
+    resolution: {integrity: sha512-rIEC0hZ17A42iXtHX+EPJVL/CakHo+tT7W0pbzdAGuWOt2jxDFh7A/lRhsNHBcqL4T36+UiAgwO8pbmn3dE8wA==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.52.5':
-    resolution: {integrity: sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==}
+  '@rollup/rollup-linux-ppc64-gnu@4.53.5':
+    resolution: {integrity: sha512-T7l409NhUE552RcAOcmJHj3xyZ2h7vMWzcwQI0hvn5tqHh3oSoclf9WgTl+0QqffWFG8MEVZZP1/OBglKZx52Q==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.52.5':
-    resolution: {integrity: sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==}
+  '@rollup/rollup-linux-riscv64-gnu@4.53.5':
+    resolution: {integrity: sha512-7OK5/GhxbnrMcxIFoYfhV/TkknarkYC1hqUw1wU2xUN3TVRLNT5FmBv4KkheSG2xZ6IEbRAhTooTV2+R5Tk0lQ==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-musl@4.52.5':
-    resolution: {integrity: sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==}
+  '@rollup/rollup-linux-riscv64-musl@4.53.5':
+    resolution: {integrity: sha512-GwuDBE/PsXaTa76lO5eLJTyr2k8QkPipAyOrs4V/KJufHCZBJ495VCGJol35grx9xryk4V+2zd3Ri+3v7NPh+w==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.52.5':
-    resolution: {integrity: sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==}
+  '@rollup/rollup-linux-s390x-gnu@4.53.5':
+    resolution: {integrity: sha512-IAE1Ziyr1qNfnmiQLHBURAD+eh/zH1pIeJjeShleII7Vj8kyEm2PF77o+lf3WTHDpNJcu4IXJxNO0Zluro8bOw==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.52.5':
-    resolution: {integrity: sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==}
+  '@rollup/rollup-linux-x64-gnu@4.53.5':
+    resolution: {integrity: sha512-Pg6E+oP7GvZ4XwgRJBuSXZjcqpIW3yCBhK4BcsANvb47qMvAbCjR6E+1a/U2WXz1JJxp9/4Dno3/iSJLcm5auw==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.52.5':
-    resolution: {integrity: sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==}
+  '@rollup/rollup-linux-x64-musl@4.53.5':
+    resolution: {integrity: sha512-txGtluxDKTxaMDzUduGP0wdfng24y1rygUMnmlUJ88fzCCULCLn7oE5kb2+tRB+MWq1QDZT6ObT5RrR8HFRKqg==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-openharmony-arm64@4.52.5':
-    resolution: {integrity: sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==}
+  '@rollup/rollup-openharmony-arm64@4.53.5':
+    resolution: {integrity: sha512-3DFiLPnTxiOQV993fMc+KO8zXHTcIjgaInrqlG8zDp1TlhYl6WgrOHuJkJQ6M8zHEcntSJsUp1XFZSY8C1DYbg==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.52.5':
-    resolution: {integrity: sha512-w0cDWVR6MlTstla1cIfOGyl8+qb93FlAVutcor14Gf5Md5ap5ySfQ7R9S/NjNaMLSFdUnKGEasmVnu3lCMqB7w==}
+  '@rollup/rollup-win32-arm64-msvc@4.53.5':
+    resolution: {integrity: sha512-nggc/wPpNTgjGg75hu+Q/3i32R00Lq1B6N1DO7MCU340MRKL3WZJMjA9U4K4gzy3dkZPXm9E1Nc81FItBVGRlA==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.52.5':
-    resolution: {integrity: sha512-Aufdpzp7DpOTULJCuvzqcItSGDH73pF3ko/f+ckJhxQyHtp67rHw3HMNxoIdDMUITJESNE6a8uh4Lo4SLouOUg==}
+  '@rollup/rollup-win32-ia32-msvc@4.53.5':
+    resolution: {integrity: sha512-U/54pTbdQpPLBdEzCT6NBCFAfSZMvmjr0twhnD9f4EIvlm9wy3jjQ38yQj1AGznrNO65EWQMgm/QUjuIVrYF9w==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.52.5':
-    resolution: {integrity: sha512-UGBUGPFp1vkj6p8wCRraqNhqwX/4kNQPS57BCFc8wYh0g94iVIW33wJtQAx3G7vrjjNtRaxiMUylM0ktp/TRSQ==}
+  '@rollup/rollup-win32-x64-gnu@4.53.5':
+    resolution: {integrity: sha512-2NqKgZSuLH9SXBBV2dWNRCZmocgSOx8OJSdpRaEcRlIfX8YrKxUT6z0F1NpvDVhOsl190UFTRh2F2WDWWCYp3A==}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.52.5':
-    resolution: {integrity: sha512-TAcgQh2sSkykPRWLrdyy2AiceMckNf5loITqXxFI5VuQjS5tSuw3WlwdN8qv8vzjLAUTvYaH/mVjSFpbkFbpTg==}
+  '@rollup/rollup-win32-x64-msvc@4.53.5':
+    resolution: {integrity: sha512-JRpZUhCfhZ4keB5v0fe02gQJy05GqboPOaxvjugW04RLSYYoB/9t2lx2u/tMs/Na/1NXfY8QYjgRljRpN+MjTQ==}
     cpu: [x64]
     os: [win32]
 
@@ -2810,8 +2814,8 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
-  body-parser@2.2.0:
-    resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
+  body-parser@2.2.1:
+    resolution: {integrity: sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==}
     engines: {node: '>=18'}
 
   bowser@2.14.1:
@@ -3571,6 +3575,7 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   global-directory@4.0.1:
@@ -3650,10 +3655,6 @@ packages:
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
-    engines: {node: '>=0.10.0'}
-
-  iconv-lite@0.6.3:
-    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.0:
@@ -3911,8 +3912,8 @@ packages:
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
@@ -4023,9 +4024,9 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
-  minimatch@10.2.1:
-    resolution: {integrity: sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==}
-    engines: {node: 20 || >=22}
+  minimatch@10.2.2:
+    resolution: {integrity: sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==}
+    engines: {node: 18 || 20 || >=22}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -4379,12 +4380,8 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
-  qs@6.14.0:
-    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
-    engines: {node: '>=0.6'}
-
-  qs@6.14.1:
-    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
+  qs@6.14.2:
+    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
     engines: {node: '>=0.6'}
 
   querystringify@2.2.0:
@@ -4503,8 +4500,8 @@ packages:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
 
-  rollup@4.52.5:
-    resolution: {integrity: sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==}
+  rollup@4.53.5:
+    resolution: {integrity: sha512-iTNAbFSlRpcHeeWu73ywU/8KuU/LZmNCSxp6fjQkJBD3ivUb8tpDrXhIxEzA05HlYMEwmtaUnb3RP+YNv162OQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -6287,7 +6284,7 @@ snapshots:
       '@nestjs/common': 11.1.8(reflect-metadata@0.1.14)(rxjs@7.8.2)
       dotenv: 16.4.7
       dotenv-expand: 12.0.1
-      lodash: 4.17.21
+      lodash: 4.17.23
       rxjs: 7.8.2
 
   '@nestjs/core@11.1.8(@nestjs/common@11.1.8(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.8)(reflect-metadata@0.1.14)(rxjs@7.8.2)':
@@ -7344,78 +7341,78 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  '@rollup/pluginutils@5.3.0(rollup@4.52.5)':
+  '@rollup/pluginutils@5.3.0(rollup@4.53.5)':
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.3
     optionalDependencies:
-      rollup: 4.52.5
+      rollup: 4.53.5
 
-  '@rollup/rollup-android-arm-eabi@4.52.5':
+  '@rollup/rollup-android-arm-eabi@4.53.5':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.52.5':
+  '@rollup/rollup-android-arm64@4.53.5':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.52.5':
+  '@rollup/rollup-darwin-arm64@4.53.5':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.52.5':
+  '@rollup/rollup-darwin-x64@4.53.5':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.52.5':
+  '@rollup/rollup-freebsd-arm64@4.53.5':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.52.5':
+  '@rollup/rollup-freebsd-x64@4.53.5':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.52.5':
+  '@rollup/rollup-linux-arm-gnueabihf@4.53.5':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.52.5':
+  '@rollup/rollup-linux-arm-musleabihf@4.53.5':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.52.5':
+  '@rollup/rollup-linux-arm64-gnu@4.53.5':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.52.5':
+  '@rollup/rollup-linux-arm64-musl@4.53.5':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.52.5':
+  '@rollup/rollup-linux-loong64-gnu@4.53.5':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.52.5':
+  '@rollup/rollup-linux-ppc64-gnu@4.53.5':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.52.5':
+  '@rollup/rollup-linux-riscv64-gnu@4.53.5':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.52.5':
+  '@rollup/rollup-linux-riscv64-musl@4.53.5':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.52.5':
+  '@rollup/rollup-linux-s390x-gnu@4.53.5':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.52.5':
+  '@rollup/rollup-linux-x64-gnu@4.53.5':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.52.5':
+  '@rollup/rollup-linux-x64-musl@4.53.5':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.52.5':
+  '@rollup/rollup-openharmony-arm64@4.53.5':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.52.5':
+  '@rollup/rollup-win32-arm64-msvc@4.53.5':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.52.5':
+  '@rollup/rollup-win32-ia32-msvc@4.53.5':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.52.5':
+  '@rollup/rollup-win32-x64-gnu@4.53.5':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.52.5':
+  '@rollup/rollup-win32-x64-msvc@4.53.5':
     optional: true
 
   '@selderee/plugin-htmlparser2@0.11.0':
@@ -8246,7 +8243,7 @@ snapshots:
       graceful-fs: 4.2.11
       is-stream: 2.0.1
       lazystream: 1.0.1
-      lodash: 4.17.21
+      lodash: 4.17.23
       normalize-path: 3.0.0
       readable-stream: 4.7.0
 
@@ -8392,15 +8389,15 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  body-parser@2.2.0:
+  body-parser@2.2.1:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
       debug: 4.4.3
       http-errors: 2.0.0
-      iconv-lite: 0.6.3
+      iconv-lite: 0.7.0
       on-finished: 2.4.1
-      qs: 6.14.1
+      qs: 6.14.2
       raw-body: 3.0.1
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -8983,7 +8980,7 @@ snapshots:
   express@5.1.0:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.0
+      body-parser: 2.2.1
       content-disposition: 1.0.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -9001,7 +8998,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.14.1
+      qs: 6.14.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.0
@@ -9067,7 +9064,7 @@ snapshots:
 
   filelist@1.0.4:
     dependencies:
-      minimatch: 10.2.1
+      minimatch: 10.2.2
 
   fill-range@7.1.1:
     dependencies:
@@ -9102,7 +9099,7 @@ snapshots:
       deepmerge: 4.3.1
       fs-extra: 10.1.0
       memfs: 3.5.3
-      minimatch: 10.2.1
+      minimatch: 10.2.2
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
       semver: 7.7.3
@@ -9225,7 +9222,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
-      minimatch: 10.2.1
+      minimatch: 10.2.2
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
@@ -9309,10 +9306,6 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  iconv-lite@0.6.3:
-    dependencies:
-      safer-buffer: 2.1.2
-
   iconv-lite@0.7.0:
     dependencies:
       safer-buffer: 2.1.2
@@ -9357,7 +9350,7 @@ snapshots:
       cli-width: 3.0.0
       external-editor: 3.1.0
       figures: 3.2.0
-      lodash: 4.17.21
+      lodash: 4.17.23
       mute-stream: 0.0.8
       ora: 5.4.1
       run-async: 2.4.1
@@ -9376,7 +9369,7 @@ snapshots:
       cli-width: 4.1.0
       external-editor: 3.1.0
       figures: 3.2.0
-      lodash: 4.17.21
+      lodash: 4.17.23
       mute-stream: 1.0.0
       ora: 5.4.1
       run-async: 3.0.0
@@ -9577,7 +9570,7 @@ snapshots:
 
   lodash.once@4.1.1: {}
 
-  lodash@4.17.21: {}
+  lodash@4.17.23: {}
 
   log-symbols@4.1.0:
     dependencies:
@@ -9660,7 +9653,7 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
-  minimatch@10.2.1:
+  minimatch@10.2.2:
     dependencies:
       brace-expansion: 5.0.2
 
@@ -9754,7 +9747,7 @@ snapshots:
 
   node-emoji@1.11.0:
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.17.23
 
   node-fetch-native@1.6.7: {}
 
@@ -10037,11 +10030,7 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
-  qs@6.14.0:
-    dependencies:
-      side-channel: 1.1.0
-
-  qs@6.14.1:
+  qs@6.14.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -10107,7 +10096,7 @@ snapshots:
 
   readdir-glob@1.1.3:
     dependencies:
-      minimatch: 10.2.1
+      minimatch: 10.2.2
 
   readdirp@3.6.0:
     dependencies:
@@ -10121,7 +10110,7 @@ snapshots:
 
   redis-info@3.1.0:
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.17.23
 
   redis-parser@3.0.0:
     dependencies:
@@ -10161,32 +10150,32 @@ snapshots:
 
   retry@0.12.0: {}
 
-  rollup@4.52.5:
+  rollup@4.53.5:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.52.5
-      '@rollup/rollup-android-arm64': 4.52.5
-      '@rollup/rollup-darwin-arm64': 4.52.5
-      '@rollup/rollup-darwin-x64': 4.52.5
-      '@rollup/rollup-freebsd-arm64': 4.52.5
-      '@rollup/rollup-freebsd-x64': 4.52.5
-      '@rollup/rollup-linux-arm-gnueabihf': 4.52.5
-      '@rollup/rollup-linux-arm-musleabihf': 4.52.5
-      '@rollup/rollup-linux-arm64-gnu': 4.52.5
-      '@rollup/rollup-linux-arm64-musl': 4.52.5
-      '@rollup/rollup-linux-loong64-gnu': 4.52.5
-      '@rollup/rollup-linux-ppc64-gnu': 4.52.5
-      '@rollup/rollup-linux-riscv64-gnu': 4.52.5
-      '@rollup/rollup-linux-riscv64-musl': 4.52.5
-      '@rollup/rollup-linux-s390x-gnu': 4.52.5
-      '@rollup/rollup-linux-x64-gnu': 4.52.5
-      '@rollup/rollup-linux-x64-musl': 4.52.5
-      '@rollup/rollup-openharmony-arm64': 4.52.5
-      '@rollup/rollup-win32-arm64-msvc': 4.52.5
-      '@rollup/rollup-win32-ia32-msvc': 4.52.5
-      '@rollup/rollup-win32-x64-gnu': 4.52.5
-      '@rollup/rollup-win32-x64-msvc': 4.52.5
+      '@rollup/rollup-android-arm-eabi': 4.53.5
+      '@rollup/rollup-android-arm64': 4.53.5
+      '@rollup/rollup-darwin-arm64': 4.53.5
+      '@rollup/rollup-darwin-x64': 4.53.5
+      '@rollup/rollup-freebsd-arm64': 4.53.5
+      '@rollup/rollup-freebsd-x64': 4.53.5
+      '@rollup/rollup-linux-arm-gnueabihf': 4.53.5
+      '@rollup/rollup-linux-arm-musleabihf': 4.53.5
+      '@rollup/rollup-linux-arm64-gnu': 4.53.5
+      '@rollup/rollup-linux-arm64-musl': 4.53.5
+      '@rollup/rollup-linux-loong64-gnu': 4.53.5
+      '@rollup/rollup-linux-ppc64-gnu': 4.53.5
+      '@rollup/rollup-linux-riscv64-gnu': 4.53.5
+      '@rollup/rollup-linux-riscv64-musl': 4.53.5
+      '@rollup/rollup-linux-s390x-gnu': 4.53.5
+      '@rollup/rollup-linux-x64-gnu': 4.53.5
+      '@rollup/rollup-linux-x64-musl': 4.53.5
+      '@rollup/rollup-openharmony-arm64': 4.53.5
+      '@rollup/rollup-win32-arm64-msvc': 4.53.5
+      '@rollup/rollup-win32-ia32-msvc': 4.53.5
+      '@rollup/rollup-win32-x64-gnu': 4.53.5
+      '@rollup/rollup-win32-x64-msvc': 4.53.5
       fsevents: 2.3.3
 
   rou3@0.7.12: {}
@@ -10451,7 +10440,7 @@ snapshots:
       formidable: 3.5.4
       methods: 1.1.2
       mime: 2.6.0
-      qs: 6.14.0
+      qs: 6.14.2
     transitivePeerDependencies:
       - supports-color
 
@@ -10543,7 +10532,7 @@ snapshots:
     dependencies:
       '@istanbuljs/schema': 0.1.3
       glob: 10.4.5
-      minimatch: 10.2.1
+      minimatch: 10.2.2
 
   testcontainers@11.8.0:
     dependencies:
@@ -10648,7 +10637,7 @@ snapshots:
       dayjs: 1.11.19
       https-proxy-agent: 5.0.1
       jsonwebtoken: 9.0.3
-      qs: 6.14.1
+      qs: 6.14.2
       scmp: 2.1.0
       xmlbuilder: 13.0.2
     transitivePeerDependencies:
@@ -10692,9 +10681,9 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-swc@1.5.8(@swc/core@1.15.0)(rollup@4.52.5):
+  unplugin-swc@1.5.8(@swc/core@1.15.0)(rollup@4.53.5):
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.52.5)
+      '@rollup/pluginutils': 5.3.0(rollup@4.53.5)
       '@swc/core': 1.15.0
       load-tsconfig: 0.2.5
       unplugin: 2.3.10
@@ -10771,7 +10760,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
-      rollup: 4.52.5
+      rollup: 4.53.5
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 20.19.24

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { RequestIdMiddleware } from "./common/middlewares/request-id.middleware"
 import { EnvConfig, validateEnvironment } from "./config/env.config";
 import { parseOtlpHeaders } from "./config/tracing.config";
 import { AccountModule } from "./modules/account/account.module";
+import { AiSearchModule } from "./modules/ai-search/ai-search.module";
 import { AuthModule } from "./modules/auth/auth.module";
 import { CarModule } from "./modules/car/car.module";
 import { DashboardModule } from "./modules/dashboard/dashboard.module";
@@ -151,6 +152,7 @@ import { StatusChangeModule } from "./modules/status-change/status-change.module
     // Queues are registered in their respective feature modules
     HttpClientModule,
     DatabaseModule,
+    AiSearchModule,
     AccountModule,
     FlutterwaveModule,
     DocumentsModule,

--- a/src/config/env.config.ts
+++ b/src/config/env.config.ts
@@ -66,6 +66,7 @@ export const envSchema = z.object({
 
   // Google Maps configuration (for drive time calculations)
   GOOGLE_DISTANCE_MATRIX_API_KEY: z.string().min(1, "GOOGLE_DISTANCE_MATRIX_API_KEY is required"),
+  OPENAI_API_KEY: z.string().min(1, "OPENAI_API_KEY is required"),
 
   // Auth configuration (optional - only required when AuthModule is used)
   SESSION_SECRET: z.string().min(32, "SESSION_SECRET must be at least 32 characters"),

--- a/src/modules/ai-search/ai-search.controller.spec.ts
+++ b/src/modules/ai-search/ai-search.controller.spec.ts
@@ -1,0 +1,41 @@
+import { Test, type TestingModule } from "@nestjs/testing";
+import type { Response } from "express";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AiSearchController } from "./ai-search.controller";
+import { AiSearchService } from "./ai-search.service";
+
+describe("AiSearchController", () => {
+  let controller: AiSearchController;
+  let aiSearchService: { search: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    aiSearchService = {
+      search: vi.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AiSearchController],
+      providers: [{ provide: AiSearchService, useValue: aiSearchService }],
+    }).compile();
+
+    controller = module.get<AiSearchController>(AiSearchController);
+  });
+
+  it("sets no-store header and delegates search", async () => {
+    aiSearchService.search.mockResolvedValue({
+      params: { make: "Toyota" },
+      interpretation: "Looking for: toyota",
+      raw: { make: "Toyota" },
+    });
+
+    const response = {
+      setHeader: vi.fn(),
+    } as unknown as Response;
+
+    const result = await controller.search({ query: "toyota" }, response);
+
+    expect(response.setHeader).toHaveBeenCalledWith("Cache-Control", "no-store");
+    expect(aiSearchService.search).toHaveBeenCalledWith("toyota");
+    expect(result.params.make).toBe("Toyota");
+  });
+});

--- a/src/modules/ai-search/ai-search.controller.ts
+++ b/src/modules/ai-search/ai-search.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Post, Res } from "@nestjs/common";
+import type { Response } from "express";
+import { ZodBody } from "../../common/decorators/zod-validation.decorator";
+import { AiSearchService } from "./ai-search.service";
+import { type AiSearchBodyDto, aiSearchBodySchema } from "./dto/ai-search.dto";
+
+@Controller("api")
+export class AiSearchController {
+  constructor(private readonly aiSearchService: AiSearchService) {}
+
+  @Post("ai-search")
+  async search(
+    @ZodBody(aiSearchBodySchema) body: AiSearchBodyDto,
+    @Res({ passthrough: true }) response: Response,
+  ) {
+    response.setHeader("Cache-Control", "no-store");
+    return this.aiSearchService.search(body.query);
+  }
+}

--- a/src/modules/ai-search/ai-search.error.ts
+++ b/src/modules/ai-search/ai-search.error.ts
@@ -1,0 +1,49 @@
+import { HttpStatus } from "@nestjs/common";
+import { AppException } from "../../common/errors/app.exception";
+
+export const AiSearchErrorCode = {
+  AI_SEARCH_FAILED: "AI_SEARCH_FAILED",
+  AI_SEARCH_TIMEOUT: "AI_SEARCH_TIMEOUT",
+  AI_SEARCH_PROVIDER_RESPONSE_INVALID: "AI_SEARCH_PROVIDER_RESPONSE_INVALID",
+} as const;
+
+export class AiSearchException extends AppException {}
+
+export class AiSearchFailedException extends AiSearchException {
+  constructor() {
+    super(
+      AiSearchErrorCode.AI_SEARCH_FAILED,
+      "Failed to process search. Please try again.",
+      HttpStatus.INTERNAL_SERVER_ERROR,
+      {
+        title: "AI Search Failed",
+      },
+    );
+  }
+}
+
+export class AiSearchTimeoutException extends AiSearchException {
+  constructor() {
+    super(
+      AiSearchErrorCode.AI_SEARCH_TIMEOUT,
+      "AI search request timed out. Please try again.",
+      HttpStatus.GATEWAY_TIMEOUT,
+      {
+        title: "AI Search Timeout",
+      },
+    );
+  }
+}
+
+export class AiSearchProviderResponseInvalidException extends AiSearchException {
+  constructor() {
+    super(
+      AiSearchErrorCode.AI_SEARCH_PROVIDER_RESPONSE_INVALID,
+      "AI provider returned an invalid response.",
+      HttpStatus.BAD_GATEWAY,
+      {
+        title: "AI Provider Response Invalid",
+      },
+    );
+  }
+}

--- a/src/modules/ai-search/ai-search.interface.ts
+++ b/src/modules/ai-search/ai-search.interface.ts
@@ -1,0 +1,18 @@
+export interface ExtractedAiSearchParams {
+  color?: string;
+  make?: string;
+  model?: string;
+  vehicleType?: "SEDAN" | "SUV" | "LUXURY_SEDAN" | "LUXURY_SUV" | "VAN" | "CROSSOVER";
+  serviceTier?: "STANDARD" | "EXECUTIVE" | "LUXURY" | "ULTRA_LUXURY";
+  from?: string;
+  to?: string;
+  bookingType?: "DAY" | "NIGHT" | "FULL_DAY" | "AIRPORT_PICKUP";
+  pickupTime?: string;
+  flightNumber?: string;
+}
+
+export interface AiSearchResponse {
+  params: Record<string, string>;
+  interpretation: string;
+  raw: ExtractedAiSearchParams;
+}

--- a/src/modules/ai-search/ai-search.module.ts
+++ b/src/modules/ai-search/ai-search.module.ts
@@ -1,0 +1,13 @@
+import { Module } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config";
+import { AiSearchController } from "./ai-search.controller";
+import { AiSearchService } from "./ai-search.service";
+import { OpenAiAiSearchExtractorService } from "./openai-ai-search-extractor.service";
+
+@Module({
+  imports: [ConfigModule],
+  controllers: [AiSearchController],
+  providers: [AiSearchService, OpenAiAiSearchExtractorService],
+  exports: [AiSearchService],
+})
+export class AiSearchModule {}

--- a/src/modules/ai-search/ai-search.service.spec.ts
+++ b/src/modules/ai-search/ai-search.service.spec.ts
@@ -1,0 +1,64 @@
+import { Test, type TestingModule } from "@nestjs/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AiSearchFailedException, AiSearchTimeoutException } from "./ai-search.error";
+import { AiSearchService } from "./ai-search.service";
+import { OpenAiAiSearchExtractorService } from "./openai-ai-search-extractor.service";
+
+describe("AiSearchService", () => {
+  let service: AiSearchService;
+  let extractorService: { extract: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    extractorService = {
+      extract: vi.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AiSearchService,
+        { provide: OpenAiAiSearchExtractorService, useValue: extractorService },
+      ],
+    }).compile();
+
+    service = module.get<AiSearchService>(AiSearchService);
+  });
+
+  it("returns mapped params and interpretation", async () => {
+    extractorService.extract.mockResolvedValue({
+      color: "black",
+      make: "Toyota",
+      model: "Camry",
+      vehicleType: "LUXURY_SEDAN",
+      bookingType: "DAY",
+      from: "2026-03-01",
+      to: "2026-03-02",
+    });
+
+    const result = await service.search("Need a black camry");
+
+    expect(result.params).toEqual({
+      color: "black",
+      make: "Toyota",
+      model: "Camry",
+      vehicleType: "LUXURY_SEDAN",
+      bookingType: "DAY",
+      from: "2026-03-01",
+      to: "2026-03-02",
+    });
+    expect(result.interpretation).toContain("Looking for:");
+    expect(result.interpretation).toContain("luxury sedan");
+    expect(result.interpretation).toContain("Dates: 2026-03-01 to 2026-03-02");
+  });
+
+  it("rethrows known ai search exceptions", async () => {
+    extractorService.extract.mockRejectedValue(new AiSearchTimeoutException());
+
+    await expect(service.search("any")).rejects.toBeInstanceOf(AiSearchTimeoutException);
+  });
+
+  it("throws generic ai search failed for unknown errors", async () => {
+    extractorService.extract.mockRejectedValue(new Error("boom"));
+
+    await expect(service.search("any")).rejects.toBeInstanceOf(AiSearchFailedException);
+  });
+});

--- a/src/modules/ai-search/ai-search.service.spec.ts
+++ b/src/modules/ai-search/ai-search.service.spec.ts
@@ -28,6 +28,7 @@ describe("AiSearchService", () => {
       color: "black",
       make: "Toyota",
       model: "Camry",
+      serviceTier: "ULTRA_LUXURY",
       vehicleType: "LUXURY_SEDAN",
       bookingType: "DAY",
       from: "2026-03-01",
@@ -40,12 +41,14 @@ describe("AiSearchService", () => {
       color: "black",
       make: "Toyota",
       model: "Camry",
+      serviceTier: "ULTRA_LUXURY",
       vehicleType: "LUXURY_SEDAN",
       bookingType: "DAY",
       from: "2026-03-01",
       to: "2026-03-02",
     });
     expect(result.interpretation).toContain("Looking for:");
+    expect(result.interpretation).toContain("ultra luxury");
     expect(result.interpretation).toContain("luxury sedan");
     expect(result.interpretation).toContain("Dates: 2026-03-01 to 2026-03-02");
   });

--- a/src/modules/ai-search/ai-search.service.ts
+++ b/src/modules/ai-search/ai-search.service.ts
@@ -1,0 +1,77 @@
+import { Injectable } from "@nestjs/common";
+import { AiSearchException, AiSearchFailedException } from "./ai-search.error";
+import type { AiSearchResponse, ExtractedAiSearchParams } from "./ai-search.interface";
+import { OpenAiAiSearchExtractorService } from "./openai-ai-search-extractor.service";
+
+@Injectable()
+export class AiSearchService {
+  constructor(private readonly extractorService: OpenAiAiSearchExtractorService) {}
+
+  async search(query: string): Promise<AiSearchResponse> {
+    try {
+      const extracted = await this.extractorService.extract(query.trim());
+      return {
+        params: this.buildSearchParams(extracted),
+        interpretation: this.generateInterpretation(extracted),
+        raw: extracted,
+      };
+    } catch (error) {
+      if (error instanceof AiSearchException) {
+        throw error;
+      }
+      throw new AiSearchFailedException();
+    }
+  }
+
+  private buildSearchParams(params: ExtractedAiSearchParams): Record<string, string> {
+    const searchParams: Record<string, string> = {};
+
+    if (params.color) searchParams.color = params.color;
+    if (params.make) searchParams.make = params.make;
+    if (params.model) searchParams.model = params.model;
+    if (params.vehicleType) searchParams.vehicleType = params.vehicleType;
+    if (params.serviceTier) searchParams.serviceTier = params.serviceTier;
+    if (params.from) searchParams.from = params.from;
+    if (params.to) searchParams.to = params.to;
+    if (params.bookingType) searchParams.bookingType = params.bookingType;
+    if (params.pickupTime) searchParams.pickupTime = params.pickupTime;
+    if (params.flightNumber) searchParams.flightNumber = params.flightNumber;
+
+    return searchParams;
+  }
+
+  private generateInterpretation(params: ExtractedAiSearchParams): string {
+    const parts: string[] = [];
+
+    if (params.color || params.make || params.vehicleType || params.serviceTier || params.model) {
+      const vehicle = [
+        params.color,
+        params.make,
+        params.model,
+        params.serviceTier?.toLowerCase(),
+        params.vehicleType?.toLowerCase().replaceAll("_", " "),
+      ]
+        .filter(Boolean)
+        .join(" ");
+      parts.push(`Looking for: ${vehicle}`);
+    }
+
+    if (params.from && params.to) {
+      parts.push(`Dates: ${params.from} to ${params.to}`);
+    } else if (params.from) {
+      parts.push(`Starting: ${params.from}`);
+    }
+
+    if (params.bookingType) {
+      const typeLabels = {
+        DAY: "day rental",
+        NIGHT: "night service",
+        FULL_DAY: "full day (24hr)",
+        AIRPORT_PICKUP: "airport pickup",
+      } as const;
+      parts.push(`Type: ${typeLabels[params.bookingType]}`);
+    }
+
+    return parts.join(" • ");
+  }
+}

--- a/src/modules/ai-search/ai-search.service.ts
+++ b/src/modules/ai-search/ai-search.service.ts
@@ -48,7 +48,7 @@ export class AiSearchService {
         params.color,
         params.make,
         params.model,
-        params.serviceTier?.toLowerCase(),
+        params.serviceTier?.toLowerCase().replaceAll("_", " "),
         params.vehicleType?.toLowerCase().replaceAll("_", " "),
       ]
         .filter(Boolean)

--- a/src/modules/ai-search/dto/ai-search.dto.spec.ts
+++ b/src/modules/ai-search/dto/ai-search.dto.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { extractedAiSearchParamsSchema } from "./ai-search.dto";
+
+describe("extractedAiSearchParamsSchema", () => {
+  it("accepts valid ISO date range", () => {
+    const parsed = extractedAiSearchParamsSchema.safeParse({
+      make: "Toyota",
+      from: "2026-03-01",
+      to: "2026-03-05",
+      bookingType: "DAY",
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects non-ISO dates", () => {
+    const parsed = extractedAiSearchParamsSchema.safeParse({
+      from: "03/01/2026",
+      to: "2026-03-05",
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects end date before start date", () => {
+    const parsed = extractedAiSearchParamsSchema.safeParse({
+      from: "2026-03-05",
+      to: "2026-03-01",
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/src/modules/ai-search/dto/ai-search.dto.ts
+++ b/src/modules/ai-search/dto/ai-search.dto.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+export const aiSearchBodySchema = z.object({
+  query: z.string().trim().min(1, "Query is required"),
+});
+
+export type AiSearchBodyDto = z.infer<typeof aiSearchBodySchema>;
+
+export const extractedAiSearchParamsSchema = z
+  .object({
+    color: z.string().optional(),
+    make: z.string().optional(),
+    model: z.string().optional(),
+    vehicleType: z
+      .enum(["SEDAN", "SUV", "LUXURY_SEDAN", "LUXURY_SUV", "VAN", "CROSSOVER"])
+      .optional(),
+    serviceTier: z.enum(["STANDARD", "EXECUTIVE", "LUXURY", "ULTRA_LUXURY"]).optional(),
+    from: z.string().optional(),
+    to: z.string().optional(),
+    bookingType: z.enum(["DAY", "NIGHT", "FULL_DAY", "AIRPORT_PICKUP"]).optional(),
+    pickupTime: z.string().optional(),
+    flightNumber: z.string().optional(),
+  })
+  .strict();

--- a/src/modules/ai-search/dto/ai-search.dto.ts
+++ b/src/modules/ai-search/dto/ai-search.dto.ts
@@ -15,10 +15,21 @@ export const extractedAiSearchParamsSchema = z
       .enum(["SEDAN", "SUV", "LUXURY_SEDAN", "LUXURY_SUV", "VAN", "CROSSOVER"])
       .optional(),
     serviceTier: z.enum(["STANDARD", "EXECUTIVE", "LUXURY", "ULTRA_LUXURY"]).optional(),
-    from: z.string().optional(),
-    to: z.string().optional(),
+    from: z.iso.date().optional(),
+    to: z.iso.date().optional(),
     bookingType: z.enum(["DAY", "NIGHT", "FULL_DAY", "AIRPORT_PICKUP"]).optional(),
     pickupTime: z.string().optional(),
     flightNumber: z.string().optional(),
   })
+  .refine(
+    (data) => {
+      if (data.from && data.to) {
+        return data.to >= data.from;
+      }
+      return true;
+    },
+    {
+      error: "End date must be on or after start date",
+    },
+  )
   .strict();

--- a/src/modules/ai-search/openai-ai-search-extractor.service.spec.ts
+++ b/src/modules/ai-search/openai-ai-search-extractor.service.spec.ts
@@ -1,0 +1,60 @@
+import { ConfigService } from "@nestjs/config";
+import { Test, type TestingModule } from "@nestjs/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AiSearchProviderResponseInvalidException,
+  AiSearchTimeoutException,
+} from "./ai-search.error";
+import { OpenAiAiSearchExtractorService } from "./openai-ai-search-extractor.service";
+
+describe("OpenAiAiSearchExtractorService", () => {
+  let service: OpenAiAiSearchExtractorService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OpenAiAiSearchExtractorService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: vi.fn().mockReturnValue("test-openai-api-key"),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<OpenAiAiSearchExtractorService>(OpenAiAiSearchExtractorService);
+  });
+
+  it("builds parity system prompt with timezone and mapping rules", () => {
+    const prompt = (
+      service as unknown as { buildSystemPrompt: (now: Date) => string }
+    ).buildSystemPrompt(new Date("2026-03-01T12:00:00.000Z"));
+
+    expect(prompt).toContain("Timezone: Africa/Lagos (WAT)");
+    expect(prompt).toContain("Vehicle type mapping:");
+    expect(prompt).toContain('"Benz" = "Mercedes"');
+    expect(prompt).toContain("today");
+    expect(prompt).toContain("tomorrow");
+  });
+
+  it("throws invalid response error when OpenAI returns empty content", async () => {
+    const create = vi.fn().mockResolvedValue({ choices: [{ message: { content: "" } }] });
+    (service as unknown as { openAiClient: unknown }).openAiClient = {
+      chat: { completions: { create } },
+    };
+
+    await expect(service.extract("find me a car")).rejects.toBeInstanceOf(
+      AiSearchProviderResponseInvalidException,
+    );
+  });
+
+  it("throws timeout error on timeout message", async () => {
+    const create = vi.fn().mockRejectedValue(new Error("Request timed out"));
+    (service as unknown as { openAiClient: unknown }).openAiClient = {
+      chat: { completions: { create } },
+    };
+
+    await expect(service.extract("find me a car")).rejects.toBeInstanceOf(AiSearchTimeoutException);
+  });
+});

--- a/src/modules/ai-search/openai-ai-search-extractor.service.ts
+++ b/src/modules/ai-search/openai-ai-search-extractor.service.ts
@@ -81,7 +81,7 @@ export class OpenAiAiSearchExtractorService {
     return `You are a car rental search assistant for Tripdly in Lagos, Nigeria.
 Extract search parameters from user queries and return them as JSON.
 
-Today's date is: ${today} (${now.toDateString()})
+Today's date is: ${today} (${today})
 Timezone: Africa/Lagos (WAT)
 
 Extract the following fields when mentioned:

--- a/src/modules/ai-search/openai-ai-search-extractor.service.ts
+++ b/src/modules/ai-search/openai-ai-search-extractor.service.ts
@@ -1,0 +1,73 @@
+import { Injectable } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import OpenAI from "openai";
+import type { EnvConfig } from "../../config/env.config";
+import {
+  AiSearchException,
+  AiSearchProviderResponseInvalidException,
+  AiSearchTimeoutException,
+} from "./ai-search.error";
+import type { ExtractedAiSearchParams } from "./ai-search.interface";
+import { extractedAiSearchParamsSchema } from "./dto/ai-search.dto";
+
+@Injectable()
+export class OpenAiAiSearchExtractorService {
+  private readonly openAiClient: OpenAI;
+
+  constructor(private readonly configService: ConfigService<EnvConfig>) {
+    const apiKey = this.configService.get("OPENAI_API_KEY", { infer: true });
+    this.openAiClient = new OpenAI({
+      apiKey,
+      timeout: 8000,
+      maxRetries: 1,
+    });
+  }
+
+  async extract(query: string): Promise<ExtractedAiSearchParams> {
+    try {
+      const completion = await this.openAiClient.chat.completions.create({
+        model: "gpt-4o-mini",
+        messages: [
+          {
+            role: "system",
+            content:
+              "Extract car search parameters from user query and return strict JSON keys only: color, make, model, vehicleType, serviceTier, from, to, bookingType, pickupTime, flightNumber. Do not include unknown keys.",
+          },
+          { role: "user", content: query },
+        ],
+        response_format: { type: "json_object" },
+        temperature: 0,
+        max_tokens: 300,
+      });
+
+      const content = completion.choices[0]?.message?.content;
+      if (!content) {
+        throw new AiSearchProviderResponseInvalidException();
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(content);
+      } catch {
+        throw new AiSearchProviderResponseInvalidException();
+      }
+
+      const validated = extractedAiSearchParamsSchema.safeParse(parsed);
+      if (!validated.success) {
+        throw new AiSearchProviderResponseInvalidException();
+      }
+
+      return validated.data;
+    } catch (error) {
+      if (error instanceof AiSearchException) {
+        throw error;
+      }
+
+      if (error instanceof Error && /timeout|timed out/i.test(error.message)) {
+        throw new AiSearchTimeoutException();
+      }
+
+      throw new AiSearchProviderResponseInvalidException();
+    }
+  }
+}

--- a/src/modules/ai-search/openai-ai-search-extractor.service.ts
+++ b/src/modules/ai-search/openai-ai-search-extractor.service.ts
@@ -13,6 +13,7 @@ import { extractedAiSearchParamsSchema } from "./dto/ai-search.dto";
 @Injectable()
 export class OpenAiAiSearchExtractorService {
   private readonly openAiClient: OpenAI;
+  private static readonly LAGOS_TIMEZONE = "Africa/Lagos";
 
   constructor(private readonly configService: ConfigService<EnvConfig>) {
     const apiKey = this.configService.get("OPENAI_API_KEY", { infer: true });
@@ -30,8 +31,7 @@ export class OpenAiAiSearchExtractorService {
         messages: [
           {
             role: "system",
-            content:
-              "Extract car search parameters from user query and return strict JSON keys only: color, make, model, vehicleType, serviceTier, from, to, bookingType, pickupTime, flightNumber. Do not include unknown keys.",
+            content: this.buildSystemPrompt(),
           },
           { role: "user", content: query },
         ],
@@ -69,5 +69,76 @@ export class OpenAiAiSearchExtractorService {
 
       throw new AiSearchProviderResponseInvalidException();
     }
+  }
+
+  private buildSystemPrompt(now: Date = new Date()): string {
+    const today = this.formatDateInTimezone(now, OpenAiAiSearchExtractorService.LAGOS_TIMEZONE);
+    const tomorrow = this.formatDateInTimezone(
+      new Date(now.getTime() + 24 * 60 * 60 * 1000),
+      OpenAiAiSearchExtractorService.LAGOS_TIMEZONE,
+    );
+
+    return `You are a car rental search assistant for Tripdly in Lagos, Nigeria.
+Extract search parameters from user queries and return them as JSON.
+
+Today's date is: ${today} (${now.toDateString()})
+Timezone: Africa/Lagos (WAT)
+
+Extract the following fields when mentioned:
+- color: Vehicle color (e.g., "black", "white", "silver", "blue", "red")
+- make: Car brand (e.g., "Toyota", "Mercedes", "BMW", "Lexus")
+- model: Car model (e.g., "Camry", "E-Class", "X5")
+- vehicleType: One of: SEDAN, SUV, LUXURY_SEDAN, LUXURY_SUV, VAN, CROSSOVER
+- serviceTier: One of: STANDARD, EXECUTIVE, LUXURY, ULTRA_LUXURY
+- from: Start date in YYYY-MM-DD format
+- to: End date in YYYY-MM-DD format
+- bookingType: One of: DAY, NIGHT, FULL_DAY, AIRPORT_PICKUP
+- pickupTime: Time in "HH AM/PM" format (e.g., "10 AM", "2 PM")
+- flightNumber: Flight number for airport pickups
+
+Date parsing rules:
+- "today" = ${today}
+- "tomorrow" = ${tomorrow}
+- "next Monday/Tuesday/etc" = calculate the next occurrence
+- "X days" = duration from start date
+- "X nights" = duration + set bookingType to NIGHT
+
+Vehicle type mapping:
+- "sedan", "car", "saloon" → SEDAN
+- "suv", "jeep" → SUV
+- "luxury sedan", "premium sedan" → LUXURY_SEDAN
+- "luxury suv", "premium suv" → LUXURY_SUV
+- "van", "bus", "minibus" → VAN
+- "crossover" → CROSSOVER
+
+Service tier mapping:
+- "standard", "budget", "cheap", "affordable" → STANDARD
+- "executive", "business" → EXECUTIVE
+- "luxury", "premium" → LUXURY
+- "ultra luxury", "ultra-luxury", "high-end" → ULTRA_LUXURY
+
+Booking type mapping:
+- Default to DAY if dates are mentioned without specifying night/airport
+- "night", "overnight" → NIGHT
+- "24 hours", "full day", "24hr" → FULL_DAY
+- "airport", "flight", "pickup" → AIRPORT_PICKUP
+
+Important:
+- Only include fields that are explicitly mentioned or can be inferred
+- If duration is mentioned (e.g., "5 days"), calculate the end date
+- Be flexible with synonyms (e.g., "Benz" = "Mercedes")
+- Return strict JSON only with these keys: color, make, model, vehicleType, serviceTier, from, to, bookingType, pickupTime, flightNumber
+- Do not include unknown keys or explanatory text`;
+  }
+
+  private formatDateInTimezone(date: Date, timezone: string): string {
+    const formatter = new Intl.DateTimeFormat("en-CA", {
+      timeZone: timezone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    });
+
+    return formatter.format(date);
   }
 }

--- a/src/modules/auth/auth.config.ts
+++ b/src/modules/auth/auth.config.ts
@@ -255,7 +255,7 @@ export function createAuth(options: AuthConfigOptions) {
     database: prismaAdapter(prisma, { provider: "postgresql" }),
     secret: sessionSecret,
     baseURL: authBaseUrl,
-    basePath: "/auth/api",
+    basePath: "/api/auth",
     trustedOrigins,
     session: {
       expiresIn: 60 * 60 * 24 * 7, // 7 days

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -24,18 +24,18 @@ function toHeaders(incomingHeaders: IncomingHttpHeaders): Headers {
   return headers;
 }
 
-@Controller("auth")
+@Controller()
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   /**
    * Catch-all handler for Better Auth endpoints.
-   * Routes all /auth/api/* requests to Better Auth.
+   * Routes all /api/auth/* requests to Better Auth.
    *
    * Note: We use @Res() here because Better Auth needs direct access
    * to the response object to handle cookies and headers.
    */
-  @All("api/*path")
+  @All("api/auth/*path")
   async handleAuthRequest(@Req() req: Request, @Res() res: Response): Promise<void> {
     this.ensureAuthInitialized();
 
@@ -48,7 +48,7 @@ export class AuthController {
    * Get current session information.
    * Returns session data with user roles if authenticated, 401 if not.
    */
-  @Get("session")
+  @Get("auth/session")
   async getSession(
     @Req() req: Request,
   ): Promise<{ user: Record<string, unknown> & { roles: string[] }; session: unknown }> {

--- a/src/modules/auth/guards/session.guard.ts
+++ b/src/modules/auth/guards/session.guard.ts
@@ -57,9 +57,14 @@ export class SessionGuard implements CanActivate {
     }
 
     const request = context.switchToHttp().getRequest<Request>();
-    const session = await this.authService.auth.api.getSession({
-      headers: toHeaders(request.headers),
-    });
+    let session: Awaited<ReturnType<typeof this.authService.auth.api.getSession>> = null;
+    try {
+      session = await this.authService.auth.api.getSession({
+        headers: toHeaders(request.headers),
+      });
+    } catch {
+      throw new UnauthorizedException("Invalid or expired session");
+    }
 
     if (!session) {
       throw new UnauthorizedException("Invalid or expired session");

--- a/src/modules/car/car-categories.service.spec.ts
+++ b/src/modules/car/car-categories.service.spec.ts
@@ -1,0 +1,251 @@
+import { Test, type TestingModule } from "@nestjs/testing";
+import { ServiceTier, VehicleType } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DatabaseService } from "../database/database.service";
+import { CarFetchFailedException } from "./car.error";
+import { CarCategoriesService } from "./car-categories.service";
+import type { PublicCarDto } from "./dto/car-categories.dto";
+
+describe("CarCategoriesService", () => {
+  let service: CarCategoriesService;
+
+  const databaseServiceMock = {
+    car: {
+      findMany: vi.fn(),
+    },
+  };
+
+  const createMockCar = (overrides: Partial<PublicCarDto> = {}): PublicCarDto => ({
+    id: `car-${Math.random().toString(36).slice(2, 9)}`,
+    make: "Toyota",
+    model: "Camry",
+    year: 2022,
+    dayRate: 50000,
+    passengerCapacity: 4,
+    pricingIncludesFuel: true,
+    vehicleType: VehicleType.SEDAN,
+    serviceTier: ServiceTier.STANDARD,
+    images: [{ url: "https://example.com/car.jpg" }],
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CarCategoriesService,
+        { provide: DatabaseService, useValue: databaseServiceMock },
+      ],
+    }).compile();
+
+    service = module.get<CarCategoriesService>(CarCategoriesService);
+  });
+
+  const findCategory = (
+    categories: { name: string; title: string; cars: PublicCarDto[] }[],
+    name: string,
+  ) => categories.find((c) => c.name === name);
+
+  describe("getCategorizedCars", () => {
+    it("returns empty categories when no cars exist", async () => {
+      databaseServiceMock.car.findMany.mockResolvedValueOnce([]);
+
+      const result = await service.getCategorizedCars({ limit: 50 });
+
+      expect(result).toEqual({
+        categories: [],
+        allCars: [],
+        total: 0,
+      });
+    });
+
+    it("categorizes SUVs correctly with name and title", async () => {
+      const suvCars = [
+        createMockCar({ id: "suv-1", vehicleType: VehicleType.SUV }),
+        createMockCar({ id: "suv-2", vehicleType: VehicleType.SUV }),
+        createMockCar({ id: "suv-3", vehicleType: VehicleType.LUXURY_SUV }),
+      ];
+      databaseServiceMock.car.findMany.mockResolvedValueOnce(suvCars);
+
+      const result = await service.getCategorizedCars({ limit: 50 });
+
+      const suvsCategory = findCategory(result.categories, "suvs");
+      expect(suvsCategory).toBeDefined();
+      expect(suvsCategory?.title).toBe("SUV");
+      expect(suvsCategory?.cars).toHaveLength(3);
+      expect(suvsCategory?.cars.map((c) => c.id)).toEqual(["suv-1", "suv-2", "suv-3"]);
+    });
+
+    it("categorizes sedans correctly", async () => {
+      const sedanCars = [
+        createMockCar({ id: "sedan-1", vehicleType: VehicleType.SEDAN }),
+        createMockCar({ id: "sedan-2", vehicleType: VehicleType.SEDAN }),
+        createMockCar({ id: "sedan-3", vehicleType: VehicleType.LUXURY_SEDAN }),
+      ];
+      databaseServiceMock.car.findMany.mockResolvedValueOnce(sedanCars);
+
+      const result = await service.getCategorizedCars({ limit: 50 });
+
+      const sedansCategory = findCategory(result.categories, "sedans");
+      expect(sedansCategory).toBeDefined();
+      expect(sedansCategory?.title).toBe("Sedans");
+      expect(sedansCategory?.cars).toHaveLength(3);
+    });
+
+    it("categorizes luxury cars by serviceTier", async () => {
+      const luxuryCars = [
+        createMockCar({ id: "lux-1", serviceTier: ServiceTier.LUXURY }),
+        createMockCar({ id: "lux-2", serviceTier: ServiceTier.LUXURY }),
+        createMockCar({ id: "lux-3", serviceTier: ServiceTier.ULTRA_LUXURY }),
+      ];
+      databaseServiceMock.car.findMany.mockResolvedValueOnce(luxuryCars);
+
+      const result = await service.getCategorizedCars({ limit: 50 });
+
+      const luxuryCategory = findCategory(result.categories, "luxury");
+      expect(luxuryCategory).toBeDefined();
+      expect(luxuryCategory?.title).toBe("Luxury");
+      expect(luxuryCategory?.cars).toHaveLength(3);
+    });
+
+    it("categorizes executive cars by serviceTier", async () => {
+      const execCars = [
+        createMockCar({ id: "exec-1", serviceTier: ServiceTier.EXECUTIVE }),
+        createMockCar({ id: "exec-2", serviceTier: ServiceTier.EXECUTIVE }),
+        createMockCar({ id: "exec-3", serviceTier: ServiceTier.EXECUTIVE }),
+      ];
+      databaseServiceMock.car.findMany.mockResolvedValueOnce(execCars);
+
+      const result = await service.getCategorizedCars({ limit: 50 });
+
+      const execCategory = findCategory(result.categories, "executive");
+      expect(execCategory).toBeDefined();
+      expect(execCategory?.title).toBe("Executive");
+      expect(execCategory?.cars).toHaveLength(3);
+    });
+
+    it("categorizes budget cars by STANDARD serviceTier", async () => {
+      const budgetCars = [
+        createMockCar({ id: "budget-1", serviceTier: ServiceTier.STANDARD }),
+        createMockCar({ id: "budget-2", serviceTier: ServiceTier.STANDARD }),
+        createMockCar({ id: "budget-3", serviceTier: ServiceTier.STANDARD }),
+      ];
+      databaseServiceMock.car.findMany.mockResolvedValueOnce(budgetCars);
+
+      const result = await service.getCategorizedCars({ limit: 50 });
+
+      const budgetCategory = findCategory(result.categories, "budget");
+      expect(budgetCategory).toBeDefined();
+      expect(budgetCategory?.title).toBe("Budget-friendly");
+      expect(budgetCategory?.cars).toHaveLength(3);
+    });
+
+    it("categorizes popular cars by make (Toyota, Honda, Lexus)", async () => {
+      const popularCars = [
+        createMockCar({ id: "pop-1", make: "Toyota" }),
+        createMockCar({ id: "pop-2", make: "Honda" }),
+        createMockCar({ id: "pop-3", make: "Lexus" }),
+      ];
+      databaseServiceMock.car.findMany.mockResolvedValueOnce(popularCars);
+
+      const result = await service.getCategorizedCars({ limit: 50 });
+
+      const popularCategory = findCategory(result.categories, "popular");
+      expect(popularCategory).toBeDefined();
+      expect(popularCategory?.title).toBe("Popular");
+      expect(popularCategory?.cars).toHaveLength(3);
+    });
+
+    it("handles case-insensitive make matching for popular category", async () => {
+      const popularCars = [
+        createMockCar({ id: "pop-1", make: "TOYOTA" }),
+        createMockCar({ id: "pop-2", make: "honda" }),
+        createMockCar({ id: "pop-3", make: "LeXuS" }),
+      ];
+      databaseServiceMock.car.findMany.mockResolvedValueOnce(popularCars);
+
+      const result = await service.getCategorizedCars({ limit: 50 });
+
+      const popularCategory = findCategory(result.categories, "popular");
+      expect(popularCategory?.cars).toHaveLength(3);
+    });
+
+    it("excludes categories with less than 3 cars", async () => {
+      const cars = [
+        createMockCar({ id: "suv-1", vehicleType: VehicleType.SUV }),
+        createMockCar({ id: "suv-2", vehicleType: VehicleType.SUV }),
+        // Only 2 SUVs - should not show in categories
+      ];
+      databaseServiceMock.car.findMany.mockResolvedValueOnce(cars);
+
+      const result = await service.getCategorizedCars({ limit: 50 });
+
+      const suvsCategory = findCategory(result.categories, "suvs");
+      expect(suvsCategory).toBeUndefined();
+      expect(result.allCars).toHaveLength(2);
+    });
+
+    it("allows cars to appear in multiple categories", async () => {
+      // Lexus SUVs with LUXURY tier should appear in: suvs, luxury, popular
+      const cars = [
+        createMockCar({
+          id: "lexus-suv-1",
+          make: "Lexus",
+          vehicleType: VehicleType.LUXURY_SUV,
+          serviceTier: ServiceTier.LUXURY,
+        }),
+        createMockCar({
+          id: "lexus-suv-2",
+          make: "Lexus",
+          vehicleType: VehicleType.SUV,
+          serviceTier: ServiceTier.LUXURY,
+        }),
+        createMockCar({
+          id: "lexus-suv-3",
+          make: "Lexus",
+          vehicleType: VehicleType.SUV,
+          serviceTier: ServiceTier.LUXURY,
+        }),
+      ];
+      databaseServiceMock.car.findMany.mockResolvedValueOnce(cars);
+
+      const result = await service.getCategorizedCars({ limit: 50 });
+
+      expect(findCategory(result.categories, "suvs")?.cars).toHaveLength(3);
+      expect(findCategory(result.categories, "luxury")?.cars).toHaveLength(3);
+      expect(findCategory(result.categories, "popular")?.cars).toHaveLength(3);
+    });
+
+    it("respects the limit parameter", async () => {
+      databaseServiceMock.car.findMany.mockResolvedValueOnce([]);
+
+      await service.getCategorizedCars({ limit: 25 });
+
+      expect(databaseServiceMock.car.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ take: 25 }),
+      );
+    });
+
+    it("returns total count and allCars", async () => {
+      const cars = [
+        createMockCar({ id: "car-1" }),
+        createMockCar({ id: "car-2" }),
+        createMockCar({ id: "car-3" }),
+      ];
+      databaseServiceMock.car.findMany.mockResolvedValueOnce(cars);
+
+      const result = await service.getCategorizedCars({ limit: 50 });
+
+      expect(result.total).toBe(3);
+      expect(result.allCars).toHaveLength(3);
+    });
+
+    it("throws CarFetchFailedException when database query fails", async () => {
+      databaseServiceMock.car.findMany.mockRejectedValueOnce(new Error("Database error"));
+
+      await expect(service.getCategorizedCars({ limit: 50 })).rejects.toThrow(
+        CarFetchFailedException,
+      );
+    });
+  });
+});

--- a/src/modules/car/car-categories.service.ts
+++ b/src/modules/car/car-categories.service.ts
@@ -1,0 +1,94 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { CarApprovalStatus, Status } from "@prisma/client";
+import { DatabaseService } from "../database/database.service";
+import { CarException, CarFetchFailedException } from "./car.error";
+import type {
+  CarCategoriesQueryDto,
+  CarCategoriesResponseDto,
+  CarCategory,
+  CategoryName,
+  PublicCarDto,
+} from "./dto/car-categories.dto";
+import { CATEGORY_DEFINITIONS, MIN_CATEGORY_SIZE } from "./dto/car-categories.dto";
+
+@Injectable()
+export class CarCategoriesService {
+  private readonly logger = new Logger(CarCategoriesService.name);
+
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  /**
+   * Categorizes cars into meaningful groups for display.
+   * Returns an array of categories with name, title, and cars.
+   * Only includes categories that meet the minimum size threshold.
+   */
+  private categorizeCars(cars: PublicCarDto[]): CarCategory[] {
+    const buckets: Record<CategoryName, PublicCarDto[]> = {
+      suvs: [],
+      luxury: [],
+      budget: [],
+      sedans: [],
+      executive: [],
+      popular: [],
+    };
+
+    for (const car of cars) {
+      for (const { name, matcher } of CATEGORY_DEFINITIONS) {
+        if (matcher(car)) {
+          buckets[name].push(car);
+        }
+      }
+    }
+
+    // Build result array, only including categories that meet minimum size
+    return CATEGORY_DEFINITIONS.filter(({ name }) => buckets[name].length >= MIN_CATEGORY_SIZE).map(
+      ({ name, title }) => ({
+        name,
+        title,
+        cars: buckets[name],
+      }),
+    );
+  }
+
+  async getCategorizedCars(query: CarCategoriesQueryDto): Promise<CarCategoriesResponseDto> {
+    try {
+      const cars = await this.databaseService.car.findMany({
+        where: {
+          status: { in: [Status.AVAILABLE, Status.BOOKED] },
+          approvalStatus: CarApprovalStatus.APPROVED,
+          owner: { fleetOwnerStatus: "APPROVED", hasOnboarded: true },
+        },
+        select: {
+          id: true,
+          make: true,
+          model: true,
+          year: true,
+          dayRate: true,
+          passengerCapacity: true,
+          pricingIncludesFuel: true,
+          vehicleType: true,
+          serviceTier: true,
+          images: { select: { url: true }, orderBy: { createdAt: "asc" }, take: 3 },
+        },
+        orderBy: [{ updatedAt: "desc" }, { dayRate: "asc" }],
+        take: query.limit,
+      });
+
+      const categories = this.categorizeCars(cars);
+
+      return {
+        categories,
+        allCars: cars,
+        total: cars.length,
+      };
+    } catch (error) {
+      if (error instanceof CarException) {
+        throw error;
+      }
+      this.logger.error("Failed to fetch categorized cars", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw new CarFetchFailedException();
+    }
+  }
+}

--- a/src/modules/car/car-search.service.spec.ts
+++ b/src/modules/car/car-search.service.spec.ts
@@ -1,0 +1,349 @@
+import { Test, type TestingModule } from "@nestjs/testing";
+import { BookingType, ServiceTier, VehicleType } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DatabaseService } from "../database/database.service";
+import { CarFetchFailedException, CarNotFoundException } from "./car.error";
+import { CarSearchService } from "./car-search.service";
+import type { SearchCarDto } from "./dto/car-search.dto";
+import { mapQueryToFilters } from "./dto/car-search.dto";
+
+describe("CarSearchService", () => {
+  let service: CarSearchService;
+
+  const databaseServiceMock = {
+    car: {
+      findMany: vi.fn(),
+      findFirst: vi.fn(),
+      count: vi.fn(),
+    },
+    user: {
+      findMany: vi.fn(),
+    },
+    booking: {
+      findMany: vi.fn(),
+    },
+  };
+
+  const createMockCar = (overrides: Partial<SearchCarDto> = {}): SearchCarDto => ({
+    id: `car-${Math.random().toString(36).slice(2, 9)}`,
+    make: "Toyota",
+    model: "Camry",
+    year: 2022,
+    color: "Black",
+    dayRate: 50000,
+    nightRate: 60000,
+    fullDayRate: 100000,
+    airportPickupRate: 30000,
+    passengerCapacity: 4,
+    pricingIncludesFuel: true,
+    vehicleType: VehicleType.SEDAN,
+    serviceTier: ServiceTier.STANDARD,
+    images: [{ url: "https://example.com/car.jpg" }],
+    owner: { username: "fleetowner1", name: "Fleet Owner" },
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CarSearchService, { provide: DatabaseService, useValue: databaseServiceMock }],
+    }).compile();
+
+    service = module.get<CarSearchService>(CarSearchService);
+  });
+
+  describe("mapQueryToFilters", () => {
+    it("maps exact vehicle type match", () => {
+      expect(mapQueryToFilters("SUV")).toEqual({ vehicleType: VehicleType.SUV });
+      expect(mapQueryToFilters("sedan")).toEqual({ vehicleType: VehicleType.SEDAN });
+    });
+
+    it("maps exact service tier match", () => {
+      expect(mapQueryToFilters("Luxury")).toEqual({ serviceTier: ServiceTier.LUXURY });
+      expect(mapQueryToFilters("EXECUTIVE")).toEqual({ serviceTier: ServiceTier.EXECUTIVE });
+    });
+
+    it("extracts remaining query after mapping", () => {
+      const result = mapQueryToFilters("Toyota Luxury");
+      expect(result.serviceTier).toBe(ServiceTier.LUXURY);
+      expect(result.remainingQuery).toBe("Toyota");
+    });
+
+    it("returns query as remainingQuery when no mapping", () => {
+      expect(mapQueryToFilters("Mercedes")).toEqual({ remainingQuery: "Mercedes" });
+      expect(mapQueryToFilters("BMW X5")).toEqual({ remainingQuery: "BMW X5" });
+    });
+
+    it("handles case insensitive matching", () => {
+      expect(mapQueryToFilters("suv")).toEqual({ vehicleType: VehicleType.SUV });
+      expect(mapQueryToFilters("LUXURY")).toEqual({ serviceTier: ServiceTier.LUXURY });
+    });
+
+    it("returns remainingQuery for short queries (< 3 chars)", () => {
+      expect(mapQueryToFilters("AB")).toEqual({ remainingQuery: "AB" });
+    });
+  });
+
+  describe("searchCars", () => {
+    it("returns empty results when no cars exist", async () => {
+      databaseServiceMock.car.count.mockResolvedValueOnce(0);
+      databaseServiceMock.car.findMany.mockResolvedValueOnce([]);
+
+      const result = await service.searchCars({ page: 1, limit: 12 });
+
+      expect(result.cars).toEqual([]);
+      expect(result.pagination.total).toBe(0);
+      expect(result.pagination.totalPages).toBe(0);
+    });
+
+    it("returns cars matching serviceTier filter", async () => {
+      const luxuryCars = [
+        createMockCar({ id: "lux-1", serviceTier: ServiceTier.LUXURY }),
+        createMockCar({ id: "lux-2", serviceTier: ServiceTier.LUXURY }),
+      ];
+      databaseServiceMock.car.count.mockResolvedValueOnce(2);
+      databaseServiceMock.car.findMany.mockResolvedValueOnce(luxuryCars);
+
+      const result = await service.searchCars({
+        serviceTier: ServiceTier.LUXURY,
+        page: 1,
+        limit: 12,
+      });
+
+      expect(result.cars).toHaveLength(2);
+      expect(result.filters.serviceTier).toBe(ServiceTier.LUXURY);
+    });
+
+    it("returns cars matching vehicleType filter", async () => {
+      const suvCars = [
+        createMockCar({ id: "suv-1", vehicleType: VehicleType.SUV }),
+        createMockCar({ id: "suv-2", vehicleType: VehicleType.SUV }),
+      ];
+      databaseServiceMock.car.count.mockResolvedValueOnce(2);
+      databaseServiceMock.car.findMany.mockResolvedValueOnce(suvCars);
+
+      const result = await service.searchCars({
+        vehicleType: VehicleType.SUV,
+        page: 1,
+        limit: 12,
+      });
+
+      expect(result.cars).toHaveLength(2);
+      expect(result.filters.vehicleType).toBe(VehicleType.SUV);
+    });
+
+    it("maps free-text query to filters", async () => {
+      const luxuryCars = [createMockCar({ id: "lux-1", serviceTier: ServiceTier.LUXURY })];
+      databaseServiceMock.car.count.mockResolvedValueOnce(1);
+      databaseServiceMock.car.findMany.mockResolvedValueOnce(luxuryCars);
+
+      const result = await service.searchCars({
+        q: "Luxury",
+        page: 1,
+        limit: 12,
+      });
+
+      expect(result.filters.serviceTier).toBe(ServiceTier.LUXURY);
+    });
+
+    it("searches by make/model when query doesn't match filters", async () => {
+      const mercedesCars = [createMockCar({ id: "merc-1", make: "Mercedes" })];
+      databaseServiceMock.car.count.mockResolvedValueOnce(1);
+      databaseServiceMock.car.findMany.mockResolvedValueOnce(mercedesCars);
+
+      const result = await service.searchCars({
+        q: "Mercedes",
+        page: 1,
+        limit: 12,
+      });
+
+      expect(result.cars).toHaveLength(1);
+      expect(result.filters.serviceTier).toBeNull();
+      expect(result.filters.vehicleType).toBeNull();
+    });
+
+    it("filters by color", async () => {
+      const blackCars = [createMockCar({ id: "black-1", color: "Black" })];
+      databaseServiceMock.car.count.mockResolvedValueOnce(1);
+      databaseServiceMock.car.findMany.mockResolvedValueOnce(blackCars);
+
+      const result = await service.searchCars({
+        color: "Black",
+        page: 1,
+        limit: 12,
+      });
+
+      expect(result.cars).toHaveLength(1);
+    });
+
+    it("paginates results correctly", async () => {
+      const cars = Array.from({ length: 25 }, (_, i) => createMockCar({ id: `car-${i}` }));
+      databaseServiceMock.car.count.mockResolvedValueOnce(25);
+      databaseServiceMock.car.findMany.mockResolvedValueOnce(cars.slice(0, 12));
+
+      const result = await service.searchCars({ page: 1, limit: 12 });
+
+      expect(result.pagination.page).toBe(1);
+      expect(result.pagination.limit).toBe(12);
+      expect(result.pagination.total).toBe(25);
+      expect(result.pagination.totalPages).toBe(3);
+      expect(result.pagination.hasNextPage).toBe(true);
+      expect(result.pagination.hasPreviousPage).toBe(false);
+    });
+
+    it("returns hasPreviousPage true for page 2", async () => {
+      const cars = [createMockCar({ id: "car-1" })];
+      databaseServiceMock.car.count.mockResolvedValueOnce(15);
+      databaseServiceMock.car.findMany.mockResolvedValueOnce(cars);
+
+      const result = await service.searchCars({ page: 2, limit: 12 });
+
+      expect(result.pagination.hasPreviousPage).toBe(true);
+    });
+
+    it("excludes unavailable fleet owners when date provided", async () => {
+      const unavailableOwners = [{ id: "owner-busy" }];
+      databaseServiceMock.user.findMany.mockResolvedValueOnce(unavailableOwners);
+      databaseServiceMock.car.count.mockResolvedValueOnce(5);
+      databaseServiceMock.car.findMany.mockResolvedValueOnce([createMockCar({ id: "car-1" })]);
+
+      await service.searchCars({
+        from: new Date("2024-03-01"),
+        page: 1,
+        limit: 12,
+      });
+
+      expect(databaseServiceMock.user.findMany).toHaveBeenCalled();
+      expect(databaseServiceMock.car.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            AND: expect.arrayContaining([
+              expect.objectContaining({
+                ownerId: { notIn: ["owner-busy"] },
+              }),
+            ]),
+          }),
+        }),
+      );
+    });
+
+    it("filters by availability when booking params provided", async () => {
+      const cars = [createMockCar({ id: "car-available" })];
+
+      databaseServiceMock.user.findMany.mockResolvedValueOnce([]);
+      databaseServiceMock.car.count.mockResolvedValueOnce(1);
+      databaseServiceMock.car.findMany.mockResolvedValueOnce(cars);
+
+      const result = await service.searchCars({
+        from: new Date("2024-03-01"),
+        to: new Date("2024-03-02"),
+        bookingType: BookingType.NIGHT,
+        page: 1,
+        limit: 12,
+      });
+
+      expect(result.cars).toHaveLength(1);
+      expect(result.cars[0].id).toBe("car-available");
+      expect(databaseServiceMock.car.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            AND: expect.arrayContaining([
+              expect.objectContaining({
+                bookings: expect.objectContaining({
+                  none: expect.objectContaining({
+                    status: { in: ["CONFIRMED", "ACTIVE"] },
+                  }),
+                }),
+              }),
+            ]),
+          }),
+        }),
+      );
+    });
+
+    it("sets bookingType in filters when provided", async () => {
+      databaseServiceMock.user.findMany.mockResolvedValueOnce([]);
+      databaseServiceMock.car.count.mockResolvedValueOnce(0);
+      databaseServiceMock.car.findMany.mockResolvedValueOnce([]);
+
+      const result = await service.searchCars({
+        from: new Date("2024-03-01"),
+        to: new Date("2024-03-02"),
+        bookingType: BookingType.AIRPORT_PICKUP,
+        page: 1,
+        limit: 12,
+      });
+
+      expect(result.filters.bookingType).toBe(BookingType.AIRPORT_PICKUP);
+    });
+
+    it("throws CarFetchFailedException when database query fails", async () => {
+      databaseServiceMock.car.count.mockRejectedValueOnce(new Error("Database error"));
+
+      await expect(service.searchCars({ page: 1, limit: 12 })).rejects.toThrow(
+        CarFetchFailedException,
+      );
+    });
+
+    it("combines multiple filters", async () => {
+      const cars = [
+        createMockCar({
+          id: "match",
+          make: "Toyota",
+          serviceTier: ServiceTier.EXECUTIVE,
+          vehicleType: VehicleType.SUV,
+        }),
+      ];
+      databaseServiceMock.car.count.mockResolvedValueOnce(1);
+      databaseServiceMock.car.findMany.mockResolvedValueOnce(cars);
+
+      const result = await service.searchCars({
+        serviceTier: ServiceTier.EXECUTIVE,
+        vehicleType: VehicleType.SUV,
+        make: "Toyota",
+        page: 1,
+        limit: 12,
+      });
+
+      expect(result.cars).toHaveLength(1);
+      expect(result.filters.serviceTier).toBe(ServiceTier.EXECUTIVE);
+      expect(result.filters.vehicleType).toBe(VehicleType.SUV);
+    });
+  });
+
+  describe("getPublicCarById", () => {
+    it("returns a car when found", async () => {
+      const mockCar = {
+        ...createMockCar({ id: "car-123" }),
+        hourlyRate: 5000,
+        fuelUpgradeRate: 10000,
+      };
+      databaseServiceMock.car.findFirst.mockResolvedValueOnce(mockCar);
+
+      const result = await service.getPublicCarById("car-123");
+
+      expect(result).toEqual(mockCar);
+      expect(databaseServiceMock.car.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            id: "car-123",
+          }),
+        }),
+      );
+    });
+
+    it("throws CarNotFoundException when car not found", async () => {
+      databaseServiceMock.car.findFirst.mockResolvedValueOnce(null);
+
+      await expect(service.getPublicCarById("nonexistent-id")).rejects.toThrow(
+        CarNotFoundException,
+      );
+    });
+
+    it("throws CarFetchFailedException on database error", async () => {
+      databaseServiceMock.car.findFirst.mockRejectedValueOnce(new Error("Database error"));
+
+      await expect(service.getPublicCarById("car-123")).rejects.toThrow(CarFetchFailedException);
+    });
+  });
+});

--- a/src/modules/car/car-search.service.ts
+++ b/src/modules/car/car-search.service.ts
@@ -1,0 +1,331 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { BookingStatus, BookingType, CarApprovalStatus, Prisma, Status } from "@prisma/client";
+import { DatabaseService } from "../database/database.service";
+import { CarException, CarFetchFailedException, CarNotFoundException } from "./car.error";
+import type {
+  CarSearchQueryDto,
+  CarSearchResponseDto,
+  MappedQueryFilters,
+  PublicCarDetailDto,
+} from "./dto/car-search.dto";
+import { mapQueryToFilters } from "./dto/car-search.dto";
+
+interface AvailabilityWindow {
+  fromStart: Date;
+  endWindow: Date;
+}
+
+@Injectable()
+export class CarSearchService {
+  private readonly logger = new Logger(CarSearchService.name);
+
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  /**
+   * Parses search query params, applying free-text mapping if needed.
+   * Returns resolved filters with any mapped values from the query string.
+   */
+  private parseSearchFilters(query: CarSearchQueryDto): {
+    serviceTier: CarSearchQueryDto["serviceTier"];
+    vehicleType: CarSearchQueryDto["vehicleType"];
+    makeModelQuery: string | null;
+  } {
+    let serviceTier = query.serviceTier;
+    let vehicleType = query.vehicleType;
+    let makeModelQuery: string | null = null;
+
+    // If free-text query provided and no explicit filters, try to map it
+    if (query.q && !serviceTier && !vehicleType) {
+      const mapped: MappedQueryFilters = mapQueryToFilters(query.q);
+      if (mapped.vehicleType) vehicleType = mapped.vehicleType;
+      if (mapped.serviceTier) serviceTier = mapped.serviceTier;
+      makeModelQuery = mapped.remainingQuery?.trim() || null;
+    }
+
+    // If no mapping happened and there's a query, use it for make/model search
+    if (query.q && !serviceTier && !vehicleType && !makeModelQuery) {
+      makeModelQuery = query.q.trim();
+    }
+
+    return { serviceTier, vehicleType, makeModelQuery };
+  }
+
+  /**
+   * Builds Prisma where clause for car search
+   */
+  private buildWhereClause(
+    params: {
+      serviceTier: CarSearchQueryDto["serviceTier"];
+      vehicleType: CarSearchQueryDto["vehicleType"];
+      color: string | undefined;
+      make: string | undefined;
+      model: string | undefined;
+      makeModelQuery: string | null;
+    },
+    fleetOwnersToExclude: string[],
+    availabilityWindow: AvailabilityWindow | null,
+  ): Prisma.CarWhereInput {
+    return {
+      AND: [
+        {
+          ...(fleetOwnersToExclude.length > 0 && {
+            ownerId: { notIn: fleetOwnersToExclude },
+          }),
+          status: { in: [Status.AVAILABLE, Status.BOOKED] },
+          approvalStatus: CarApprovalStatus.APPROVED,
+          owner: { fleetOwnerStatus: "APPROVED", hasOnboarded: true },
+          ...(params.serviceTier && { serviceTier: params.serviceTier }),
+          ...(params.vehicleType && { vehicleType: params.vehicleType }),
+          ...(params.color && {
+            color: { contains: params.color, mode: Prisma.QueryMode.insensitive },
+          }),
+          ...(params.make && {
+            make: { contains: params.make, mode: Prisma.QueryMode.insensitive },
+          }),
+          ...(params.model && {
+            model: { contains: params.model, mode: Prisma.QueryMode.insensitive },
+          }),
+          ...(params.makeModelQuery && {
+            OR: [
+              { make: { contains: params.makeModelQuery, mode: Prisma.QueryMode.insensitive } },
+              { model: { contains: params.makeModelQuery, mode: Prisma.QueryMode.insensitive } },
+            ],
+          }),
+          ...(availabilityWindow && {
+            bookings: {
+              none: {
+                status: { in: [BookingStatus.CONFIRMED, BookingStatus.ACTIVE] },
+                AND: [
+                  { startDate: { lt: availabilityWindow.endWindow } },
+                  { endDate: { gt: availabilityWindow.fromStart } },
+                ],
+              },
+            },
+          }),
+        },
+      ],
+    };
+  }
+
+  /**
+   * Gets fleet owners who have no chauffeurs or all chauffeurs are busy on a specific date.
+   * Used to exclude their cars from search results for that date.
+   */
+  private async getUnavailableFleetOwners(date: Date): Promise<string[]> {
+    const year = date.getUTCFullYear();
+    const month = date.getUTCMonth();
+    const day = date.getUTCDate();
+
+    const startOfDay = new Date(Date.UTC(year, month, day, 0, 0, 0, 0));
+    const endOfDay = new Date(Date.UTC(year, month, day, 23, 59, 59, 999));
+
+    const unavailableOwners = await this.databaseService.user.findMany({
+      where: {
+        cars: { some: {} },
+        isOwnerDriver: false,
+        OR: [
+          { chauffeurs: { none: {} } },
+          {
+            chauffeurs: {
+              some: {},
+              every: {
+                bookingsAsChauffeur: {
+                  some: {
+                    status: {
+                      in: [BookingStatus.PENDING, BookingStatus.CONFIRMED, BookingStatus.ACTIVE],
+                    },
+                    AND: [{ startDate: { lte: endOfDay } }, { endDate: { gte: startOfDay } }],
+                  },
+                },
+              },
+            },
+          },
+        ],
+      },
+      select: { id: true },
+      distinct: ["id"],
+    });
+
+    this.logger.debug(
+      `Found ${unavailableOwners.length} unavailable fleet owners for ${date.toISOString()}`,
+    );
+
+    return unavailableOwners.map((owner) => owner.id);
+  }
+
+  private buildAvailabilityWindow(from: Date, to: Date): AvailabilityWindow {
+    // Normalize from date to start of day in UTC
+    const fromStart = new Date(from);
+    fromStart.setUTCHours(0, 0, 0, 0);
+
+    // End window is end of next day at 5 AM UTC
+    const endWindow = new Date(to);
+    endWindow.setUTCDate(endWindow.getUTCDate() + 1);
+    endWindow.setUTCHours(5, 0, 0, 0);
+
+    return { fromStart, endWindow };
+  }
+
+  /**
+   * Main search method - fetches cars matching the query and filters by availability.
+   */
+  async searchCars(query: CarSearchQueryDto): Promise<CarSearchResponseDto> {
+    const startTime = Date.now();
+
+    try {
+      // Parse filters from query
+      const { serviceTier, vehicleType, makeModelQuery } = this.parseSearchFilters(query);
+
+      // Get unavailable fleet owners for the date if provided
+      const fleetOwnersToExclude = query.from
+        ? await this.getUnavailableFleetOwners(query.from)
+        : [];
+
+      // Check if we have all required params for availability filtering
+      const canFilterByAvailability =
+        query.from &&
+        query.to &&
+        query.bookingType &&
+        (query.pickupTime ||
+          query.bookingType === BookingType.NIGHT ||
+          (query.bookingType === BookingType.AIRPORT_PICKUP && query.flightNumber));
+      const availabilityWindow = canFilterByAvailability
+        ? this.buildAvailabilityWindow(query.from, query.to)
+        : null;
+
+      // Build where clause
+      const whereClause = this.buildWhereClause(
+        {
+          serviceTier,
+          vehicleType,
+          color: query.color,
+          make: query.make,
+          model: query.model,
+          makeModelQuery,
+        },
+        fleetOwnersToExclude,
+        availabilityWindow,
+      );
+
+      // Pagination setup
+      const take = query.limit;
+      const skip = (query.page - 1) * query.limit;
+
+      const [totalCount, cars] = await Promise.all([
+        this.databaseService.car.count({ where: whereClause }),
+        this.databaseService.car.findMany({
+          where: whereClause,
+          select: {
+            id: true,
+            make: true,
+            model: true,
+            year: true,
+            color: true,
+            dayRate: true,
+            nightRate: true,
+            fullDayRate: true,
+            airportPickupRate: true,
+            passengerCapacity: true,
+            pricingIncludesFuel: true,
+            vehicleType: true,
+            serviceTier: true,
+            images: { select: { url: true }, orderBy: { createdAt: "asc" }, take: 4 },
+            owner: { select: { username: true, name: true } },
+          },
+          orderBy: [{ updatedAt: "desc" }, { dayRate: "asc" }],
+          skip,
+          take,
+        }),
+      ]);
+
+      // Calculate pagination
+      const totalPages = Math.ceil(totalCount / query.limit);
+      const hasNextPage = query.page < totalPages;
+      const hasPreviousPage = query.page > 1;
+
+      const totalTime = Date.now() - startTime;
+      this.logger.log(`Search completed in ${totalTime}ms`, {
+        totalCount,
+        returnedCount: cars.length,
+        page: query.page,
+      });
+
+      return {
+        cars,
+        filters: {
+          serviceTier: serviceTier ?? null,
+          vehicleType: vehicleType ?? null,
+          bookingType: query.bookingType ?? null,
+        },
+        pagination: {
+          page: query.page,
+          limit: query.limit,
+          total: totalCount,
+          totalPages,
+          hasNextPage,
+          hasPreviousPage,
+        },
+      };
+    } catch (error) {
+      if (error instanceof CarException) {
+        throw error;
+      }
+      this.logger.error("Search failed", {
+        error: error instanceof Error ? error.message : String(error),
+        query,
+      });
+      throw new CarFetchFailedException();
+    }
+  }
+
+  /**
+   * Fetches a single car by ID for public display.
+   * Only returns approved cars from approved fleet owners.
+   */
+  async getPublicCarById(carId: string): Promise<PublicCarDetailDto> {
+    try {
+      const car = await this.databaseService.car.findFirst({
+        where: {
+          id: carId,
+          status: { in: [Status.AVAILABLE, Status.BOOKED] },
+          approvalStatus: CarApprovalStatus.APPROVED,
+          owner: { fleetOwnerStatus: "APPROVED", hasOnboarded: true },
+        },
+        select: {
+          id: true,
+          make: true,
+          model: true,
+          year: true,
+          color: true,
+          dayRate: true,
+          hourlyRate: true,
+          nightRate: true,
+          fullDayRate: true,
+          airportPickupRate: true,
+          fuelUpgradeRate: true,
+          passengerCapacity: true,
+          pricingIncludesFuel: true,
+          vehicleType: true,
+          serviceTier: true,
+          images: { select: { url: true }, orderBy: { createdAt: "asc" } },
+          owner: { select: { username: true, name: true } },
+        },
+      });
+
+      if (!car) {
+        throw new CarNotFoundException();
+      }
+
+      return car;
+    } catch (error) {
+      if (error instanceof CarException) {
+        throw error;
+      }
+      this.logger.error("Failed to fetch public car", {
+        carId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw new CarFetchFailedException();
+    }
+  }
+}

--- a/src/modules/car/car.controller.spec.ts
+++ b/src/modules/car/car.controller.spec.ts
@@ -1,132 +1,228 @@
-import { Reflector } from "@nestjs/core";
 import { Test, type TestingModule } from "@nestjs/testing";
-import { ServiceTier, VehicleType } from "@prisma/client";
+import { BookingType, ServiceTier, VehicleType } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { AuthService } from "../auth/auth.service";
 import { CarController } from "./car.controller";
-import type { CarCreateFiles } from "./car.interface";
-import { CarService } from "./car.service";
-import type { CreateCarMultipartBodyDto } from "./dto/create-car.dto";
+import { CarCategoriesService } from "./car-categories.service";
+import { CarSearchService } from "./car-search.service";
+import type { CarCategoriesResponseDto, PublicCarDto } from "./dto/car-categories.dto";
+import type { CarSearchResponseDto, SearchCarDto } from "./dto/car-search.dto";
 
 describe("CarController", () => {
   let controller: CarController;
-  let carService: CarService;
+  let carCategoriesService: CarCategoriesService;
+  let carSearchService: CarSearchService;
 
-  const mockUser = {
-    id: "owner-1",
-    name: "Fleet Owner",
-    emailVerified: true,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    roles: ["fleetOwner" as const],
-  };
+  const createMockCar = (overrides: Partial<PublicCarDto> = {}): PublicCarDto => ({
+    id: `car-${Math.random().toString(36).slice(2, 9)}`,
+    make: "Toyota",
+    model: "Camry",
+    year: 2022,
+    dayRate: 50000,
+    passengerCapacity: 4,
+    pricingIncludesFuel: true,
+    vehicleType: VehicleType.SEDAN,
+    serviceTier: ServiceTier.STANDARD,
+    images: [{ url: "https://example.com/car.jpg" }],
+    ...overrides,
+  });
+
+  const createMockSearchCar = (overrides: Partial<SearchCarDto> = {}): SearchCarDto => ({
+    id: `car-${Math.random().toString(36).slice(2, 9)}`,
+    make: "Toyota",
+    model: "Camry",
+    year: 2022,
+    color: "Black",
+    dayRate: 50000,
+    nightRate: 60000,
+    fullDayRate: 100000,
+    airportPickupRate: 30000,
+    passengerCapacity: 4,
+    pricingIncludesFuel: true,
+    vehicleType: VehicleType.SEDAN,
+    serviceTier: ServiceTier.STANDARD,
+    images: [{ url: "https://example.com/car.jpg" }],
+    owner: { username: "fleetowner1", name: "Fleet Owner" },
+    ...overrides,
+  });
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [CarController],
       providers: [
         {
-          provide: CarService,
+          provide: CarCategoriesService,
           useValue: {
-            listOwnerCars: vi.fn(),
-            getOwnerCarById: vi.fn(),
-            createCar: vi.fn(),
-            updateCar: vi.fn(),
+            getCategorizedCars: vi.fn(),
           },
         },
         {
-          provide: AuthService,
+          provide: CarSearchService,
           useValue: {
-            isInitialized: true,
-            auth: {
-              api: {
-                getSession: vi.fn().mockResolvedValue(null),
-              },
-            },
-            getUserRoles: vi.fn().mockResolvedValue(["fleetOwner"]),
+            searchCars: vi.fn(),
+            getPublicCarById: vi.fn(),
           },
         },
-        Reflector,
       ],
     }).compile();
 
     controller = module.get<CarController>(CarController);
-    carService = module.get<CarService>(CarService);
+    carCategoriesService = module.get<CarCategoriesService>(CarCategoriesService);
+    carSearchService = module.get<CarSearchService>(CarSearchService);
   });
 
-  it("lists owner cars", async () => {
-    vi.mocked(carService.listOwnerCars).mockResolvedValueOnce([{ id: "car-1" }] as never);
+  describe("getCarCategories", () => {
+    it("returns categorized cars (GET /api/cars/categories)", async () => {
+      const mockResponse: CarCategoriesResponseDto = {
+        categories: [
+          {
+            name: "suvs",
+            title: "SUV",
+            cars: [
+              createMockCar({ id: "suv-1", vehicleType: VehicleType.SUV }),
+              createMockCar({ id: "suv-2", vehicleType: VehicleType.SUV }),
+              createMockCar({ id: "suv-3", vehicleType: VehicleType.LUXURY_SUV }),
+            ],
+          },
+        ],
+        allCars: [],
+        total: 3,
+      };
+      vi.mocked(carCategoriesService.getCategorizedCars).mockResolvedValueOnce(mockResponse);
 
-    const result = await controller.listOwnerCars(mockUser);
+      const result = await controller.getCarCategories({ limit: 50 });
 
-    expect(result).toEqual([{ id: "car-1" }]);
-    expect(carService.listOwnerCars).toHaveBeenCalledWith("owner-1");
+      expect(result).toEqual(mockResponse);
+      expect(carCategoriesService.getCategorizedCars).toHaveBeenCalledWith({ limit: 50 });
+    });
+
+    it("returns empty categories when no cars exist", async () => {
+      const emptyResponse: CarCategoriesResponseDto = {
+        categories: [],
+        allCars: [],
+        total: 0,
+      };
+      vi.mocked(carCategoriesService.getCategorizedCars).mockResolvedValueOnce(emptyResponse);
+
+      const result = await controller.getCarCategories({ limit: 50 });
+
+      expect(result.total).toBe(0);
+      expect(result.categories).toEqual([]);
+    });
   });
 
-  it("returns owner car detail", async () => {
-    vi.mocked(carService.getOwnerCarById).mockResolvedValueOnce({ id: "car-1" } as never);
-
-    const result = await controller.getOwnerCarById("car-1", mockUser);
-
-    expect(result).toEqual({ id: "car-1" });
-    expect(carService.getOwnerCarById).toHaveBeenCalledWith("car-1", "owner-1");
-  });
-
-  it("creates a car for authenticated fleet owner", async () => {
-    const body: CreateCarMultipartBodyDto = {
-      make: "Toyota",
-      model: "Camry",
-      year: 2022,
-      color: "",
-      registrationNumber: "ABC-123XY",
-      dayRate: 50000,
-      hourlyRate: 5000,
-      nightRate: 60000,
-      fullDayRate: 100000,
-      airportPickupRate: 30000,
-      pricingIncludesFuel: false,
-      fuelUpgradeRate: 10000,
-      vehicleType: VehicleType.SEDAN,
-      serviceTier: ServiceTier.STANDARD,
-      passengerCapacity: 4,
-    };
-    const files: CarCreateFiles = {
-      images: [
-        {
-          originalname: "car-1.jpg",
-          mimetype: "image/jpeg",
-          buffer: Buffer.from("image"),
-          size: 5,
+  describe("searchCars", () => {
+    it("returns search results (GET /api/cars/search)", async () => {
+      const mockResponse: CarSearchResponseDto = {
+        cars: [
+          createMockSearchCar({ id: "car-1", serviceTier: ServiceTier.LUXURY }),
+          createMockSearchCar({ id: "car-2", serviceTier: ServiceTier.LUXURY }),
+        ],
+        filters: {
+          serviceTier: ServiceTier.LUXURY,
+          vehicleType: null,
+          bookingType: null,
         },
-      ],
-      motCertificate: {
-        originalname: "mot.pdf",
-        mimetype: "application/pdf",
-        buffer: Buffer.from("pdf"),
-        size: 3,
-      },
-      insuranceCertificate: {
-        originalname: "insurance.pdf",
-        mimetype: "application/pdf",
-        buffer: Buffer.from("pdf"),
-        size: 3,
-      },
-    };
+        pagination: {
+          page: 1,
+          limit: 12,
+          total: 2,
+          totalPages: 1,
+          hasNextPage: false,
+          hasPreviousPage: false,
+        },
+      };
+      vi.mocked(carSearchService.searchCars).mockResolvedValueOnce(mockResponse);
 
-    vi.mocked(carService.createCar).mockResolvedValueOnce({ id: "car-1" } as never);
+      const result = await controller.searchCars({
+        serviceTier: ServiceTier.LUXURY,
+        page: 1,
+        limit: 12,
+      });
 
-    const result = await controller.createCar(body, files, mockUser);
+      expect(result).toEqual(mockResponse);
+      expect(carSearchService.searchCars).toHaveBeenCalledWith({
+        serviceTier: ServiceTier.LUXURY,
+        page: 1,
+        limit: 12,
+      });
+    });
 
-    expect(result).toEqual({ id: "car-1" });
-    expect(carService.createCar).toHaveBeenCalledWith("owner-1", body, files);
+    it("returns empty results when no cars match", async () => {
+      const emptyResponse: CarSearchResponseDto = {
+        cars: [],
+        filters: {
+          serviceTier: null,
+          vehicleType: null,
+          bookingType: null,
+        },
+        pagination: {
+          page: 1,
+          limit: 12,
+          total: 0,
+          totalPages: 0,
+          hasNextPage: false,
+          hasPreviousPage: false,
+        },
+      };
+      vi.mocked(carSearchService.searchCars).mockResolvedValueOnce(emptyResponse);
+
+      const result = await controller.searchCars({ page: 1, limit: 12 });
+
+      expect(result.cars).toEqual([]);
+      expect(result.pagination.total).toBe(0);
+    });
+
+    it("passes all query parameters to service", async () => {
+      const mockResponse: CarSearchResponseDto = {
+        cars: [],
+        filters: {
+          serviceTier: ServiceTier.EXECUTIVE,
+          vehicleType: VehicleType.SUV,
+          bookingType: BookingType.DAY,
+        },
+        pagination: {
+          page: 2,
+          limit: 10,
+          total: 15,
+          totalPages: 2,
+          hasNextPage: false,
+          hasPreviousPage: true,
+        },
+      };
+      vi.mocked(carSearchService.searchCars).mockResolvedValueOnce(mockResponse);
+
+      const query = {
+        q: "Toyota",
+        serviceTier: ServiceTier.EXECUTIVE,
+        vehicleType: VehicleType.SUV,
+        color: "Black",
+        make: "Toyota",
+        from: new Date("2024-03-01"),
+        to: new Date("2024-03-02"),
+        bookingType: BookingType.DAY,
+        page: 2,
+        limit: 10,
+      };
+
+      await controller.searchCars(query);
+
+      expect(carSearchService.searchCars).toHaveBeenCalledWith(query);
+    });
   });
 
-  it("updates owner car", async () => {
-    vi.mocked(carService.updateCar).mockResolvedValueOnce({ id: "car-1", status: "HOLD" } as never);
+  describe("getPublicCarById", () => {
+    it("returns a public car by ID (GET /api/cars/:carId)", async () => {
+      const mockCar = {
+        ...createMockSearchCar({ id: "car-123" }),
+        hourlyRate: 5000,
+        fuelUpgradeRate: 10000,
+      };
+      vi.mocked(carSearchService.getPublicCarById).mockResolvedValueOnce(mockCar);
 
-    const result = await controller.updateCar("car-1", { status: "HOLD" }, mockUser);
+      const result = await controller.getPublicCarById("car-123");
 
-    expect(result).toEqual({ id: "car-1", status: "HOLD" });
-    expect(carService.updateCar).toHaveBeenCalledWith("car-1", "owner-1", { status: "HOLD" });
+      expect(result).toEqual(mockCar);
+      expect(carSearchService.getPublicCarById).toHaveBeenCalledWith("car-123");
+    });
   });
 });

--- a/src/modules/car/car.controller.ts
+++ b/src/modules/car/car.controller.ts
@@ -1,62 +1,33 @@
-import {
-  Controller,
-  Get,
-  Patch,
-  Post,
-  UploadedFiles,
-  UseGuards,
-  UseInterceptors,
-} from "@nestjs/common";
-import { FileFieldsInterceptor } from "@nestjs/platform-express";
-import { ZodBody, ZodParam } from "../../common/decorators/zod-validation.decorator";
-import { FLEET_OWNER } from "../auth/auth.types";
-import { CurrentUser } from "../auth/decorators/current-user.decorator";
-import { Roles } from "../auth/decorators/roles.decorator";
-import { RoleGuard } from "../auth/guards/role.guard";
-import type { AuthSession } from "../auth/guards/session.guard";
-import { SessionGuard } from "../auth/guards/session.guard";
-import { CAR_UPLOAD_FIELD_CONFIG } from "./car.const";
-import type { CarCreateFiles } from "./car.interface";
-import { CarService } from "./car.service";
-import { CarCreateFilesPipe } from "./car-create-files.pipe";
-import { type CreateCarMultipartBodyDto, createCarMultipartBodySchema } from "./dto/create-car.dto";
-import { carIdParamSchema, type UpdateCarBodyDto, updateCarBodySchema } from "./dto/update-car.dto";
+import { Controller, Get, Header } from "@nestjs/common";
+import { ZodParam, ZodQuery } from "../../common/decorators/zod-validation.decorator";
+import { CarCategoriesService } from "./car-categories.service";
+import { CarSearchService } from "./car-search.service";
+import { type CarCategoriesQueryDto, carCategoriesQuerySchema } from "./dto/car-categories.dto";
+import { type CarSearchQueryDto, carSearchQuerySchema } from "./dto/car-search.dto";
+import { carIdParamSchema } from "./dto/update-car.dto";
 
 @Controller("api/cars")
-@UseGuards(SessionGuard, RoleGuard)
-@Roles(FLEET_OWNER)
 export class CarController {
-  constructor(private readonly carService: CarService) {}
+  constructor(
+    private readonly carCategoriesService: CarCategoriesService,
+    private readonly carSearchService: CarSearchService,
+  ) {}
 
-  @Get()
-  async listOwnerCars(@CurrentUser() sessionUser: AuthSession["user"]) {
-    return this.carService.listOwnerCars(sessionUser.id);
+  @Get("categories")
+  @Header("Cache-Control", "public, max-age=300, stale-while-revalidate=1800")
+  async getCarCategories(@ZodQuery(carCategoriesQuerySchema) query: CarCategoriesQueryDto) {
+    return this.carCategoriesService.getCategorizedCars(query);
+  }
+
+  @Get("search")
+  @Header("Cache-Control", "public, max-age=60, stale-while-revalidate=300")
+  async searchCars(@ZodQuery(carSearchQuerySchema) query: CarSearchQueryDto) {
+    return this.carSearchService.searchCars(query);
   }
 
   @Get(":carId")
-  async getOwnerCarById(
-    @ZodParam("carId", carIdParamSchema) carId: string,
-    @CurrentUser() sessionUser: AuthSession["user"],
-  ) {
-    return this.carService.getOwnerCarById(carId, sessionUser.id);
-  }
-
-  @Post()
-  @UseInterceptors(FileFieldsInterceptor([...CAR_UPLOAD_FIELD_CONFIG]))
-  async createCar(
-    @ZodBody(createCarMultipartBodySchema) body: CreateCarMultipartBodyDto,
-    @UploadedFiles(new CarCreateFilesPipe()) files: CarCreateFiles,
-    @CurrentUser() sessionUser: AuthSession["user"],
-  ) {
-    return this.carService.createCar(sessionUser.id, body, files);
-  }
-
-  @Patch(":carId")
-  async updateCar(
-    @ZodParam("carId", carIdParamSchema) carId: string,
-    @ZodBody(updateCarBodySchema) body: UpdateCarBodyDto,
-    @CurrentUser() sessionUser: AuthSession["user"],
-  ) {
-    return this.carService.updateCar(carId, sessionUser.id, body);
+  @Header("Cache-Control", "public, max-age=60, stale-while-revalidate=300")
+  async getPublicCarById(@ZodParam("carId", carIdParamSchema) carId: string) {
+    return this.carSearchService.getPublicCarById(carId);
   }
 }

--- a/src/modules/car/car.module.ts
+++ b/src/modules/car/car.module.ts
@@ -3,11 +3,14 @@ import { AuthModule } from "../auth/auth.module";
 import { StorageModule } from "../storage/storage.module";
 import { CarController } from "./car.controller";
 import { CarService } from "./car.service";
+import { CarCategoriesService } from "./car-categories.service";
+import { CarSearchService } from "./car-search.service";
+import { FleetOwnerCarController } from "./fleet-owner-car.controller";
 
 @Module({
   imports: [AuthModule, StorageModule],
-  controllers: [CarController],
-  providers: [CarService],
-  exports: [CarService],
+  controllers: [CarController, FleetOwnerCarController],
+  providers: [CarService, CarCategoriesService, CarSearchService],
+  exports: [CarService, CarCategoriesService, CarSearchService],
 })
 export class CarModule {}

--- a/src/modules/car/dto/car-categories.dto.ts
+++ b/src/modules/car/dto/car-categories.dto.ts
@@ -1,0 +1,115 @@
+import { ServiceTier, VehicleType } from "@prisma/client";
+import { z } from "zod";
+
+/** Minimum number of cars needed to show a category */
+export const MIN_CATEGORY_SIZE = 3;
+
+/**
+ * Query parameters for the car categories endpoint
+ */
+export const carCategoriesQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+});
+
+export type CarCategoriesQueryDto = z.infer<typeof carCategoriesQuerySchema>;
+
+/**
+ * Lightweight car type for public display (optimized for mobile/web)
+ * Only includes fields needed by CarCard components
+ */
+export interface PublicCarDto {
+  id: string;
+  make: string;
+  model: string;
+  year: number;
+  dayRate: number;
+  passengerCapacity: number;
+  pricingIncludesFuel: boolean;
+  vehicleType: VehicleType;
+  serviceTier: ServiceTier;
+  images: { url: string }[];
+}
+
+/**
+ * Category names as a const array for type safety
+ */
+export const CATEGORY_NAMES = [
+  "suvs",
+  "luxury",
+  "budget",
+  "sedans",
+  "executive",
+  "popular",
+] as const;
+
+export type CategoryName = (typeof CATEGORY_NAMES)[number];
+
+/**
+ * Category definition with matcher function and display title
+ */
+export interface CategoryDefinition {
+  name: CategoryName;
+  title: string;
+  matcher: (car: PublicCarDto) => boolean;
+}
+
+/**
+ * Category definitions - single source of truth for categorization logic.
+ * To add a new category: add to CATEGORY_NAMES and add a definition here.
+ */
+export const CATEGORY_DEFINITIONS: CategoryDefinition[] = [
+  {
+    name: "suvs",
+    title: "SUV",
+    matcher: (car) =>
+      car.vehicleType === VehicleType.SUV || car.vehicleType === VehicleType.LUXURY_SUV,
+  },
+  {
+    name: "luxury",
+    title: "Luxury",
+    matcher: (car) =>
+      car.serviceTier === ServiceTier.LUXURY || car.serviceTier === ServiceTier.ULTRA_LUXURY,
+  },
+  {
+    name: "budget",
+    title: "Budget-friendly",
+    matcher: (car) => car.serviceTier === ServiceTier.STANDARD,
+  },
+  {
+    name: "sedans",
+    title: "Sedans",
+    matcher: (car) =>
+      car.vehicleType === VehicleType.SEDAN || car.vehicleType === VehicleType.LUXURY_SEDAN,
+  },
+  {
+    name: "executive",
+    title: "Executive",
+    matcher: (car) => car.serviceTier === ServiceTier.EXECUTIVE,
+  },
+  {
+    name: "popular",
+    title: "Popular",
+    matcher: (car) => {
+      const popularMakes = new Set(["toyota", "honda", "lexus"]);
+      return popularMakes.has(car.make.toLowerCase());
+    },
+  },
+];
+
+/**
+ * Single category in the response array
+ */
+export interface CarCategory {
+  name: CategoryName;
+  title: string;
+  cars: PublicCarDto[];
+}
+
+/**
+ * Response shape for GET /api/cars/categories
+ */
+export interface CarCategoriesResponseDto {
+  categories: CarCategory[];
+  allCars: PublicCarDto[];
+  total: number;
+}

--- a/src/modules/car/dto/car-search.dto.ts
+++ b/src/modules/car/dto/car-search.dto.ts
@@ -1,0 +1,211 @@
+import { BookingType, ServiceTier, VehicleType } from "@prisma/client";
+import { z } from "zod";
+
+/**
+ * Mapping of free-text queries to vehicle types
+ */
+export const VEHICLE_TYPE_LABELS: Record<VehicleType, string> = {
+  SEDAN: "Sedan",
+  SUV: "SUV",
+  LUXURY_SEDAN: "Luxury Sedan",
+  LUXURY_SUV: "Luxury SUV",
+  VAN: "Van",
+  CROSSOVER: "Crossover",
+};
+
+/**
+ * Mapping of free-text queries to service tiers
+ */
+export const SERVICE_TIER_LABELS: Record<ServiceTier, string> = {
+  STANDARD: "Standard",
+  EXECUTIVE: "Executive",
+  LUXURY: "Luxury",
+  ULTRA_LUXURY: "Ultra Luxury",
+};
+
+/**
+ * Valid booking types for search
+ */
+export const BOOKING_TYPES = ["DAY", "NIGHT", "FULL_DAY", "AIRPORT_PICKUP"] as const;
+
+/**
+ * Query parameters schema for car search endpoint
+ */
+export const carSearchQuerySchema = z.object({
+  // Free-text search query (maps to vehicleType/serviceTier or make/model)
+  q: z.string().optional(),
+
+  // Direct filters
+  serviceTier: z.enum(Object.values(ServiceTier) as [ServiceTier, ...ServiceTier[]]).optional(),
+  vehicleType: z.enum(Object.values(VehicleType) as [VehicleType, ...VehicleType[]]).optional(),
+  color: z.string().optional(),
+  make: z.string().optional(),
+  model: z.string().optional(),
+
+  // Date/availability filters (accepts ISO strings like "2024-03-01" and coerces to Date)
+  from: z.coerce.date().optional(),
+  to: z.coerce.date().optional(),
+  bookingType: z.enum(Object.values(BookingType) as [BookingType, ...BookingType[]]).optional(),
+  // Pickup time: "9 AM", "9:00 AM", "11 PM", "2:30 PM" (matches booking DTO)
+  pickupTime: z
+    .string()
+    .regex(/^(1[0-2]|[1-9])(:[0-5]\d)?\s?(AM|PM)$/i, "Pickup time format: H:MM AM/PM")
+    .optional(),
+  flightNumber: z.string().optional(),
+
+  // Pagination
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(50).default(12),
+});
+
+export type CarSearchQueryDto = z.infer<typeof carSearchQuerySchema>;
+
+/**
+ * Car owner info for search results
+ */
+export interface CarOwnerDto {
+  username: string | null;
+  name: string;
+}
+
+/**
+ * Extended car type for search results (includes more fields than PublicCarDto)
+ */
+export interface SearchCarDto {
+  id: string;
+  make: string;
+  model: string;
+  year: number;
+  color: string | null;
+  dayRate: number;
+  nightRate: number | null;
+  fullDayRate: number | null;
+  airportPickupRate: number | null;
+  passengerCapacity: number;
+  pricingIncludesFuel: boolean;
+  vehicleType: VehicleType;
+  serviceTier: ServiceTier;
+  images: { url: string }[];
+  owner: CarOwnerDto;
+}
+
+/**
+ * Full car detail for public car detail endpoint
+ * Includes hourly rate and fuel upgrade rate for booking calculations
+ */
+export interface PublicCarDetailDto extends SearchCarDto {
+  hourlyRate: number | null;
+  fuelUpgradeRate: number | null;
+}
+
+/**
+ * Applied filters in the response (for client to display active filters)
+ */
+export interface SearchFiltersDto {
+  serviceTier: ServiceTier | null;
+  vehicleType: VehicleType | null;
+  bookingType: BookingType | null;
+}
+
+/**
+ * Pagination metadata
+ */
+export interface SearchPaginationDto {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+}
+
+/**
+ * Response shape for GET /api/cars/search
+ */
+export interface CarSearchResponseDto {
+  cars: SearchCarDto[];
+  filters: SearchFiltersDto;
+  pagination: SearchPaginationDto;
+}
+
+/**
+ * Result of mapping a free-text query to filters
+ */
+export interface MappedQueryFilters {
+  vehicleType?: VehicleType;
+  serviceTier?: ServiceTier;
+  remainingQuery?: string;
+}
+
+/**
+ * Maps a free-text query to vehicle type or service tier if possible.
+ * Returns the matched enum values and the remaining query text for make/model search.
+ *
+ * @example
+ * mapQueryToFilters("Toyota Luxury") // { serviceTier: "LUXURY", remainingQuery: "Toyota" }
+ * mapQueryToFilters("SUV") // { vehicleType: "SUV" }
+ * mapQueryToFilters("Mercedes") // { remainingQuery: "Mercedes" }
+ */
+export function mapQueryToFilters(query: string): MappedQueryFilters {
+  const normalizedQuery = query.trim().toLowerCase();
+  let remainingQuery = query.trim();
+
+  // Prioritize exact matches first
+  for (const [type, label] of Object.entries(VEHICLE_TYPE_LABELS)) {
+    if (normalizedQuery === label.toLowerCase() || normalizedQuery === type.toLowerCase()) {
+      return { vehicleType: type as VehicleType };
+    }
+  }
+
+  for (const [tier, label] of Object.entries(SERVICE_TIER_LABELS)) {
+    if (normalizedQuery === label.toLowerCase() || normalizedQuery === tier.toLowerCase()) {
+      return { serviceTier: tier as ServiceTier };
+    }
+  }
+
+  // Then try partial matches (only for queries with 3+ characters)
+  if (normalizedQuery.length < 3) {
+    return { remainingQuery };
+  }
+
+  // Track matched terms to extract them from the query
+  let matchedVehicleType: VehicleType | undefined;
+  let matchedServiceTier: ServiceTier | undefined;
+  let matchedLabel: string | undefined;
+
+  for (const [type, label] of Object.entries(VEHICLE_TYPE_LABELS)) {
+    if (
+      normalizedQuery.includes(label.toLowerCase()) ||
+      label.toLowerCase().includes(normalizedQuery)
+    ) {
+      matchedVehicleType = type as VehicleType;
+      matchedLabel = label;
+      break;
+    }
+  }
+
+  // Try to match service tiers (only if no vehicle type was matched)
+  if (!matchedVehicleType) {
+    for (const [tier, label] of Object.entries(SERVICE_TIER_LABELS)) {
+      if (
+        normalizedQuery.includes(label.toLowerCase()) ||
+        label.toLowerCase().includes(normalizedQuery)
+      ) {
+        matchedServiceTier = tier as ServiceTier;
+        matchedLabel = label;
+        break;
+      }
+    }
+  }
+
+  // Extract matched term from query to get remaining text for make/model search
+  if (matchedLabel) {
+    remainingQuery = remainingQuery.replaceAll(new RegExp(matchedLabel, "gi"), "").trim();
+  }
+
+  return {
+    vehicleType: matchedVehicleType,
+    serviceTier: matchedServiceTier,
+    remainingQuery: remainingQuery || undefined,
+  };
+}

--- a/src/modules/car/fleet-owner-car.controller.spec.ts
+++ b/src/modules/car/fleet-owner-car.controller.spec.ts
@@ -1,0 +1,143 @@
+import { Reflector } from "@nestjs/core";
+import { Test, type TestingModule } from "@nestjs/testing";
+import { ServiceTier, VehicleType } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthService } from "../auth/auth.service";
+import type { CarCreateFiles } from "./car.interface";
+import { CarService } from "./car.service";
+import type { CreateCarMultipartBodyDto } from "./dto/create-car.dto";
+import { FleetOwnerCarController } from "./fleet-owner-car.controller";
+
+describe("FleetOwnerCarController", () => {
+  let controller: FleetOwnerCarController;
+  let carService: CarService;
+
+  const mockUser = {
+    id: "owner-1",
+    name: "Fleet Owner",
+    emailVerified: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    roles: ["fleetOwner" as const],
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [FleetOwnerCarController],
+      providers: [
+        {
+          provide: CarService,
+          useValue: {
+            listOwnerCars: vi.fn(),
+            getOwnerCarById: vi.fn(),
+            createCar: vi.fn(),
+            updateCar: vi.fn(),
+          },
+        },
+        {
+          provide: AuthService,
+          useValue: {
+            isInitialized: true,
+            auth: {
+              api: {
+                getSession: vi.fn().mockResolvedValue(null),
+              },
+            },
+            getUserRoles: vi.fn().mockResolvedValue(["fleetOwner"]),
+          },
+        },
+        Reflector,
+      ],
+    }).compile();
+
+    controller = module.get<FleetOwnerCarController>(FleetOwnerCarController);
+    carService = module.get<CarService>(CarService);
+  });
+
+  describe("listOwnerCars", () => {
+    it("lists owner cars (GET /api/fleet-owner/cars)", async () => {
+      vi.mocked(carService.listOwnerCars).mockResolvedValueOnce([{ id: "car-1" }] as never);
+
+      const result = await controller.listOwnerCars(mockUser);
+
+      expect(result).toEqual([{ id: "car-1" }]);
+      expect(carService.listOwnerCars).toHaveBeenCalledWith("owner-1");
+    });
+  });
+
+  describe("getOwnerCarById", () => {
+    it("returns owner car detail (GET /api/fleet-owner/cars/:carId)", async () => {
+      vi.mocked(carService.getOwnerCarById).mockResolvedValueOnce({ id: "car-1" } as never);
+
+      const result = await controller.getOwnerCarById("car-1", mockUser);
+
+      expect(result).toEqual({ id: "car-1" });
+      expect(carService.getOwnerCarById).toHaveBeenCalledWith("car-1", "owner-1");
+    });
+  });
+
+  describe("createCar", () => {
+    it("creates a car for authenticated fleet owner (POST /api/fleet-owner/cars)", async () => {
+      const body: CreateCarMultipartBodyDto = {
+        make: "Toyota",
+        model: "Camry",
+        year: 2022,
+        color: "",
+        registrationNumber: "ABC-123XY",
+        dayRate: 50000,
+        hourlyRate: 5000,
+        nightRate: 60000,
+        fullDayRate: 100000,
+        airportPickupRate: 30000,
+        pricingIncludesFuel: false,
+        fuelUpgradeRate: 10000,
+        vehicleType: VehicleType.SEDAN,
+        serviceTier: ServiceTier.STANDARD,
+        passengerCapacity: 4,
+      };
+      const files: CarCreateFiles = {
+        images: [
+          {
+            originalname: "car-1.jpg",
+            mimetype: "image/jpeg",
+            buffer: Buffer.from("image"),
+            size: 5,
+          },
+        ],
+        motCertificate: {
+          originalname: "mot.pdf",
+          mimetype: "application/pdf",
+          buffer: Buffer.from("pdf"),
+          size: 3,
+        },
+        insuranceCertificate: {
+          originalname: "insurance.pdf",
+          mimetype: "application/pdf",
+          buffer: Buffer.from("pdf"),
+          size: 3,
+        },
+      };
+
+      vi.mocked(carService.createCar).mockResolvedValueOnce({ id: "car-1" } as never);
+
+      const result = await controller.createCar(body, files, mockUser);
+
+      expect(result).toEqual({ id: "car-1" });
+      expect(carService.createCar).toHaveBeenCalledWith("owner-1", body, files);
+    });
+  });
+
+  describe("updateCar", () => {
+    it("updates owner car (PATCH /api/fleet-owner/cars/:carId)", async () => {
+      vi.mocked(carService.updateCar).mockResolvedValueOnce({
+        id: "car-1",
+        status: "HOLD",
+      } as never);
+
+      const result = await controller.updateCar("car-1", { status: "HOLD" }, mockUser);
+
+      expect(result).toEqual({ id: "car-1", status: "HOLD" });
+      expect(carService.updateCar).toHaveBeenCalledWith("car-1", "owner-1", { status: "HOLD" });
+    });
+  });
+});

--- a/src/modules/car/fleet-owner-car.controller.ts
+++ b/src/modules/car/fleet-owner-car.controller.ts
@@ -1,0 +1,62 @@
+import {
+  Controller,
+  Get,
+  Patch,
+  Post,
+  UploadedFiles,
+  UseGuards,
+  UseInterceptors,
+} from "@nestjs/common";
+import { FileFieldsInterceptor } from "@nestjs/platform-express";
+import { ZodBody, ZodParam } from "../../common/decorators/zod-validation.decorator";
+import { FLEET_OWNER } from "../auth/auth.types";
+import { CurrentUser } from "../auth/decorators/current-user.decorator";
+import { Roles } from "../auth/decorators/roles.decorator";
+import { RoleGuard } from "../auth/guards/role.guard";
+import type { AuthSession } from "../auth/guards/session.guard";
+import { SessionGuard } from "../auth/guards/session.guard";
+import { CAR_UPLOAD_FIELD_CONFIG } from "./car.const";
+import type { CarCreateFiles } from "./car.interface";
+import { CarService } from "./car.service";
+import { CarCreateFilesPipe } from "./car-create-files.pipe";
+import { type CreateCarMultipartBodyDto, createCarMultipartBodySchema } from "./dto/create-car.dto";
+import { carIdParamSchema, type UpdateCarBodyDto, updateCarBodySchema } from "./dto/update-car.dto";
+
+@Controller("api/fleet-owner/cars")
+@UseGuards(SessionGuard, RoleGuard)
+@Roles(FLEET_OWNER)
+export class FleetOwnerCarController {
+  constructor(private readonly carService: CarService) {}
+
+  @Get()
+  async listOwnerCars(@CurrentUser() sessionUser: AuthSession["user"]) {
+    return this.carService.listOwnerCars(sessionUser.id);
+  }
+
+  @Get(":carId")
+  async getOwnerCarById(
+    @ZodParam("carId", carIdParamSchema) carId: string,
+    @CurrentUser() sessionUser: AuthSession["user"],
+  ) {
+    return this.carService.getOwnerCarById(carId, sessionUser.id);
+  }
+
+  @Post()
+  @UseInterceptors(FileFieldsInterceptor([...CAR_UPLOAD_FIELD_CONFIG]))
+  async createCar(
+    @ZodBody(createCarMultipartBodySchema) body: CreateCarMultipartBodyDto,
+    @UploadedFiles(new CarCreateFilesPipe()) files: CarCreateFiles,
+    @CurrentUser() sessionUser: AuthSession["user"],
+  ) {
+    return this.carService.createCar(sessionUser.id, body, files);
+  }
+
+  @Patch(":carId")
+  async updateCar(
+    @ZodParam("carId", carIdParamSchema) carId: string,
+    @ZodBody(updateCarBodySchema) body: UpdateCarBodyDto,
+    @CurrentUser() sessionUser: AuthSession["user"],
+  ) {
+    return this.carService.updateCar(carId, sessionUser.id, body);
+  }
+}

--- a/src/modules/referral/referral-throttler.guard.spec.ts
+++ b/src/modules/referral/referral-throttler.guard.spec.ts
@@ -1,0 +1,78 @@
+import type { ExecutionContext } from "@nestjs/common";
+import { Test, type TestingModule } from "@nestjs/testing";
+import { ThrottlerModule } from "@nestjs/throttler";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AUTH_SESSION_KEY } from "../auth/guards/session.guard";
+import { ReferralRateLimitExceededException } from "./referral.error";
+import { ReferralThrottlerGuard } from "./referral-throttler.guard";
+import { REFERRAL_THROTTLE_CONFIG } from "./referral-throttling.config";
+
+function createContext({
+  userId = "user-1",
+  ip = "10.10.10.10",
+  response = { setHeader: vi.fn() },
+}: {
+  userId?: string;
+  ip?: string;
+  response?: { setHeader: ReturnType<typeof vi.fn> };
+}): ExecutionContext {
+  const request = {
+    method: "GET",
+    route: { path: "validate/:code" },
+    headers: { "x-forwarded-for": ip },
+    [AUTH_SESSION_KEY]: { user: { id: userId } },
+  };
+
+  return {
+    switchToHttp: () => ({
+      getRequest: () => request,
+      getResponse: () => response,
+    }),
+  } as unknown as ExecutionContext;
+}
+
+describe("ReferralThrottlerGuard", () => {
+  let guard: ReferralThrottlerGuard;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        ThrottlerModule.forRoot([
+          {
+            name: REFERRAL_THROTTLE_CONFIG.name,
+            ttl: REFERRAL_THROTTLE_CONFIG.ttlMs,
+            limit: REFERRAL_THROTTLE_CONFIG.userLimit,
+          },
+        ]),
+      ],
+      providers: [ReferralThrottlerGuard],
+    }).compile();
+
+    guard = module.get<ReferralThrottlerGuard>(ReferralThrottlerGuard);
+  });
+
+  it("resolves with throttler storage dependency", () => {
+    expect(guard).toBeDefined();
+  });
+
+  it("allows request under rate limits", async () => {
+    await expect(guard.canActivate(createContext({}))).resolves.toBe(true);
+  });
+
+  it("throws rate limit exception after user limit is exceeded", async () => {
+    const response = { setHeader: vi.fn() };
+
+    for (let attempt = 0; attempt < REFERRAL_THROTTLE_CONFIG.userLimit; attempt += 1) {
+      await expect(guard.canActivate(createContext({ response }))).resolves.toBe(true);
+    }
+
+    await expect(guard.canActivate(createContext({ response }))).rejects.toThrow(
+      ReferralRateLimitExceededException,
+    );
+    expect(response.setHeader).toHaveBeenCalledWith(
+      "RateLimit-Limit",
+      String(REFERRAL_THROTTLE_CONFIG.userLimit),
+    );
+    expect(response.setHeader).toHaveBeenCalledWith("RateLimit-Remaining", "0");
+  });
+});

--- a/src/modules/referral/referral-throttling.config.ts
+++ b/src/modules/referral/referral-throttling.config.ts
@@ -1,0 +1,7 @@
+export const REFERRAL_THROTTLE_CONFIG = {
+  name: "referral-validation",
+  ttlMs: 60 * 60 * 1000,
+  ttlSeconds: 60 * 60,
+  userLimit: 20,
+  ipLimit: 60,
+} as const;

--- a/src/modules/referral/referral.module.ts
+++ b/src/modules/referral/referral.module.ts
@@ -12,6 +12,7 @@ import { ReferralService } from "./referral.service";
 import { ReferralApiService } from "./referral-api.service";
 import { ReferralProcessingService } from "./referral-processing.service";
 import { ReferralThrottlerGuard } from "./referral-throttler.guard";
+import { REFERRAL_THROTTLE_CONFIG } from "./referral-throttling.config";
 
 @Module({
   imports: [
@@ -19,9 +20,9 @@ import { ReferralThrottlerGuard } from "./referral-throttler.guard";
     DatabaseModule,
     ThrottlerModule.forRoot([
       {
-        name: "referral-validation",
-        ttl: 3600 * 1000,
-        limit: 10,
+        name: REFERRAL_THROTTLE_CONFIG.name,
+        ttl: REFERRAL_THROTTLE_CONFIG.ttlMs,
+        limit: REFERRAL_THROTTLE_CONFIG.userLimit,
       },
       {
         name: "manual-triggers",

--- a/src/modules/referral/referral.service.ts
+++ b/src/modules/referral/referral.service.ts
@@ -134,11 +134,12 @@ export class ReferralService {
       throw new ReferralUserNotFoundException();
     }
 
+    const nowAfterFetch = Date.now();
     this.userSummaryCache.set(cacheKey, {
       value: referralInfo,
-      expiresAt: now + this.userSummaryTtlMs,
+      expiresAt: nowAfterFetch + this.userSummaryTtlMs,
     });
-    this.pruneExpiredUserSummaryCache(now, this.maxPruneChecksPerWrite);
+    this.pruneExpiredUserSummaryCache(nowAfterFetch, this.maxPruneChecksPerWrite);
 
     return referralInfo;
   }

--- a/test/ai-search.e2e-spec.ts
+++ b/test/ai-search.e2e-spec.ts
@@ -1,0 +1,74 @@
+import { HttpStatus, type INestApplication } from "@nestjs/common";
+import { HttpAdapterHost } from "@nestjs/core";
+import { Test, type TestingModule } from "@nestjs/testing";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { AppModule } from "../src/app.module";
+import { GlobalExceptionFilter } from "../src/common/filters/global-exception.filter";
+import { AiSearchTimeoutException } from "../src/modules/ai-search/ai-search.error";
+import { OpenAiAiSearchExtractorService } from "../src/modules/ai-search/openai-ai-search-extractor.service";
+
+describe("AI Search E2E Tests", () => {
+  let app: INestApplication;
+  let extractorService: { extract: ReturnType<typeof vi.fn> };
+
+  beforeAll(async () => {
+    extractorService = {
+      extract: vi.fn(),
+    };
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(OpenAiAiSearchExtractorService)
+      .useValue(extractorService)
+      .compile();
+
+    app = moduleFixture.createNestApplication({ logger: false });
+    const httpAdapterHost = app.get(HttpAdapterHost);
+    app.useGlobalFilters(new GlobalExceptionFilter(httpAdapterHost));
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  it("POST /api/ai-search returns structured response", async () => {
+    extractorService.extract.mockResolvedValue({
+      make: "Toyota",
+      model: "Camry",
+      vehicleType: "SEDAN",
+      from: "2026-03-01",
+      to: "2026-03-02",
+      bookingType: "DAY",
+    });
+
+    const response = await request(app.getHttpServer())
+      .post("/api/ai-search")
+      .send({ query: "Need a toyota camry sedan for two days" });
+
+    expect(response.status).toBe(HttpStatus.CREATED);
+    expect(response.body.params.make).toBe("Toyota");
+    expect(response.body.raw.vehicleType).toBe("SEDAN");
+    expect(response.body.interpretation).toContain("Looking for:");
+    expect(response.headers["cache-control"]).toContain("no-store");
+  });
+
+  it("POST /api/ai-search returns 400 for invalid payload", async () => {
+    const response = await request(app.getHttpServer()).post("/api/ai-search").send({ query: "" });
+
+    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+  });
+
+  it("POST /api/ai-search returns timeout error when provider times out", async () => {
+    extractorService.extract.mockRejectedValue(new AiSearchTimeoutException());
+
+    const response = await request(app.getHttpServer())
+      .post("/api/ai-search")
+      .send({ query: "Need a car" });
+
+    expect(response.status).toBe(HttpStatus.GATEWAY_TIMEOUT);
+    expect(response.body.detail).toBe("AI search request timed out. Please try again.");
+  });
+});

--- a/test/cars.e2e-spec.ts
+++ b/test/cars.e2e-spec.ts
@@ -19,6 +19,7 @@ describe("Cars E2E Tests", () => {
   let secondOwnerCookie: string;
   let secondOwnerId: string;
   let userCookie: string;
+  let publicCarId: string;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -61,25 +62,39 @@ describe("Cars E2E Tests", () => {
 
     const userAuth = await factory.authenticateAndGetUser(uniqueEmail("cars-user"), "user");
     userCookie = userAuth.cookie;
+
+    await databaseService.user.update({
+      where: { id: ownerId },
+      data: { fleetOwnerStatus: "APPROVED", hasOnboarded: true },
+    });
+
+    const publicCar = await factory.createCar(ownerId, {
+      registrationNumber: "PUB-123AA",
+      approvalStatus: "APPROVED",
+      status: "AVAILABLE",
+    });
+    publicCarId = publicCar.id;
   });
 
   afterAll(async () => {
     await app.close();
   });
 
-  it("GET /api/cars returns 401 when unauthenticated", async () => {
-    const response = await request(app.getHttpServer()).get("/api/cars");
+  it("GET /api/fleet-owner/cars returns 401 when unauthenticated", async () => {
+    const response = await request(app.getHttpServer()).get("/api/fleet-owner/cars");
     expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
   });
 
-  it("GET /api/cars returns 403 when authenticated as non-fleet owner", async () => {
-    const response = await request(app.getHttpServer()).get("/api/cars").set("Cookie", userCookie);
+  it("GET /api/fleet-owner/cars returns 403 when authenticated as non-fleet owner", async () => {
+    const response = await request(app.getHttpServer())
+      .get("/api/fleet-owner/cars")
+      .set("Cookie", userCookie);
     expect(response.status).toBe(HttpStatus.FORBIDDEN);
   });
 
-  it("POST /api/cars creates car for fleet owner", async () => {
+  it("POST /api/fleet-owner/cars creates car for fleet owner", async () => {
     const response = await request(app.getHttpServer())
-      .post("/api/cars")
+      .post("/api/fleet-owner/cars")
       .set("Cookie", ownerCookie)
       .field("make", "Toyota")
       .field("model", "Camry")
@@ -116,10 +131,12 @@ describe("Cars E2E Tests", () => {
     expect(response.body.documents).toHaveLength(2);
   });
 
-  it("GET /api/cars lists only requesting fleet owner's cars", async () => {
+  it("GET /api/fleet-owner/cars lists only requesting fleet owner's cars", async () => {
     await factory.createCar(secondOwnerId, { registrationNumber: "ABC-987ZZ" });
 
-    const response = await request(app.getHttpServer()).get("/api/cars").set("Cookie", ownerCookie);
+    const response = await request(app.getHttpServer())
+      .get("/api/fleet-owner/cars")
+      .set("Cookie", ownerCookie);
 
     expect(response.status).toBe(HttpStatus.OK);
     expect(Array.isArray(response.body)).toBe(true);
@@ -127,14 +144,14 @@ describe("Cars E2E Tests", () => {
     expect(response.body.every((car: { ownerId: string }) => car.ownerId === ownerId)).toBe(true);
   });
 
-  it("GET /api/cars/:carId returns car detail for owner", async () => {
+  it("GET /api/fleet-owner/cars/:carId returns car detail for owner", async () => {
     const ownerCar = await databaseService.car.findFirstOrThrow({
       where: { ownerId, registrationNumber: "KJA-123AB" },
       select: { id: true },
     });
 
     const response = await request(app.getHttpServer())
-      .get(`/api/cars/${ownerCar.id}`)
+      .get(`/api/fleet-owner/cars/${ownerCar.id}`)
       .set("Cookie", ownerCookie);
 
     expect(response.status).toBe(HttpStatus.OK);
@@ -142,27 +159,27 @@ describe("Cars E2E Tests", () => {
     expect(response.body.ownerId).toBe(ownerId);
   });
 
-  it("GET /api/cars/:carId returns 404 for other fleet owner's car", async () => {
+  it("GET /api/fleet-owner/cars/:carId returns 404 for other fleet owner's car", async () => {
     const ownerCar = await databaseService.car.findFirstOrThrow({
       where: { ownerId, registrationNumber: "KJA-123AB" },
       select: { id: true },
     });
 
     const response = await request(app.getHttpServer())
-      .get(`/api/cars/${ownerCar.id}`)
+      .get(`/api/fleet-owner/cars/${ownerCar.id}`)
       .set("Cookie", secondOwnerCookie);
 
     expect(response.status).toBe(HttpStatus.NOT_FOUND);
   });
 
-  it("PATCH /api/cars/:carId updates owner car", async () => {
+  it("PATCH /api/fleet-owner/cars/:carId updates owner car", async () => {
     const ownerCar = await databaseService.car.findFirstOrThrow({
       where: { ownerId, registrationNumber: "KJA-123AB" },
       select: { id: true },
     });
 
     const response = await request(app.getHttpServer())
-      .patch(`/api/cars/${ownerCar.id}`)
+      .patch(`/api/fleet-owner/cars/${ownerCar.id}`)
       .set("Cookie", ownerCookie)
       .send({
         dayRate: 55000,
@@ -174,16 +191,54 @@ describe("Cars E2E Tests", () => {
     expect(response.body.status).toBe("HOLD");
   });
 
-  it("PATCH /api/cars/:carId returns 404 when updating another owner's car", async () => {
+  it("PATCH /api/fleet-owner/cars/:carId returns 404 when updating another owner's car", async () => {
     const ownerCar = await databaseService.car.findFirstOrThrow({
       where: { ownerId, registrationNumber: "KJA-123AB" },
       select: { id: true },
     });
 
     const response = await request(app.getHttpServer())
-      .patch(`/api/cars/${ownerCar.id}`)
+      .patch(`/api/fleet-owner/cars/${ownerCar.id}`)
       .set("Cookie", secondOwnerCookie)
       .send({ status: "AVAILABLE" });
+
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+  });
+
+  it("GET /api/cars/categories returns public categories payload", async () => {
+    const response = await request(app.getHttpServer()).get("/api/cars/categories?limit=20");
+
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(Array.isArray(response.body.categories)).toBe(true);
+    expect(Array.isArray(response.body.allCars)).toBe(true);
+    expect(response.body.total).toBeGreaterThanOrEqual(1);
+  });
+
+  it("GET /api/cars/search returns public search payload", async () => {
+    const response = await request(app.getHttpServer()).get("/api/cars/search?page=1&limit=12");
+
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(Array.isArray(response.body.cars)).toBe(true);
+    expect(response.body.pagination.page).toBe(1);
+    expect(response.body.pagination.limit).toBe(12);
+    expect(response.body.pagination.total).toBeGreaterThanOrEqual(1);
+  });
+
+  it("GET /api/cars/:carId returns approved public car detail", async () => {
+    const response = await request(app.getHttpServer()).get(`/api/cars/${publicCarId}`);
+
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(response.body.id).toBe(publicCarId);
+  });
+
+  it("GET /api/cars/:carId returns 404 for non-approved car", async () => {
+    const pendingCar = await factory.createCar(ownerId, {
+      registrationNumber: "PUB-404AA",
+      approvalStatus: "PENDING",
+      status: "AVAILABLE",
+    });
+
+    const response = await request(app.getHttpServer()).get(`/api/cars/${pendingCar.id}`);
 
     expect(response.status).toBe(HttpStatus.NOT_FOUND);
   });

--- a/test/flightaware.e2e-spec.ts
+++ b/test/flightaware.e2e-spec.ts
@@ -19,13 +19,9 @@ describe("FlightAware E2E Tests", () => {
   let flightAwareService: FlightAwareService;
   let webhookPath: string;
 
-  const originalFlightawareSecret = process.env.FLIGHTAWARE_WEBHOOK_SECRET;
-  const webhookSecret = "test-flightaware-webhook-secret";
   const upcomingDate = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
 
   beforeAll(async () => {
-    process.env.FLIGHTAWARE_WEBHOOK_SECRET = webhookSecret;
-
     const mockSendOtpEmail = vi.fn().mockResolvedValue(undefined);
     const mockFlightAwareService = {
       searchAirportPickupFlight: vi.fn(),
@@ -48,8 +44,7 @@ describe("FlightAware E2E Tests", () => {
     factory = new TestDataFactory(databaseService, app);
     flightAwareService = moduleFixture.get(FlightAwareService);
     const configService = app.get(ConfigService);
-    const configuredWebhookSecret =
-      configService.get("FLIGHTAWARE_WEBHOOK_SECRET") ?? webhookSecret;
+    const configuredWebhookSecret = configService.getOrThrow("FLIGHTAWARE_WEBHOOK_SECRET");
     webhookPath = `/api/webhooks/flightaware?secret=${configuredWebhookSecret}`;
 
     await app.init();
@@ -62,13 +57,6 @@ describe("FlightAware E2E Tests", () => {
 
   afterAll(async () => {
     await app.close();
-
-    if (originalFlightawareSecret === undefined) {
-      delete process.env.FLIGHTAWARE_WEBHOOK_SECRET;
-      return;
-    }
-
-    process.env.FLIGHTAWARE_WEBHOOK_SECRET = originalFlightawareSecret;
   });
 
   it("GET /api/search-flight returns info for non-Lagos destination", async () => {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -131,7 +131,7 @@ export class TestDataFactory {
 
     // Send OTP
     await request(this.app.getHttpServer())
-      .post("/auth/api/email-otp/send-verification-otp")
+      .post("/api/auth/email-otp/send-verification-otp")
       .set(authHeaders)
       .send({ email, type: "sign-in", role });
 
@@ -149,7 +149,7 @@ export class TestDataFactory {
 
     // Verify OTP
     const verifyResponse = await request(this.app.getHttpServer())
-      .post("/auth/api/sign-in/email-otp")
+      .post("/api/auth/sign-in/email-otp")
       .set(authHeaders)
       .send({ email, otp, role });
 

--- a/test/rates.e2e-spec.ts
+++ b/test/rates.e2e-spec.ts
@@ -219,7 +219,7 @@ describe("Rates Admin E2E Tests", () => {
       const response = await request(app.getHttpServer())
         .patch("/api/rates/addon/nonexistent/end")
         .set("Cookie", nonAdminCookie);
-      expect(response.status).toBe(HttpStatus.FORBIDDEN);
+      expect([HttpStatus.FORBIDDEN, HttpStatus.UNAUTHORIZED]).toContain(response.status);
     });
 
     it("should return 404 for non-existent addon rate", async () => {

--- a/test/referrals.e2e-spec.ts
+++ b/test/referrals.e2e-spec.ts
@@ -94,7 +94,7 @@ describe("Referrals E2E Tests", () => {
         .get("/api/referrals/validate/VALIDR01")
         .set("Cookie", freshAuth.cookie)
         .set("x-forwarded-for", "10.10.10.11")
-        .query({ email: "new-user@example.com" });
+        .query({ email: uniqueEmail("referral-validate-new") });
 
       expect(response.status).toBe(HttpStatus.OK);
       expect(response.body.valid).toBe(true);

--- a/test/referrals.e2e-spec.ts
+++ b/test/referrals.e2e-spec.ts
@@ -7,6 +7,7 @@ import { AppModule } from "../src/app.module";
 import { GlobalExceptionFilter } from "../src/common/filters/global-exception.filter";
 import { AuthEmailService } from "../src/modules/auth/auth-email.service";
 import { DatabaseService } from "../src/modules/database/database.service";
+import { REFERRAL_THROTTLE_CONFIG } from "../src/modules/referral/referral-throttling.config";
 import { TestDataFactory, uniqueEmail } from "./helpers";
 
 describe("Referrals E2E Tests", () => {
@@ -56,7 +57,7 @@ describe("Referrals E2E Tests", () => {
     });
 
     it("returns 429 after exceeding validation attempts from same IP", async () => {
-      for (let attempt = 0; attempt < 20; attempt += 1) {
+      for (let attempt = 0; attempt < REFERRAL_THROTTLE_CONFIG.userLimit; attempt += 1) {
         await request(app.getHttpServer())
           .get("/api/referrals/validate/INVAL123")
           .set("Cookie", userCookie)
@@ -71,8 +72,34 @@ describe("Referrals E2E Tests", () => {
       expect(response.status).toBe(HttpStatus.TOO_MANY_REQUESTS);
       expect(response.body.detail).toBe("Too many validation attempts. Please try again later.");
       expect(response.headers["retry-after"]).toBeDefined();
-      expect(response.headers["ratelimit-limit"]).toBe("20");
+      expect(response.headers["ratelimit-limit"]).toBe(String(REFERRAL_THROTTLE_CONFIG.userLimit));
       expect(response.headers["ratelimit-remaining"]).toBe("0");
+      expect(response.headers["ratelimit-policy"]).toBe(
+        `${REFERRAL_THROTTLE_CONFIG.userLimit};w=${REFERRAL_THROTTLE_CONFIG.ttlSeconds}`,
+      );
+    });
+
+    it("returns valid payload for an existing referral code", async () => {
+      const freshAuth = await factory.authenticateAndGetUser(
+        uniqueEmail("referral-validate"),
+        "user",
+      );
+
+      await databaseService.user.update({
+        where: { id: freshAuth.user.id },
+        data: { referralCode: "VALIDR01" },
+      });
+
+      const response = await request(app.getHttpServer())
+        .get("/api/referrals/validate/VALIDR01")
+        .set("Cookie", freshAuth.cookie)
+        .set("x-forwarded-for", "10.10.10.11")
+        .query({ email: "new-user@example.com" });
+
+      expect(response.status).toBe(HttpStatus.OK);
+      expect(response.body.valid).toBe(true);
+      expect(response.body.referrer.name).toBeDefined();
+      expect(response.body.message).toBe("Valid referral code.");
     });
   });
 

--- a/test/setup.e2e.ts
+++ b/test/setup.e2e.ts
@@ -5,6 +5,8 @@ import { vi } from "vitest";
 declare global {
   // eslint-disable-next-line no-var
   var __E2E_WORKER_ISOLATION_INITIALIZED__: boolean | undefined;
+  // eslint-disable-next-line no-var
+  var __E2E_REDIS_REJECTION_HANDLER_ATTACHED__: boolean | undefined;
 }
 
 function getWorkerId(): string {
@@ -98,6 +100,17 @@ async function initializeWorkerIsolation(): Promise<void> {
 }
 
 await initializeWorkerIsolation();
+
+if (!globalThis.__E2E_REDIS_REJECTION_HANDLER_ATTACHED__) {
+  process.on("unhandledRejection", (reason) => {
+    const message = reason instanceof Error ? reason.message : String(reason);
+    // Ignore known BullMQ/ioredis teardown race when test containers shut down.
+    if (message.includes("Connection is closed.")) {
+      return;
+    }
+  });
+  globalThis.__E2E_REDIS_REJECTION_HANDLER_ATTACHED__ = true;
+}
 
 // Mock email template rendering functions to avoid React dependency in e2e tests
 // The NotificationProcessor imports these functions which use @react-email/components (React)

--- a/test/setup.e2e.ts
+++ b/test/setup.e2e.ts
@@ -108,6 +108,12 @@ if (!globalThis.__E2E_REDIS_REJECTION_HANDLER_ATTACHED__) {
     if (message.includes("Connection is closed.")) {
       return;
     }
+    // Surface unexpected rejections to fail the test run.
+    // eslint-disable-next-line no-console
+    console.error("Unhandled rejection in e2e tests:", reason);
+    setImmediate(() => {
+      throw reason instanceof Error ? reason : new Error(message);
+    });
   });
   globalThis.__E2E_REDIS_REJECTION_HANDLER_ATTACHED__ = true;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new external OpenAI dependency and request path changes for Better Auth (`/api/auth`), which can break clients and introduces third-party call failure modes; referral changes also alter rate-limiting and caching behavior that could affect edge-case responses.
> 
> **Overview**
> Introduces a new **AI search** feature module exposing `POST /api/ai-search`, which uses the `openai` SDK to extract structured car-search parameters from free-text queries, validates the provider JSON via Zod, and returns both normalized params and a human-readable interpretation with explicit AI-specific error mapping.
> 
> Updates **authentication routing** to standardize Better Auth under `/api/auth` (including controller catch-all and config `basePath`) while keeping session retrieval at `/auth/session`, and makes `SessionGuard` treat provider errors as `401` instead of leaking failures.
> 
> Hardens **referrals** by centralizing throttling constants (`REFERRAL_THROTTLE_CONFIG`), injecting throttler storage properly, incrementing user/ip counters in parallel, and adding a short-lived in-memory cache + unified exception boundary/logging for referral summary/eligibility calls. E2E tests are updated accordingly, plus test setup now ignores a known Redis teardown `unhandledRejection` and adds coverage for AI search and referral validation payloads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1177c0d4941d32ec4195ebb2b3c3156990a05e2. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->