### PR TITLE
test(whatsapp-agent): harden reset-slot e2e coverage and close Nest test modules

### DIFF
--- a/src/modules/whatsapp-agent/whatsapp-followup-question.service.spec.ts
+++ b/src/modules/whatsapp-agent/whatsapp-followup-question.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from "@nestjs/testing";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WHATSAPP_OPENAI_CLIENT } from "./whatsapp-agent.tokens";
 import { WhatsAppFollowupQuestionService } from "./whatsapp-followup-question.service";
 
@@ -34,6 +34,12 @@ describe("WhatsAppFollowupQuestionService", () => {
     }).compile();
 
     service = moduleRef.get(WhatsAppFollowupQuestionService);
+  });
+
+  afterEach(async () => {
+    if (moduleRef) {
+      await moduleRef.close();
+    }
   });
 
   it("falls back when model response is empty", async () => {

--- a/src/modules/whatsapp-agent/whatsapp-search-slot-memory.service.spec.ts
+++ b/src/modules/whatsapp-agent/whatsapp-search-slot-memory.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from "@nestjs/testing";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WHATSAPP_SEARCH_SLOT_TTL_SECONDS } from "./whatsapp-agent.const";
 import { WhatsAppSlotMemoryPersistFailedException } from "./whatsapp-agent.error";
 import { WHATSAPP_REDIS_CLIENT } from "./whatsapp-agent.tokens";
@@ -22,7 +22,7 @@ describe("WhatsAppSearchSlotMemoryService", () => {
       eval: vi.fn(),
       set: vi.fn(),
       del: vi.fn(),
-      quit: vi.fn(),
+      quit: vi.fn().mockResolvedValue("OK"),
     };
     moduleRef = await Test.createTestingModule({
       providers: [
@@ -34,6 +34,11 @@ describe("WhatsAppSearchSlotMemoryService", () => {
       ],
     }).compile();
     service = moduleRef.get(WhatsAppSearchSlotMemoryService);
+  });
+
+  afterEach(async () => {
+    await moduleRef?.close();
+    vi.resetAllMocks();
   });
 
   it("merges latest non-empty fields with previous slot payload", async () => {


### PR DESCRIPTION
Strengthen WhatsApp agent tests by verifying slot memory is actually used before reset and cleared after reset, and replace brittle AI-phrasing assertions with stable intent-level checks. Also, add module teardown/reset cleanup in unit specs to prevent leaked handles and improve suite reliability.