### PR TITLE
feat(whatsapp-agent): scaffold MVP async ingest-to-outbox pipeline

### DIFF
--- a/prisma/migrations/20260226195200_whatsapp_agent_mvp_reconcile/migration.sql
+++ b/prisma/migrations/20260226195200_whatsapp_agent_mvp_reconcile/migration.sql
@@ -19,26 +19,6 @@ CREATE TYPE "WhatsAppOutboxStatus" AS ENUM ('PENDING', 'PROCESSING', 'SENT', 'FA
 -- CreateEnum
 CREATE TYPE "WhatsAppDeliveryMode" AS ENUM ('FREE_FORM', 'TEMPLATE');
 
--- AlterEnum
-ALTER TYPE "PaymentAttemptStatus" ADD VALUE 'REFUND_ERROR';
-
--- DropIndex
-DROP INDEX "Review_bookingId_idx";
-
--- AlterTable
-ALTER TABLE "Payment" ADD COLUMN     "refundIdempotencyKey" TEXT;
-
--- AlterTable
-ALTER TABLE "User" DROP COLUMN "marketingConsent",
-DROP COLUMN "privacyAcceptedAt",
-DROP COLUMN "termsAcceptedAt";
-
--- AlterTable
-ALTER TABLE "_RoleToUser" ADD CONSTRAINT "_RoleToUser_AB_pkey" PRIMARY KEY ("A", "B");
-
--- DropIndex
-DROP INDEX "_RoleToUser_AB_unique";
-
 -- CreateTable
 CREATE TABLE "WhatsAppConversation" (
     "id" TEXT NOT NULL,
@@ -170,15 +150,6 @@ CREATE INDEX "BookingDraft_conversationId_status_idx" ON "BookingDraft"("convers
 -- CreateIndex
 CREATE INDEX "BookingDraft_updatedAt_idx" ON "BookingDraft"("updatedAt" DESC);
 
--- CreateIndex
-CREATE UNIQUE INDEX "FlightStatusEvent_flightId_eventType_eventTime_key" ON "FlightStatusEvent"("flightId", "eventType", "eventTime");
-
--- CreateIndex
-CREATE UNIQUE INDEX "Payment_refundIdempotencyKey_key" ON "Payment"("refundIdempotencyKey");
-
--- CreateIndex
-CREATE INDEX "Review_serviceRating_idx" ON "Review"("serviceRating");
-
 -- AddForeignKey
 ALTER TABLE "WhatsAppMessage" ADD CONSTRAINT "WhatsAppMessage_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "WhatsAppConversation"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
@@ -187,4 +158,3 @@ ALTER TABLE "WhatsAppOutbox" ADD CONSTRAINT "WhatsAppOutbox_conversationId_fkey"
 
 -- AddForeignKey
 ALTER TABLE "BookingDraft" ADD CONSTRAINT "BookingDraft_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "WhatsAppConversation"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-

--- a/prisma/migrations/20260226195200_whatsapp_agent_mvp_reconcile/migration.sql
+++ b/prisma/migrations/20260226195200_whatsapp_agent_mvp_reconcile/migration.sql
@@ -1,0 +1,190 @@
+-- CreateEnum
+CREATE TYPE "WhatsAppConversationStatus" AS ENUM ('ACTIVE', 'HANDOFF', 'CLOSED');
+
+-- CreateEnum
+CREATE TYPE "BookingDraftStatus" AS ENUM ('NEW', 'COLLECTING', 'QUOTED', 'AWAITING_PAYMENT', 'CONFIRMED', 'CLOSED', 'CANCELLED');
+
+-- CreateEnum
+CREATE TYPE "WhatsAppMessageDirection" AS ENUM ('INBOUND', 'OUTBOUND');
+
+-- CreateEnum
+CREATE TYPE "WhatsAppMessageKind" AS ENUM ('TEXT', 'IMAGE', 'AUDIO', 'DOCUMENT', 'LOCATION', 'INTERACTIVE', 'SYSTEM', 'UNKNOWN');
+
+-- CreateEnum
+CREATE TYPE "WhatsAppMessageStatus" AS ENUM ('RECEIVED', 'QUEUED', 'PROCESSED', 'SENT', 'DELIVERED', 'READ', 'FAILED');
+
+-- CreateEnum
+CREATE TYPE "WhatsAppOutboxStatus" AS ENUM ('PENDING', 'PROCESSING', 'SENT', 'FAILED', 'DEAD_LETTER');
+
+-- CreateEnum
+CREATE TYPE "WhatsAppDeliveryMode" AS ENUM ('FREE_FORM', 'TEMPLATE');
+
+-- AlterEnum
+ALTER TYPE "PaymentAttemptStatus" ADD VALUE 'REFUND_ERROR';
+
+-- DropIndex
+DROP INDEX "Review_bookingId_idx";
+
+-- AlterTable
+ALTER TABLE "Payment" ADD COLUMN     "refundIdempotencyKey" TEXT;
+
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "marketingConsent",
+DROP COLUMN "privacyAcceptedAt",
+DROP COLUMN "termsAcceptedAt";
+
+-- AlterTable
+ALTER TABLE "_RoleToUser" ADD CONSTRAINT "_RoleToUser_AB_pkey" PRIMARY KEY ("A", "B");
+
+-- DropIndex
+DROP INDEX "_RoleToUser_AB_unique";
+
+-- CreateTable
+CREATE TABLE "WhatsAppConversation" (
+    "id" TEXT NOT NULL,
+    "phoneE164" TEXT NOT NULL,
+    "waId" TEXT,
+    "profileName" TEXT,
+    "status" "WhatsAppConversationStatus" NOT NULL DEFAULT 'ACTIVE',
+    "lastInboundAt" TIMESTAMP(3),
+    "lastOutboundAt" TIMESTAMP(3),
+    "windowExpiresAt" TIMESTAMP(3),
+    "handoffReason" TEXT,
+    "handoffAt" TIMESTAMP(3),
+    "activeBookingDraftId" TEXT,
+    "processingLockToken" TEXT,
+    "processingLockExpiresAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "WhatsAppConversation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "WhatsAppMessage" (
+    "id" TEXT NOT NULL,
+    "conversationId" TEXT NOT NULL,
+    "providerMessageSid" TEXT,
+    "dedupeKey" TEXT NOT NULL,
+    "direction" "WhatsAppMessageDirection" NOT NULL,
+    "kind" "WhatsAppMessageKind" NOT NULL DEFAULT 'UNKNOWN',
+    "status" "WhatsAppMessageStatus" NOT NULL DEFAULT 'RECEIVED',
+    "body" TEXT,
+    "mediaUrl" TEXT,
+    "mediaContentType" TEXT,
+    "providerStatus" TEXT,
+    "errorCode" TEXT,
+    "errorMessage" TEXT,
+    "rawPayload" JSONB NOT NULL,
+    "receivedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "processedAt" TIMESTAMP(3),
+    "sentAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "WhatsAppMessage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "WhatsAppOutbox" (
+    "id" TEXT NOT NULL,
+    "conversationId" TEXT NOT NULL,
+    "dedupeKey" TEXT NOT NULL,
+    "mode" "WhatsAppDeliveryMode" NOT NULL,
+    "status" "WhatsAppOutboxStatus" NOT NULL DEFAULT 'PENDING',
+    "textBody" TEXT,
+    "mediaUrl" TEXT,
+    "templateName" TEXT,
+    "templateVariables" JSONB,
+    "payload" JSONB,
+    "providerMessageSid" TEXT,
+    "failureReason" TEXT,
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "maxAttempts" INTEGER NOT NULL DEFAULT 5,
+    "nextAttemptAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastAttemptAt" TIMESTAMP(3),
+    "sentAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "WhatsAppOutbox_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "BookingDraft" (
+    "id" TEXT NOT NULL,
+    "conversationId" TEXT NOT NULL,
+    "status" "BookingDraftStatus" NOT NULL DEFAULT 'NEW',
+    "state" JSONB NOT NULL,
+    "selectedOptionId" TEXT,
+    "quoteExpiresAt" TIMESTAMP(3),
+    "checkoutUrl" TEXT,
+    "checkoutExpiresAt" TIMESTAMP(3),
+    "linkedBookingId" TEXT,
+    "paymentStatus" "PaymentStatus",
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "BookingDraft_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WhatsAppConversation_phoneE164_key" ON "WhatsAppConversation"("phoneE164");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WhatsAppConversation_waId_key" ON "WhatsAppConversation"("waId");
+
+-- CreateIndex
+CREATE INDEX "WhatsAppConversation_status_idx" ON "WhatsAppConversation"("status");
+
+-- CreateIndex
+CREATE INDEX "WhatsAppConversation_windowExpiresAt_idx" ON "WhatsAppConversation"("windowExpiresAt");
+
+-- CreateIndex
+CREATE INDEX "WhatsAppConversation_processingLockExpiresAt_idx" ON "WhatsAppConversation"("processingLockExpiresAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WhatsAppMessage_providerMessageSid_key" ON "WhatsAppMessage"("providerMessageSid");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WhatsAppMessage_dedupeKey_key" ON "WhatsAppMessage"("dedupeKey");
+
+-- CreateIndex
+CREATE INDEX "WhatsAppMessage_conversationId_receivedAt_idx" ON "WhatsAppMessage"("conversationId", "receivedAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "WhatsAppMessage_direction_status_idx" ON "WhatsAppMessage"("direction", "status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WhatsAppOutbox_dedupeKey_key" ON "WhatsAppOutbox"("dedupeKey");
+
+-- CreateIndex
+CREATE INDEX "WhatsAppOutbox_conversationId_createdAt_idx" ON "WhatsAppOutbox"("conversationId", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "WhatsAppOutbox_status_nextAttemptAt_idx" ON "WhatsAppOutbox"("status", "nextAttemptAt");
+
+-- CreateIndex
+CREATE INDEX "BookingDraft_conversationId_status_idx" ON "BookingDraft"("conversationId", "status");
+
+-- CreateIndex
+CREATE INDEX "BookingDraft_updatedAt_idx" ON "BookingDraft"("updatedAt" DESC);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FlightStatusEvent_flightId_eventType_eventTime_key" ON "FlightStatusEvent"("flightId", "eventType", "eventTime");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Payment_refundIdempotencyKey_key" ON "Payment"("refundIdempotencyKey");
+
+-- CreateIndex
+CREATE INDEX "Review_serviceRating_idx" ON "Review"("serviceRating");
+
+-- AddForeignKey
+ALTER TABLE "WhatsAppMessage" ADD CONSTRAINT "WhatsAppMessage_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "WhatsAppConversation"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "WhatsAppOutbox" ADD CONSTRAINT "WhatsAppOutbox_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "WhatsAppConversation"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BookingDraft" ADD CONSTRAINT "BookingDraft_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "WhatsAppConversation"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/prisma/migrations/20260226201000_add_whatsapp_draft_pointer_relations/migration.sql
+++ b/prisma/migrations/20260226201000_add_whatsapp_draft_pointer_relations/migration.sql
@@ -1,0 +1,15 @@
+-- AddForeignKey
+ALTER TABLE "WhatsAppConversation"
+ADD CONSTRAINT "WhatsAppConversation_activeBookingDraftId_fkey"
+FOREIGN KEY ("activeBookingDraftId")
+REFERENCES "BookingDraft"("id")
+ON DELETE SET NULL
+ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BookingDraft"
+ADD CONSTRAINT "BookingDraft_linkedBookingId_fkey"
+FOREIGN KEY ("linkedBookingId")
+REFERENCES "Booking"("id")
+ON DELETE SET NULL
+ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -743,6 +743,160 @@ model ReferralProgramConfig {
   updatedBy String?
 }
 
+enum WhatsAppConversationStatus {
+  ACTIVE
+  HANDOFF
+  CLOSED
+}
+
+enum BookingDraftStatus {
+  NEW
+  COLLECTING
+  QUOTED
+  AWAITING_PAYMENT
+  CONFIRMED
+  CLOSED
+  CANCELLED
+}
+
+enum WhatsAppMessageDirection {
+  INBOUND
+  OUTBOUND
+}
+
+enum WhatsAppMessageKind {
+  TEXT
+  IMAGE
+  AUDIO
+  DOCUMENT
+  LOCATION
+  INTERACTIVE
+  SYSTEM
+  UNKNOWN
+}
+
+enum WhatsAppMessageStatus {
+  RECEIVED
+  QUEUED
+  PROCESSED
+  SENT
+  DELIVERED
+  READ
+  FAILED
+}
+
+enum WhatsAppOutboxStatus {
+  PENDING
+  PROCESSING
+  SENT
+  FAILED
+  DEAD_LETTER
+}
+
+enum WhatsAppDeliveryMode {
+  FREE_FORM
+  TEMPLATE
+}
+
+model WhatsAppConversation {
+  id                      String                     @id @default(cuid())
+  phoneE164               String                     @unique
+  waId                    String?                    @unique
+  profileName             String?
+  status                  WhatsAppConversationStatus @default(ACTIVE)
+  lastInboundAt           DateTime?
+  lastOutboundAt          DateTime?
+  windowExpiresAt         DateTime?
+  handoffReason           String?
+  handoffAt               DateTime?
+  activeBookingDraftId    String?
+  processingLockToken     String?
+  processingLockExpiresAt DateTime?
+  messages                WhatsAppMessage[]
+  outboxItems             WhatsAppOutbox[]
+  bookingDrafts           BookingDraft[]
+  createdAt               DateTime                   @default(now())
+  updatedAt               DateTime                   @updatedAt
+
+  @@index([status])
+  @@index([windowExpiresAt])
+  @@index([processingLockExpiresAt])
+}
+
+model WhatsAppMessage {
+  id                 String                   @id @default(cuid())
+  conversationId     String
+  providerMessageSid String?                  @unique
+  dedupeKey          String                   @unique
+  direction          WhatsAppMessageDirection
+  kind               WhatsAppMessageKind      @default(UNKNOWN)
+  status             WhatsAppMessageStatus    @default(RECEIVED)
+  body               String?
+  mediaUrl           String?
+  mediaContentType   String?
+  providerStatus     String?
+  errorCode          String?
+  errorMessage       String?
+  rawPayload         Json
+  receivedAt         DateTime                 @default(now())
+  processedAt        DateTime?
+  sentAt             DateTime?
+  createdAt          DateTime                 @default(now())
+  updatedAt          DateTime                 @updatedAt
+
+  conversation WhatsAppConversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
+
+  @@index([conversationId, receivedAt(sort: Desc)])
+  @@index([direction, status])
+}
+
+model WhatsAppOutbox {
+  id                 String               @id @default(cuid())
+  conversationId     String
+  dedupeKey          String               @unique
+  mode               WhatsAppDeliveryMode
+  status             WhatsAppOutboxStatus @default(PENDING)
+  textBody           String?
+  mediaUrl           String?
+  templateName       String?
+  templateVariables  Json?
+  payload            Json?
+  providerMessageSid String?
+  failureReason      String?
+  attempts           Int                  @default(0)
+  maxAttempts        Int                  @default(5)
+  nextAttemptAt      DateTime             @default(now())
+  lastAttemptAt      DateTime?
+  sentAt             DateTime?
+  createdAt          DateTime             @default(now())
+  updatedAt          DateTime             @updatedAt
+
+  conversation WhatsAppConversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
+
+  @@index([conversationId, createdAt(sort: Desc)])
+  @@index([status, nextAttemptAt])
+}
+
+model BookingDraft {
+  id                String             @id @default(cuid())
+  conversationId    String
+  status            BookingDraftStatus @default(NEW)
+  state             Json
+  selectedOptionId  String?
+  quoteExpiresAt    DateTime?
+  checkoutUrl       String?
+  checkoutExpiresAt DateTime?
+  linkedBookingId   String?
+  paymentStatus     PaymentStatus?
+  createdAt         DateTime           @default(now())
+  updatedAt         DateTime           @updatedAt
+
+  conversation WhatsAppConversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
+
+  @@index([conversationId, status])
+  @@index([updatedAt(sort: Desc)])
+}
+
 // Better-auth required tables
 model Session {
   id        String   @id @default(cuid())

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -272,6 +272,7 @@ model Booking {
   payoutTransactions PayoutTransaction[] @relation("BookingPayouts")
   referralRewards    ReferralReward[]
   review             Review?             @relation("BookingReview")
+  linkedDrafts       BookingDraft[]      @relation("LinkedBookingDraft")
 
   @@index([bookingReference])
   @@index([carId])
@@ -810,11 +811,12 @@ model WhatsAppConversation {
   handoffReason           String?
   handoffAt               DateTime?
   activeBookingDraftId    String?
+  activeBookingDraft      BookingDraft?               @relation("ActiveConversationDraft", fields: [activeBookingDraftId], references: [id], onDelete: SetNull)
   processingLockToken     String?
   processingLockExpiresAt DateTime?
   messages                WhatsAppMessage[]
   outboxItems             WhatsAppOutbox[]
-  bookingDrafts           BookingDraft[]
+  bookingDrafts           BookingDraft[]              @relation("ConversationDrafts")
   createdAt               DateTime                   @default(now())
   updatedAt               DateTime                   @updatedAt
 
@@ -887,11 +889,13 @@ model BookingDraft {
   checkoutUrl       String?
   checkoutExpiresAt DateTime?
   linkedBookingId   String?
+  linkedBooking     Booking?           @relation("LinkedBookingDraft", fields: [linkedBookingId], references: [id], onDelete: SetNull)
   paymentStatus     PaymentStatus?
   createdAt         DateTime           @default(now())
   updatedAt         DateTime           @updatedAt
 
-  conversation WhatsAppConversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
+  conversation          WhatsAppConversation   @relation("ConversationDrafts", fields: [conversationId], references: [id], onDelete: Cascade)
+  activeForConversations WhatsAppConversation[] @relation("ActiveConversationDraft")
 
   @@index([conversationId, status])
   @@index([updatedAt(sort: Desc)])

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -28,6 +28,7 @@ import { ReferralModule } from "./modules/referral/referral.module";
 import { ReminderModule } from "./modules/reminder/reminder.module";
 import { ReviewsModule } from "./modules/reviews/reviews.module";
 import { StatusChangeModule } from "./modules/status-change/status-change.module";
+import { WhatsAppAgentModule } from "./modules/whatsapp-agent/whatsapp-agent.module";
 
 @Module({
   imports: [
@@ -157,6 +158,7 @@ import { StatusChangeModule } from "./modules/status-change/status-change.module
     FlutterwaveModule,
     DocumentsModule,
     MessagingModule,
+    WhatsAppAgentModule,
     NotificationModule,
     PaymentModule,
     ReminderModule,

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -6,7 +6,10 @@ export const REMINDERS_QUEUE = "reminders-queue";
 export const REFERRAL_QUEUE = "referral-queue";
 export const PAYOUTS_QUEUE = "payouts-queue";
 export const FLIGHT_ALERTS_QUEUE = "flight-alerts-queue";
+export const WHATSAPP_AGENT_QUEUE = "whatsapp-agent-queue";
 export const CREATE_FLIGHT_ALERT_JOB = "create-flight-alert";
+export const PROCESS_WHATSAPP_INBOUND_JOB = "process-whatsapp-inbound";
+export const PROCESS_WHATSAPP_OUTBOX_JOB = "process-whatsapp-outbox";
 
 export const EVERY_HOUR = "0 * * * *";
 export const CONFIRMED_TO_ACTIVE = "confirmed-to-active";

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,12 @@
 import otelSdk from "./tracing";
 import "reflect-metadata";
+
+// Surface unhandled rejections during bootstrap (e.g. Redis/DB connection failures)
+process.on("unhandledRejection", (reason, promise) => {
+  console.error("[Bootstrap] Unhandled rejection:", reason);
+  console.error("Promise:", promise);
+});
+
 import { Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { HttpAdapterHost, NestFactory } from "@nestjs/core";
@@ -83,7 +90,11 @@ async function bootstrap() {
     );
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
+    const errorStack = error instanceof Error ? error.stack : undefined;
     logger.error(`Failed to start application: ${errorMessage}`);
+    // Ensure error is visible even if logger hasn't flushed
+    console.error(`[Bootstrap] Failed to start:`, errorMessage);
+    if (errorStack) console.error(errorStack);
     process.exit(1);
   }
 }

--- a/src/modules/whatsapp-agent/whatsapp-agent.const.ts
+++ b/src/modules/whatsapp-agent/whatsapp-agent.const.ts
@@ -1,6 +1,25 @@
+import type { JobsOptions } from "bullmq";
+
 export const WHATSAPP_AGENT_ACK_XML = "<Response></Response>";
 export const WHATSAPP_SERVICE_WINDOW_HOURS = 24;
 export const WHATSAPP_PROCESSING_LOCK_TTL_MS = 60_000;
 
 export const WHATSAPP_DEFAULT_JOB_ATTEMPTS = 3;
 export const WHATSAPP_DEFAULT_BACKOFF_MS = 2_000;
+export const WHATSAPP_DEFAULT_REMOVE_ON_COMPLETE = 100;
+export const WHATSAPP_DEFAULT_REMOVE_ON_FAIL = 50;
+
+export const WHATSAPP_QUEUE_DEFAULT_JOB_OPTIONS: Pick<
+  JobsOptions,
+  "attempts" | "backoff" | "removeOnComplete" | "removeOnFail"
+> = {
+  attempts: WHATSAPP_DEFAULT_JOB_ATTEMPTS,
+  backoff: { type: "exponential", delay: WHATSAPP_DEFAULT_BACKOFF_MS },
+  removeOnComplete: WHATSAPP_DEFAULT_REMOVE_ON_COMPLETE,
+  removeOnFail: WHATSAPP_DEFAULT_REMOVE_ON_FAIL,
+};
+
+export const WHATSAPP_LOCK_ACQUIRE_MAX_WAIT_MS = WHATSAPP_PROCESSING_LOCK_TTL_MS;
+export const WHATSAPP_LOCK_ACQUIRE_INITIAL_BACKOFF_MS = 200;
+export const WHATSAPP_LOCK_ACQUIRE_MAX_BACKOFF_MS = 2_000;
+export const WHATSAPP_LOCK_ACQUIRE_JITTER_MS = 150;

--- a/src/modules/whatsapp-agent/whatsapp-agent.const.ts
+++ b/src/modules/whatsapp-agent/whatsapp-agent.const.ts
@@ -1,0 +1,6 @@
+export const WHATSAPP_AGENT_ACK_XML = "<Response></Response>";
+export const WHATSAPP_SERVICE_WINDOW_HOURS = 24;
+export const WHATSAPP_PROCESSING_LOCK_TTL_MS = 60_000;
+
+export const WHATSAPP_DEFAULT_JOB_ATTEMPTS = 3;
+export const WHATSAPP_DEFAULT_BACKOFF_MS = 2_000;

--- a/src/modules/whatsapp-agent/whatsapp-agent.interface.ts
+++ b/src/modules/whatsapp-agent/whatsapp-agent.interface.ts
@@ -1,0 +1,56 @@
+import type { WhatsAppDeliveryMode, WhatsAppMessageKind } from "@prisma/client";
+
+export interface TwilioInboundWebhookPayload {
+  MessageSid?: string;
+  AccountSid?: string;
+  From?: string;
+  To?: string;
+  WaId?: string;
+  ProfileName?: string;
+  Body?: string;
+  NumMedia?: string;
+  MessageStatus?: string;
+  SmsStatus?: string;
+  ErrorCode?: string;
+  ErrorMessage?: string;
+  [key: string]: string | undefined;
+}
+
+export interface WhatsAppMediaPayload {
+  url: string;
+  contentType?: string;
+}
+
+export interface ProcessWhatsAppInboundJobData {
+  conversationId: string;
+  messageId: string;
+  dedupeKey: string;
+}
+
+export interface ProcessWhatsAppOutboxJobData {
+  outboxId: string;
+}
+
+export interface CreateOutboxInput {
+  conversationId: string;
+  dedupeKey: string;
+  mode: WhatsAppDeliveryMode;
+  textBody?: string;
+  mediaUrl?: string;
+  templateName?: string;
+  templateVariables?: Record<string, string | number>;
+}
+
+export interface OrchestratorResult {
+  enqueueOutbox: CreateOutboxInput[];
+  markAsHandoff?: {
+    reason: string;
+  };
+}
+
+export interface InboundMessageContext {
+  messageId: string;
+  conversationId: string;
+  body?: string;
+  kind: WhatsAppMessageKind;
+}

--- a/src/modules/whatsapp-agent/whatsapp-agent.module.ts
+++ b/src/modules/whatsapp-agent/whatsapp-agent.module.ts
@@ -1,0 +1,49 @@
+import { BullMQAdapter } from "@bull-board/api/bullMQAdapter";
+import { BullBoardModule } from "@bull-board/nestjs";
+import { BullModule } from "@nestjs/bullmq";
+import { Module } from "@nestjs/common";
+import { WHATSAPP_AGENT_QUEUE } from "../../config/constants";
+import { DatabaseModule } from "../database/database.module";
+import { TwilioWebhookGuard } from "../messaging/guards/twilio-webhook.guard";
+import { WHATSAPP_DEFAULT_BACKOFF_MS, WHATSAPP_DEFAULT_JOB_ATTEMPTS } from "./whatsapp-agent.const";
+import { WhatsAppAgentProcessor } from "./whatsapp-agent.processor";
+import { WhatsAppConversationService } from "./whatsapp-conversation.service";
+import { WhatsAppInboundController } from "./whatsapp-inbound.controller";
+import { WhatsAppIngressService } from "./whatsapp-ingress.service";
+import { WhatsAppOrchestratorService } from "./whatsapp-orchestrator.service";
+import { WhatsAppSenderService } from "./whatsapp-sender.service";
+import { WhatsAppWindowPolicyService } from "./whatsapp-window-policy.service";
+
+@Module({
+  imports: [
+    DatabaseModule,
+    BullModule.registerQueue({
+      name: WHATSAPP_AGENT_QUEUE,
+      defaultJobOptions: {
+        attempts: WHATSAPP_DEFAULT_JOB_ATTEMPTS,
+        backoff: {
+          type: "exponential",
+          delay: WHATSAPP_DEFAULT_BACKOFF_MS,
+        },
+        removeOnComplete: 100,
+        removeOnFail: 50,
+      },
+    }),
+    BullBoardModule.forFeature({
+      name: WHATSAPP_AGENT_QUEUE,
+      adapter: BullMQAdapter,
+    }),
+  ],
+  controllers: [WhatsAppInboundController],
+  providers: [
+    WhatsAppIngressService,
+    WhatsAppConversationService,
+    WhatsAppWindowPolicyService,
+    WhatsAppOrchestratorService,
+    WhatsAppSenderService,
+    WhatsAppAgentProcessor,
+    TwilioWebhookGuard,
+  ],
+  exports: [WhatsAppIngressService, WhatsAppSenderService, BullModule],
+})
+export class WhatsAppAgentModule {}

--- a/src/modules/whatsapp-agent/whatsapp-agent.module.ts
+++ b/src/modules/whatsapp-agent/whatsapp-agent.module.ts
@@ -5,7 +5,7 @@ import { Module } from "@nestjs/common";
 import { WHATSAPP_AGENT_QUEUE } from "../../config/constants";
 import { DatabaseModule } from "../database/database.module";
 import { TwilioWebhookGuard } from "../messaging/guards/twilio-webhook.guard";
-import { WHATSAPP_DEFAULT_BACKOFF_MS, WHATSAPP_DEFAULT_JOB_ATTEMPTS } from "./whatsapp-agent.const";
+import { WHATSAPP_QUEUE_DEFAULT_JOB_OPTIONS } from "./whatsapp-agent.const";
 import { WhatsAppAgentProcessor } from "./whatsapp-agent.processor";
 import { WhatsAppConversationService } from "./whatsapp-conversation.service";
 import { WhatsAppInboundController } from "./whatsapp-inbound.controller";
@@ -19,15 +19,7 @@ import { WhatsAppWindowPolicyService } from "./whatsapp-window-policy.service";
     DatabaseModule,
     BullModule.registerQueue({
       name: WHATSAPP_AGENT_QUEUE,
-      defaultJobOptions: {
-        attempts: WHATSAPP_DEFAULT_JOB_ATTEMPTS,
-        backoff: {
-          type: "exponential",
-          delay: WHATSAPP_DEFAULT_BACKOFF_MS,
-        },
-        removeOnComplete: 100,
-        removeOnFail: 50,
-      },
+      defaultJobOptions: WHATSAPP_QUEUE_DEFAULT_JOB_OPTIONS,
     }),
     BullBoardModule.forFeature({
       name: WHATSAPP_AGENT_QUEUE,

--- a/src/modules/whatsapp-agent/whatsapp-agent.processor.ts
+++ b/src/modules/whatsapp-agent/whatsapp-agent.processor.ts
@@ -1,0 +1,112 @@
+import { randomUUID } from "node:crypto";
+import { OnWorkerEvent, Processor, WorkerHost } from "@nestjs/bullmq";
+import { Injectable, Logger } from "@nestjs/common";
+import { Job } from "bullmq";
+import {
+  PROCESS_WHATSAPP_INBOUND_JOB,
+  PROCESS_WHATSAPP_OUTBOX_JOB,
+  WHATSAPP_AGENT_QUEUE,
+} from "../../config/constants";
+import type {
+  InboundMessageContext,
+  ProcessWhatsAppInboundJobData,
+  ProcessWhatsAppOutboxJobData,
+} from "./whatsapp-agent.interface";
+import { WhatsAppConversationService } from "./whatsapp-conversation.service";
+import { WhatsAppOrchestratorService } from "./whatsapp-orchestrator.service";
+import { WhatsAppSenderService } from "./whatsapp-sender.service";
+
+type WhatsAppAgentJobData = ProcessWhatsAppInboundJobData | ProcessWhatsAppOutboxJobData;
+
+@Injectable()
+@Processor(WHATSAPP_AGENT_QUEUE, { concurrency: 10 })
+export class WhatsAppAgentProcessor extends WorkerHost {
+  private readonly logger = new Logger(WhatsAppAgentProcessor.name);
+
+  constructor(
+    private readonly conversationService: WhatsAppConversationService,
+    private readonly orchestratorService: WhatsAppOrchestratorService,
+    private readonly senderService: WhatsAppSenderService,
+  ) {
+    super();
+  }
+
+  async process(job: Job<WhatsAppAgentJobData, unknown, string>): Promise<{ success: boolean }> {
+    switch (job.name) {
+      case PROCESS_WHATSAPP_INBOUND_JOB:
+        await this.processInbound(job as Job<ProcessWhatsAppInboundJobData, unknown, string>);
+        return { success: true };
+
+      case PROCESS_WHATSAPP_OUTBOX_JOB:
+        // Outbox dispatch worker will be implemented in the next slice.
+        return { success: true };
+
+      default:
+        throw new Error(`Unknown WhatsApp Agent job type: ${job.name}`);
+    }
+  }
+
+  private async processInbound(
+    job: Job<ProcessWhatsAppInboundJobData, unknown, string>,
+  ): Promise<void> {
+    const lockToken = randomUUID();
+    const { conversationId, messageId } = job.data;
+
+    const lockAcquired = await this.conversationService.acquireProcessingLock(
+      conversationId,
+      lockToken,
+    );
+    if (!lockAcquired) {
+      throw new Error(`Failed to acquire conversation lock for ${conversationId}`);
+    }
+
+    try {
+      const context = await this.conversationService.getInboundMessageContext(messageId);
+      if (!context) {
+        return;
+      }
+
+      const orchestratorContext: InboundMessageContext & { windowExpiresAt?: Date | null } = {
+        messageId: context.id,
+        conversationId: context.conversationId,
+        body: context.body ?? undefined,
+        kind: context.kind,
+        windowExpiresAt: context.conversation.windowExpiresAt,
+      };
+
+      const result = this.orchestratorService.decide(orchestratorContext);
+
+      for (const outbound of result.enqueueOutbox) {
+        await this.senderService.enqueueOutbound(outbound);
+      }
+
+      if (result.markAsHandoff) {
+        await this.conversationService.markConversationHandoff(
+          context.conversationId,
+          result.markAsHandoff.reason,
+        );
+      }
+
+      await this.conversationService.markInboundMessageProcessed(messageId);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      await this.conversationService.markInboundMessageFailed(messageId, errorMessage);
+      throw error;
+    } finally {
+      await this.conversationService.releaseProcessingLock(conversationId, lockToken);
+    }
+  }
+
+  @OnWorkerEvent("failed")
+  onFailed(job: Job<WhatsAppAgentJobData> | undefined, error: Error): void {
+    if (!job) {
+      this.logger.error("WhatsApp agent job failed without context", { error: error.message });
+      return;
+    }
+    this.logger.error(`WhatsApp agent job failed: ${job.name} [${job.id}]`, {
+      error: error.message,
+      attempts: job.attemptsMade,
+      maxAttempts: job.opts.attempts,
+    });
+  }
+}

--- a/src/modules/whatsapp-agent/whatsapp-agent.utils.spec.ts
+++ b/src/modules/whatsapp-agent/whatsapp-agent.utils.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildInboundDedupeKey,
+  deriveMessageKind,
+  extractInboundMedia,
+  normalizeTwilioWhatsAppPhone,
+} from "./whatsapp-agent.utils";
+
+describe("whatsapp-agent utils", () => {
+  it("normalizes Twilio WhatsApp address into E.164", () => {
+    expect(normalizeTwilioWhatsAppPhone("whatsapp:+2348012345678")).toBe("+2348012345678");
+    expect(normalizeTwilioWhatsAppPhone(" +1 (555) 123-4567 ")).toBe("+15551234567");
+  });
+
+  it("returns null for invalid phone values", () => {
+    expect(normalizeTwilioWhatsAppPhone(undefined)).toBeNull();
+    expect(normalizeTwilioWhatsAppPhone("whatsapp:abc")).toBeNull();
+  });
+
+  it("extracts media payloads from Twilio-style indexed keys", () => {
+    const media = extractInboundMedia({
+      NumMedia: "2",
+      MediaUrl0: "https://example.com/a.jpg",
+      MediaContentType0: "image/jpeg",
+      MediaUrl1: "https://example.com/b.ogg",
+      MediaContentType1: "audio/ogg",
+    });
+
+    expect(media).toEqual([
+      { url: "https://example.com/a.jpg", contentType: "image/jpeg" },
+      { url: "https://example.com/b.ogg", contentType: "audio/ogg" },
+    ]);
+  });
+
+  it("derives message kind from media and text", () => {
+    expect(
+      deriveMessageKind({
+        NumMedia: "1",
+        MediaUrl0: "https://example.com/a.ogg",
+        MediaContentType0: "audio/ogg",
+      }),
+    ).toBe("AUDIO");
+    expect(deriveMessageKind({ Body: "hello", NumMedia: "0" })).toBe("TEXT");
+    expect(deriveMessageKind({ NumMedia: "0" })).toBe("UNKNOWN");
+  });
+
+  it("uses message sid for deterministic inbound dedupe key", () => {
+    expect(buildInboundDedupeKey({ MessageSid: "SM123" })).toBe("twilio:inbound:sid:SM123");
+  });
+});

--- a/src/modules/whatsapp-agent/whatsapp-agent.utils.ts
+++ b/src/modules/whatsapp-agent/whatsapp-agent.utils.ts
@@ -1,0 +1,95 @@
+import { createHash } from "node:crypto";
+import { WHATSAPP_SERVICE_WINDOW_HOURS } from "./whatsapp-agent.const";
+import type { TwilioInboundWebhookPayload, WhatsAppMediaPayload } from "./whatsapp-agent.interface";
+
+function toE164(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.startsWith("+")) {
+    return `+${trimmed.slice(1).replaceAll(/[^\d]/g, "")}`;
+  }
+  return `+${trimmed.replaceAll(/[^\d]/g, "")}`;
+}
+
+export function normalizeTwilioWhatsAppPhone(phone: string | undefined): string | null {
+  if (!phone) {
+    return null;
+  }
+
+  const normalized = phone.replace(/^whatsapp:/i, "").trim();
+  if (!normalized) {
+    return null;
+  }
+
+  const e164 = toE164(normalized);
+  // E.164 allows up to 15 digits after plus; enforce sensible minimum.
+  if (!/^\+\d{8,15}$/.test(e164)) {
+    return null;
+  }
+
+  return e164;
+}
+
+export function extractInboundMedia(payload: TwilioInboundWebhookPayload): WhatsAppMediaPayload[] {
+  const countRaw = payload.NumMedia ?? "0";
+  const count = Number.parseInt(countRaw, 10);
+  if (!Number.isFinite(count) || count <= 0) {
+    return [];
+  }
+
+  const media: WhatsAppMediaPayload[] = [];
+  for (let index = 0; index < count; index += 1) {
+    const url = payload[`MediaUrl${index}`];
+    if (!url) {
+      continue;
+    }
+    media.push({
+      url,
+      contentType: payload[`MediaContentType${index}`],
+    });
+  }
+
+  return media;
+}
+
+export function deriveMessageKind(payload: TwilioInboundWebhookPayload) {
+  const body = payload.Body?.trim();
+  const media = extractInboundMedia(payload);
+  const firstContentType = media[0]?.contentType?.toLowerCase() ?? "";
+
+  if (media.length > 0) {
+    if (firstContentType.startsWith("image/")) return "IMAGE" as const;
+    if (firstContentType.startsWith("audio/")) return "AUDIO" as const;
+    if (firstContentType.includes("location")) return "LOCATION" as const;
+    return "DOCUMENT" as const;
+  }
+
+  if (body) {
+    return "TEXT" as const;
+  }
+
+  return "UNKNOWN" as const;
+}
+
+export function buildInboundDedupeKey(payload: TwilioInboundWebhookPayload): string {
+  if (payload.MessageSid) {
+    return `twilio:inbound:sid:${payload.MessageSid}`;
+  }
+
+  const fallbackData = JSON.stringify(payload);
+  const digest = createHash("sha256").update(fallbackData).digest("hex");
+  return `twilio:inbound:hash:${digest}`;
+}
+
+export function isInboundCustomerMessage(payload: TwilioInboundWebhookPayload): boolean {
+  // Twilio status callbacks contain MessageStatus but not a customer "From" WhatsApp identity.
+  const fromPhone = normalizeTwilioWhatsAppPhone(payload.From);
+  if (!fromPhone) {
+    return false;
+  }
+
+  return true;
+}
+
+export function computeWindowExpiry(from: Date): Date {
+  return new Date(from.getTime() + WHATSAPP_SERVICE_WINDOW_HOURS * 60 * 60 * 1000);
+}

--- a/src/modules/whatsapp-agent/whatsapp-agent.utils.ts
+++ b/src/modules/whatsapp-agent/whatsapp-agent.utils.ts
@@ -1,5 +1,4 @@
 import { createHash } from "node:crypto";
-import { WHATSAPP_SERVICE_WINDOW_HOURS } from "./whatsapp-agent.const";
 import type { TwilioInboundWebhookPayload, WhatsAppMediaPayload } from "./whatsapp-agent.interface";
 
 function toE164(value: string): string {
@@ -81,15 +80,14 @@ export function buildInboundDedupeKey(payload: TwilioInboundWebhookPayload): str
 }
 
 export function isInboundCustomerMessage(payload: TwilioInboundWebhookPayload): boolean {
-  // Twilio status callbacks contain MessageStatus but not a customer "From" WhatsApp identity.
+  if (payload.MessageStatus) {
+    return false;
+  }
+
   const fromPhone = normalizeTwilioWhatsAppPhone(payload.From);
   if (!fromPhone) {
     return false;
   }
 
   return true;
-}
-
-export function computeWindowExpiry(from: Date): Date {
-  return new Date(from.getTime() + WHATSAPP_SERVICE_WINDOW_HOURS * 60 * 60 * 1000);
 }

--- a/src/modules/whatsapp-agent/whatsapp-conversation.service.ts
+++ b/src/modules/whatsapp-agent/whatsapp-conversation.service.ts
@@ -1,0 +1,126 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { Prisma } from "@prisma/client";
+import { DatabaseService } from "../database/database.service";
+import { WHATSAPP_PROCESSING_LOCK_TTL_MS } from "./whatsapp-agent.const";
+
+@Injectable()
+export class WhatsAppConversationService {
+  private readonly logger = new Logger(WhatsAppConversationService.name);
+
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async acquireProcessingLock(
+    conversationId: string,
+    lockToken: string,
+    ttlMs = WHATSAPP_PROCESSING_LOCK_TTL_MS,
+  ): Promise<boolean> {
+    const now = new Date();
+    const lockExpiry = new Date(now.getTime() + ttlMs);
+
+    const updateResult = await this.databaseService.whatsAppConversation.updateMany({
+      where: {
+        id: conversationId,
+        OR: [
+          { processingLockExpiresAt: null },
+          { processingLockExpiresAt: { lt: now } },
+          { processingLockToken: lockToken },
+        ],
+      },
+      data: {
+        processingLockToken: lockToken,
+        processingLockExpiresAt: lockExpiry,
+      },
+    });
+
+    return updateResult.count === 1;
+  }
+
+  async releaseProcessingLock(conversationId: string, lockToken: string): Promise<void> {
+    await this.databaseService.whatsAppConversation.updateMany({
+      where: {
+        id: conversationId,
+        processingLockToken: lockToken,
+      },
+      data: {
+        processingLockToken: null,
+        processingLockExpiresAt: null,
+      },
+    });
+  }
+
+  async markInboundMessageQueued(messageId: string): Promise<void> {
+    await this.databaseService.whatsAppMessage.update({
+      where: { id: messageId },
+      data: { status: "QUEUED" },
+    });
+  }
+
+  async markInboundMessageProcessed(messageId: string): Promise<void> {
+    await this.databaseService.whatsAppMessage.update({
+      where: { id: messageId },
+      data: {
+        status: "PROCESSED",
+        processedAt: new Date(),
+      },
+    });
+  }
+
+  async markInboundMessageFailed(messageId: string, error: string): Promise<void> {
+    await this.databaseService.whatsAppMessage.update({
+      where: { id: messageId },
+      data: {
+        status: "FAILED",
+        errorMessage: error.slice(0, 500),
+      },
+    });
+  }
+
+  async getInboundMessageContext(messageId: string) {
+    const message = await this.databaseService.whatsAppMessage.findUnique({
+      where: { id: messageId },
+      select: {
+        id: true,
+        conversationId: true,
+        direction: true,
+        kind: true,
+        body: true,
+        status: true,
+        conversation: {
+          select: {
+            id: true,
+            phoneE164: true,
+            status: true,
+            windowExpiresAt: true,
+            lastInboundAt: true,
+          },
+        },
+      },
+    });
+
+    if (!message) {
+      return null;
+    }
+
+    if (message.direction !== "INBOUND") {
+      this.logger.warn("Non-inbound message was passed to inbound processor", { messageId });
+      return null;
+    }
+
+    return message;
+  }
+
+  async markConversationHandoff(conversationId: string, reason: string): Promise<void> {
+    await this.databaseService.whatsAppConversation.update({
+      where: { id: conversationId },
+      data: {
+        status: "HANDOFF",
+        handoffReason: reason,
+        handoffAt: new Date(),
+      },
+    });
+  }
+
+  isUniqueViolation(error: unknown): boolean {
+    return error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002";
+  }
+}

--- a/src/modules/whatsapp-agent/whatsapp-inbound.controller.ts
+++ b/src/modules/whatsapp-agent/whatsapp-inbound.controller.ts
@@ -1,0 +1,19 @@
+import { Body, Controller, Header, HttpCode, HttpStatus, Post, UseGuards } from "@nestjs/common";
+import { TwilioWebhookGuard } from "../messaging/guards/twilio-webhook.guard";
+import { WHATSAPP_AGENT_ACK_XML } from "./whatsapp-agent.const";
+import type { TwilioInboundWebhookPayload } from "./whatsapp-agent.interface";
+import { WhatsAppIngressService } from "./whatsapp-ingress.service";
+
+@Controller("api/whatsapp-agent")
+export class WhatsAppInboundController {
+  constructor(private readonly whatsappIngressService: WhatsAppIngressService) {}
+
+  @Post("webhook/twilio")
+  @HttpCode(HttpStatus.OK)
+  @Header("Content-Type", "application/xml")
+  @UseGuards(TwilioWebhookGuard)
+  async handleWebhook(@Body() payload: TwilioInboundWebhookPayload): Promise<string> {
+    await this.whatsappIngressService.handleInbound(payload);
+    return WHATSAPP_AGENT_ACK_XML;
+  }
+}

--- a/src/modules/whatsapp-agent/whatsapp-ingress.service.ts
+++ b/src/modules/whatsapp-agent/whatsapp-ingress.service.ts
@@ -1,0 +1,119 @@
+import { InjectQueue } from "@nestjs/bullmq";
+import { Injectable, Logger } from "@nestjs/common";
+import { Prisma, WhatsAppMessageKind } from "@prisma/client";
+import { Queue } from "bullmq";
+import { PROCESS_WHATSAPP_INBOUND_JOB, WHATSAPP_AGENT_QUEUE } from "../../config/constants";
+import { DatabaseService } from "../database/database.service";
+import { WHATSAPP_DEFAULT_BACKOFF_MS, WHATSAPP_DEFAULT_JOB_ATTEMPTS } from "./whatsapp-agent.const";
+import type {
+  ProcessWhatsAppInboundJobData,
+  TwilioInboundWebhookPayload,
+} from "./whatsapp-agent.interface";
+import {
+  buildInboundDedupeKey,
+  computeWindowExpiry,
+  deriveMessageKind,
+  extractInboundMedia,
+  isInboundCustomerMessage,
+  normalizeTwilioWhatsAppPhone,
+} from "./whatsapp-agent.utils";
+import { WhatsAppConversationService } from "./whatsapp-conversation.service";
+
+@Injectable()
+export class WhatsAppIngressService {
+  private readonly logger = new Logger(WhatsAppIngressService.name);
+
+  constructor(
+    private readonly databaseService: DatabaseService,
+    private readonly conversationService: WhatsAppConversationService,
+    @InjectQueue(WHATSAPP_AGENT_QUEUE)
+    private readonly whatsappAgentQueue: Queue<ProcessWhatsAppInboundJobData>,
+  ) {}
+
+  async handleInbound(payload: TwilioInboundWebhookPayload): Promise<void> {
+    if (!isInboundCustomerMessage(payload)) {
+      this.logger.debug("Skipping non-customer webhook payload");
+      return;
+    }
+
+    const phoneE164 = normalizeTwilioWhatsAppPhone(payload.From);
+    if (!phoneE164) {
+      this.logger.warn("Skipping payload with invalid WhatsApp phone", {
+        from: payload.From,
+        sid: payload.MessageSid,
+      });
+      return;
+    }
+
+    const dedupeKey = buildInboundDedupeKey(payload);
+    const now = new Date();
+    const windowExpiresAt = computeWindowExpiry(now);
+    const media = extractInboundMedia(payload);
+    const messageKind = deriveMessageKind(payload) as WhatsAppMessageKind;
+
+    const conversation = await this.databaseService.whatsAppConversation.upsert({
+      where: { phoneE164 },
+      create: {
+        phoneE164,
+        waId: payload.WaId ?? null,
+        profileName: payload.ProfileName ?? null,
+        lastInboundAt: now,
+        windowExpiresAt,
+      },
+      update: {
+        waId: payload.WaId ?? undefined,
+        profileName: payload.ProfileName ?? undefined,
+        lastInboundAt: now,
+        windowExpiresAt,
+        status: "ACTIVE",
+      },
+      select: { id: true },
+    });
+
+    let messageId: string | null = null;
+
+    try {
+      const message = await this.databaseService.whatsAppMessage.create({
+        data: {
+          conversationId: conversation.id,
+          providerMessageSid: payload.MessageSid ?? null,
+          dedupeKey,
+          direction: "INBOUND",
+          kind: messageKind,
+          status: "RECEIVED",
+          body: payload.Body ?? null,
+          mediaUrl: media[0]?.url ?? null,
+          mediaContentType: media[0]?.contentType ?? null,
+          rawPayload: payload as unknown as Prisma.InputJsonValue,
+          receivedAt: now,
+        },
+        select: { id: true },
+      });
+      messageId = message.id;
+    } catch (error) {
+      if (this.conversationService.isUniqueViolation(error)) {
+        this.logger.debug("Duplicate inbound webhook ignored", { dedupeKey, phoneE164 });
+        return;
+      }
+      throw error;
+    }
+
+    await this.conversationService.markInboundMessageQueued(messageId);
+
+    await this.whatsappAgentQueue.add(
+      PROCESS_WHATSAPP_INBOUND_JOB,
+      {
+        conversationId: conversation.id,
+        messageId,
+        dedupeKey,
+      },
+      {
+        jobId: dedupeKey,
+        attempts: WHATSAPP_DEFAULT_JOB_ATTEMPTS,
+        backoff: { type: "exponential", delay: WHATSAPP_DEFAULT_BACKOFF_MS },
+        removeOnComplete: 100,
+        removeOnFail: 50,
+      },
+    );
+  }
+}

--- a/src/modules/whatsapp-agent/whatsapp-orchestrator.service.ts
+++ b/src/modules/whatsapp-agent/whatsapp-orchestrator.service.ts
@@ -1,0 +1,60 @@
+import { Injectable } from "@nestjs/common";
+import { WhatsAppMessageKind } from "@prisma/client";
+import type { InboundMessageContext, OrchestratorResult } from "./whatsapp-agent.interface";
+import { WhatsAppWindowPolicyService } from "./whatsapp-window-policy.service";
+
+@Injectable()
+export class WhatsAppOrchestratorService {
+  constructor(private readonly windowPolicyService: WhatsAppWindowPolicyService) {}
+
+  /**
+   * MVP baseline:
+   * - route explicit handoff requests immediately
+   * - keep all other intents in deterministic no-op mode until booking flows are wired
+   */
+  decide(
+    context: InboundMessageContext & {
+      windowExpiresAt?: Date | null;
+    },
+  ): OrchestratorResult {
+    const body = context.body?.trim().toUpperCase() ?? "";
+    if (body === "AGENT") {
+      return {
+        enqueueOutbox: [
+          {
+            conversationId: context.conversationId,
+            dedupeKey: `handoff-ack:${context.messageId}`,
+            mode: this.windowPolicyService.resolveOutboundMode(context.windowExpiresAt),
+            textBody:
+              "A Tripdly agent will join this chat shortly. Please share your booking reference if available.",
+            templateName: "handoff-reopen",
+          },
+        ],
+        markAsHandoff: { reason: "USER_REQUESTED_AGENT" },
+      };
+    }
+
+    // Voice/media-specific fallback prompt for MVP until transcription/media flows are enabled.
+    if (
+      context.kind === WhatsAppMessageKind.AUDIO ||
+      context.kind === WhatsAppMessageKind.DOCUMENT ||
+      context.kind === WhatsAppMessageKind.IMAGE
+    ) {
+      return {
+        enqueueOutbox: [
+          {
+            conversationId: context.conversationId,
+            dedupeKey: `media-fallback:${context.messageId}`,
+            mode: this.windowPolicyService.resolveOutboundMode(context.windowExpiresAt),
+            textBody:
+              "Thanks. For now, please send your pickup location, date/time, and booking type (DAY, NIGHT, or FULL_DAY) as text.",
+            templateName: "booking-reopen",
+          },
+        ],
+      };
+    }
+
+    // No outbound side-effect yet for regular text while booking flow wiring is in progress.
+    return { enqueueOutbox: [] };
+  }
+}

--- a/src/modules/whatsapp-agent/whatsapp-sender.service.ts
+++ b/src/modules/whatsapp-agent/whatsapp-sender.service.ts
@@ -1,0 +1,39 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { Prisma } from "@prisma/client";
+import { DatabaseService } from "../database/database.service";
+import type { CreateOutboxInput } from "./whatsapp-agent.interface";
+
+@Injectable()
+export class WhatsAppSenderService {
+  private readonly logger = new Logger(WhatsAppSenderService.name);
+
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async enqueueOutbound(input: CreateOutboxInput): Promise<void> {
+    try {
+      await this.databaseService.whatsAppOutbox.create({
+        data: {
+          conversationId: input.conversationId,
+          dedupeKey: input.dedupeKey,
+          mode: input.mode,
+          textBody: input.textBody ?? null,
+          mediaUrl: input.mediaUrl ?? null,
+          templateName: input.templateName ?? null,
+          templateVariables: input.templateVariables
+            ? (input.templateVariables as unknown as Prisma.InputJsonValue)
+            : undefined,
+        },
+      });
+    } catch (error) {
+      if (this.isUniqueViolation(error)) {
+        this.logger.debug("Skipping duplicate outbound enqueue", { dedupeKey: input.dedupeKey });
+        return;
+      }
+      throw error;
+    }
+  }
+
+  private isUniqueViolation(error: unknown): boolean {
+    return error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002";
+  }
+}

--- a/src/modules/whatsapp-agent/whatsapp-window-policy.service.ts
+++ b/src/modules/whatsapp-agent/whatsapp-window-policy.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from "@nestjs/common";
+import { WhatsAppDeliveryMode } from "@prisma/client";
+import { WHATSAPP_SERVICE_WINDOW_HOURS } from "./whatsapp-agent.const";
+
+@Injectable()
+export class WhatsAppWindowPolicyService {
+  private readonly windowDurationMs = WHATSAPP_SERVICE_WINDOW_HOURS * 60 * 60 * 1000;
+
+  computeWindowExpiry(from: Date): Date {
+    return new Date(from.getTime() + this.windowDurationMs);
+  }
+
+  isWindowOpen(windowExpiresAt: Date | null | undefined, now = new Date()): boolean {
+    if (!windowExpiresAt) {
+      return false;
+    }
+    return windowExpiresAt.getTime() > now.getTime();
+  }
+
+  resolveOutboundMode(windowExpiresAt: Date | null | undefined): WhatsAppDeliveryMode {
+    return this.isWindowOpen(windowExpiresAt)
+      ? WhatsAppDeliveryMode.FREE_FORM
+      : WhatsAppDeliveryMode.TEMPLATE;
+  }
+}


### PR DESCRIPTION
- add Twilio webhook ingress with dedupe-aware inbound persistence and queueing
- process inbound jobs with per-conversation locking
- add orchestrator baseline (AGENT handoff + media fallback)
- enqueue outbound intents into WhatsApp outbox
- wire module/constants and add supporting utils/tests
- add Prisma WhatsApp agent models/enums for conversations/messages/outbox