### PR TITLE
fix(langgraph): disambiguate bare "cancel" during confirming stage

### DIFF
--- a/src/modules/booking-agent/langgraph/langgraph-cancel-clarification.policy.spec.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-cancel-clarification.policy.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { buildState, buildVehicleOption } from "./langgraph.factory";
+import {
+  CANCEL_CLARIFICATION_CONFIDENCE_THRESHOLD,
+  shouldClarifyCancelIntent,
+} from "./langgraph-cancel-clarification.policy";
+
+describe("langgraph-cancel-clarification.policy", () => {
+  it("clarifies for low-confidence bare cancel during confirming", () => {
+    const state = buildState({
+      stage: "confirming",
+      inboundMessage: "cancel",
+      selectedOption: buildVehicleOption(),
+      extraction: {
+        intent: "cancel",
+        draftPatch: {},
+        confidence: CANCEL_CLARIFICATION_CONFIDENCE_THRESHOLD - 0.01,
+      },
+    });
+
+    expect(shouldClarifyCancelIntent(state)).toBe(true);
+  });
+
+  it("does not clarify at threshold confidence and above", () => {
+    const atThresholdState = buildState({
+      stage: "confirming",
+      inboundMessage: "cancel",
+      selectedOption: buildVehicleOption(),
+      extraction: {
+        intent: "cancel",
+        draftPatch: {},
+        confidence: CANCEL_CLARIFICATION_CONFIDENCE_THRESHOLD,
+      },
+    });
+
+    const aboveThresholdState = buildState({
+      stage: "confirming",
+      inboundMessage: "cancel",
+      selectedOption: buildVehicleOption(),
+      extraction: {
+        intent: "cancel",
+        draftPatch: {},
+        confidence: CANCEL_CLARIFICATION_CONFIDENCE_THRESHOLD + 0.01,
+      },
+    });
+
+    expect(shouldClarifyCancelIntent(atThresholdState)).toBe(false);
+    expect(shouldClarifyCancelIntent(aboveThresholdState)).toBe(false);
+  });
+
+  it("does not clarify for non-bare cancel phrasing", () => {
+    const state = buildState({
+      stage: "confirming",
+      inboundMessage: "cancel booking",
+      selectedOption: buildVehicleOption(),
+      extraction: { intent: "cancel", draftPatch: {}, confidence: 0.6 },
+    });
+
+    expect(shouldClarifyCancelIntent(state)).toBe(false);
+  });
+});

--- a/src/modules/booking-agent/langgraph/langgraph-cancel-clarification.policy.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-cancel-clarification.policy.ts
@@ -1,0 +1,20 @@
+import type { BookingAgentState } from "./langgraph.interface";
+import { isBareCancelControl, normalizeControlText } from "./langgraph-control-intent.policy";
+
+export const CANCEL_CLARIFICATION_CONFIDENCE_THRESHOLD = 0.85;
+
+export function shouldClarifyCancelIntent(state: BookingAgentState): boolean {
+  if (state.stage !== "confirming" || !state.selectedOption || !state.extraction) {
+    return false;
+  }
+
+  if (state.extraction.intent !== "cancel") {
+    return false;
+  }
+
+  if (state.extraction.confidence >= CANCEL_CLARIFICATION_CONFIDENCE_THRESHOLD) {
+    return false;
+  }
+
+  return isBareCancelControl(normalizeControlText(state.inboundMessage));
+}

--- a/src/modules/booking-agent/langgraph/langgraph-control-intent.policy.spec.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-control-intent.policy.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   isAgentRequestControl,
+  isBareCancelControl,
   isCancelIntentControl,
   isLikelyAffirmativeControl,
   isLikelyNegativeControl,
@@ -26,6 +27,7 @@ describe("langgraph-control-intent.policy", () => {
 
   it("detects cancel and agent requests", () => {
     expect(isCancelIntentControl("cancel booking")).toBe(true);
+    expect(isBareCancelControl("cancel")).toBe(true);
     expect(isAgentRequestControl("talk to agent")).toBe(true);
   });
 

--- a/src/modules/booking-agent/langgraph/langgraph-control-intent.policy.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-control-intent.policy.ts
@@ -83,6 +83,10 @@ export function isCancelIntentControl(normalizedText: string): boolean {
   return cancelSet.has(normalizedText);
 }
 
+export function isBareCancelControl(normalizedText: string): boolean {
+  return normalizedText === "cancel";
+}
+
 export function isAgentRequestControl(normalizedText: string): boolean {
   const agentSet = new Set(["agent", "talk to agent", "speak to agent", "human", "talk to human"]);
   return agentSet.has(normalizedText);

--- a/src/modules/booking-agent/langgraph/langgraph-extractor.service.spec.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-extractor.service.spec.ts
@@ -411,6 +411,19 @@ describe("LangGraphExtractorService", () => {
       expect(openaiMock.invoke).not.toHaveBeenCalled();
     });
 
+    it("uses low-confidence cancel intent for bare cancel in confirming stage", async () => {
+      const state = buildState({
+        inboundMessage: "cancel",
+        stage: "confirming",
+      });
+
+      const result = await service.extract(state);
+
+      expect(result.intent).toBe("cancel");
+      expect(result.confidence).toBe(0.6);
+      expect(openaiMock.invoke).not.toHaveBeenCalled();
+    });
+
     it("extracts greeting intent", async () => {
       openaiMock.invoke.mockResolvedValue({
         content: JSON.stringify({

--- a/src/modules/booking-agent/langgraph/langgraph-extractor.service.spec.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-extractor.service.spec.ts
@@ -1,10 +1,7 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type {
-  BookingAgentState,
-  InteractiveReply,
-  VehicleSearchOption,
-} from "./langgraph.interface";
+import { buildState, buildVehicleOption } from "./langgraph.factory";
+import type { InteractiveReply } from "./langgraph.interface";
 import { LANGGRAPH_OPENAI_CLIENT } from "./langgraph.tokens";
 import { LangGraphExtractorService } from "./langgraph-extractor.service";
 
@@ -14,45 +11,6 @@ describe("LangGraphExtractorService", () => {
   let openaiMock: {
     invoke: ReturnType<typeof vi.fn>;
   };
-
-  const buildState = (overrides?: Partial<BookingAgentState>): BookingAgentState => ({
-    conversationId: "conv_test",
-    inboundMessage: "I need a car tomorrow",
-    inboundMessageId: "msg_1",
-    customerId: null,
-    stage: "collecting",
-    turnCount: 1,
-    messages: [],
-    draft: {},
-    availableOptions: [],
-    lastShownOptions: [],
-    selectedOption: null,
-    holdId: null,
-    holdExpiresAt: null,
-    bookingId: null,
-    paymentLink: null,
-    preferences: {},
-    response: null,
-    outboxItems: [],
-    extraction: null,
-    nextNode: null,
-    error: null,
-    ...overrides,
-  });
-
-  const buildVehicleOption = (overrides?: Partial<VehicleSearchOption>): VehicleSearchOption => ({
-    id: "vehicle_1",
-    make: "Toyota",
-    model: "Prado",
-    name: "Toyota Prado",
-    color: "black",
-    vehicleType: "SUV",
-    serviceTier: "EXECUTIVE",
-    imageUrl: null,
-    rates: { day: 65000, night: 70000, fullDay: 110000, airportPickup: 40000 },
-    estimatedTotalInclVat: 150000,
-    ...overrides,
-  });
 
   beforeEach(async () => {
     openaiMock = {

--- a/src/modules/booking-agent/langgraph/langgraph-extractor.service.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-extractor.service.ts
@@ -7,6 +7,7 @@ import type { LangGraphOpenAIClient } from "./langgraph.tokens";
 import { LANGGRAPH_OPENAI_CLIENT } from "./langgraph.tokens";
 import {
   isAgentRequestControl,
+  isBareCancelControl,
   isCancelIntentControl,
   isLikelyAffirmativeControl,
   isLikelyNegativeControl,
@@ -261,6 +262,10 @@ export class LangGraphExtractorService {
 
     if (isAgentRequestControl(normalized)) {
       return { intent: "request_agent", draftPatch: {}, confidence: 1 };
+    }
+
+    if (stage === "confirming" && isBareCancelControl(normalized)) {
+      return { intent: "cancel", draftPatch: {}, confidence: 0.6 };
     }
 
     if (isCancelIntentControl(normalized)) {

--- a/src/modules/booking-agent/langgraph/langgraph-graph.service.spec.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-graph.service.spec.ts
@@ -5,7 +5,8 @@ import { BookingCreationService } from "../../booking/booking-creation.service";
 import { DatabaseService } from "../../database/database.service";
 import { BookingAgentSearchService } from "../booking-agent-search.service";
 import { BookingAgentWindowPolicyService } from "../booking-agent-window-policy.service";
-import type { BookingAgentState, VehicleSearchOption } from "./langgraph.interface";
+import { buildVehicleOption } from "./langgraph.factory";
+import type { BookingAgentState } from "./langgraph.interface";
 import { LangGraphExtractorService } from "./langgraph-extractor.service";
 import { LangGraphGraphService } from "./langgraph-graph.service";
 import { LangGraphResponderService } from "./langgraph-responder.service";
@@ -67,20 +68,6 @@ describe("LangGraphGraphService", () => {
     extraction: null,
     nextNode: null,
     error: null,
-  });
-
-  const buildVehicleOption = (overrides?: Partial<VehicleSearchOption>): VehicleSearchOption => ({
-    id: "vehicle_1",
-    make: "Toyota",
-    model: "Prado",
-    name: "Toyota Prado",
-    color: "black",
-    vehicleType: "SUV",
-    serviceTier: "EXECUTIVE",
-    imageUrl: null,
-    rates: { day: 65000, night: 70000, fullDay: 110000, airportPickup: 40000 },
-    estimatedTotalInclVat: 150000,
-    ...overrides,
   });
 
   beforeEach(async () => {

--- a/src/modules/booking-agent/langgraph/langgraph-outbox.builder.spec.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-outbox.builder.spec.ts
@@ -1,75 +1,38 @@
 import { describe, expect, it } from "vitest";
-import type { BookingAgentState, VehicleSearchOption } from "./langgraph.interface";
+import { buildState, buildVehicleOption } from "./langgraph.factory";
 import { buildOutboxItems } from "./langgraph-outbox.builder";
-
-function buildVehicle(overrides?: Partial<VehicleSearchOption>): VehicleSearchOption {
-  return {
-    id: "veh_1",
-    make: "Toyota",
-    model: "Prado",
-    name: "Toyota Prado",
-    color: "black",
-    vehicleType: "SUV",
-    serviceTier: "EXECUTIVE",
-    imageUrl: null,
-    rates: { day: 65000, night: 70000, fullDay: 110000, airportPickup: 40000 },
-    estimatedTotalInclVat: 150000,
-    ...overrides,
-  };
-}
-
-function buildState(overrides?: Partial<BookingAgentState>): BookingAgentState {
-  return {
-    messages: [],
-    conversationId: "conv_test",
-    customerId: null,
-    inboundMessage: "show me options",
-    inboundMessageId: "msg_1",
-    inboundInteractive: undefined,
-    draft: {},
-    stage: "presenting_options",
-    turnCount: 1,
-    extraction: null,
-    availableOptions: [],
-    lastShownOptions: [],
-    selectedOption: null,
-    holdId: null,
-    holdExpiresAt: null,
-    bookingId: null,
-    paymentLink: null,
-    preferences: {},
-    response: null,
-    outboxItems: [],
-    nextNode: null,
-    error: null,
-    ...overrides,
-  };
-}
 
 describe("langgraph-outbox.builder", () => {
   it("builds intro + template cards mapped by vehicleId", () => {
-    const veh1 = buildVehicle({ id: "veh_1", make: "Toyota", model: "Prado" });
-    const veh2 = buildVehicle({ id: "veh_2", make: "Lexus", model: "GX" });
+    const veh1 = buildVehicleOption({ id: "veh_1", make: "Toyota", model: "Prado" });
+    const veh2 = buildVehicleOption({ id: "veh_2", make: "Lexus", model: "GX" });
 
-    const outbox = buildOutboxItems(buildState({ availableOptions: [veh1, veh2] }), {
-      text: "Here are your options!",
-      vehicleCards: [
-        {
-          vehicleId: "veh_2",
-          imageUrl: "https://img/2.jpg",
-          caption: "Card 2",
-          buttonId: "select_vehicle:veh_2",
-          buttonTitle: "Select",
-        },
-        {
-          vehicleId: "veh_1",
-          imageUrl: "https://img/1.jpg",
-          caption: "Card 1",
-          buttonId: "select_vehicle:veh_1",
-          buttonTitle: "Select",
-        },
-      ],
-    });
+    const outbox = buildOutboxItems(
+      buildState({
+        stage: "presenting_options",
+        inboundMessage: "show me options",
+        availableOptions: [veh1, veh2],
+      }),
+      {
+        text: "Here are your options!",
+        vehicleCards: [
+          {
+            vehicleId: "veh_2",
+            imageUrl: "https://img/2.jpg",
+            caption: "Card 2",
+            buttonId: "select_vehicle:veh_2",
+            buttonTitle: "Select",
+          },
+          {
+            vehicleId: "veh_1",
+            imageUrl: "https://img/1.jpg",
+            caption: "Card 1",
+            buttonId: "select_vehicle:veh_1",
+            buttonTitle: "Select",
+          },
+        ],
+      },
+    );
 
     expect(outbox).toHaveLength(3);
     expect(outbox[0].mode).toBe("FREE_FORM");
@@ -80,7 +43,11 @@ describe("langgraph-outbox.builder", () => {
 
   it("falls back to single free-form message when cards do not map to available options", () => {
     const outbox = buildOutboxItems(
-      buildState({ availableOptions: [buildVehicle({ id: "veh_1" })] }),
+      buildState({
+        stage: "presenting_options",
+        inboundMessage: "show me options",
+        availableOptions: [buildVehicleOption({ id: "veh_1" })],
+      }),
       {
         text: "Here are your options!",
         vehicleCards: [
@@ -104,7 +71,7 @@ describe("langgraph-outbox.builder", () => {
     const outbox = buildOutboxItems(
       buildState({
         stage: "awaiting_payment",
-        selectedOption: buildVehicle({ make: "KIA", model: "Sportage LX" }),
+        selectedOption: buildVehicleOption({ make: "KIA", model: "Sportage LX" }),
         paymentLink: "https://checkout-v2.dev-flutterwave.com/v3/hosted/pay/c60612d08d53343872af",
       }),
       {

--- a/src/modules/booking-agent/langgraph/langgraph-responder.service.spec.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-responder.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { BookingAgentState, VehicleSearchOption } from "./langgraph.interface";
+import { buildState, buildVehicleOption } from "./langgraph.factory";
 import { LANGGRAPH_ANTHROPIC_CLIENT } from "./langgraph.tokens";
 import { LangGraphResponderService } from "./langgraph-responder.service";
 
@@ -10,45 +10,6 @@ describe("LangGraphResponderService", () => {
   let claudeMock: {
     invoke: ReturnType<typeof vi.fn>;
   };
-
-  const buildState = (overrides?: Partial<BookingAgentState>): BookingAgentState => ({
-    conversationId: "conv_test",
-    inboundMessage: "I need a car tomorrow",
-    inboundMessageId: "msg_1",
-    customerId: null,
-    stage: "collecting",
-    turnCount: 1,
-    messages: [],
-    draft: {},
-    availableOptions: [],
-    lastShownOptions: [],
-    selectedOption: null,
-    holdId: null,
-    holdExpiresAt: null,
-    bookingId: null,
-    paymentLink: null,
-    preferences: {},
-    response: null,
-    outboxItems: [],
-    extraction: null,
-    nextNode: null,
-    error: null,
-    ...overrides,
-  });
-
-  const buildVehicleOption = (overrides?: Partial<VehicleSearchOption>): VehicleSearchOption => ({
-    id: "vehicle_1",
-    make: "Toyota",
-    model: "Prado",
-    name: "Toyota Prado",
-    color: "black",
-    vehicleType: "SUV",
-    serviceTier: "EXECUTIVE",
-    imageUrl: null,
-    rates: { day: 65000, night: 70000, fullDay: 110000, airportPickup: 40000 },
-    estimatedTotalInclVat: 150000,
-    ...overrides,
-  });
 
   beforeEach(async () => {
     claudeMock = {

--- a/src/modules/booking-agent/langgraph/langgraph-responder.service.spec.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-responder.service.spec.ts
@@ -289,6 +289,31 @@ describe("LangGraphResponderService", () => {
       expect(response.interactive?.buttons?.[2].id).toBe("agent");
     });
 
+    it("asks for clarification on low-confidence bare cancel during confirming", async () => {
+      const state = buildState({
+        stage: "confirming",
+        inboundMessage: "cancel",
+        selectedOption: buildVehicleOption(),
+        extraction: { intent: "cancel", draftPatch: {}, confidence: 0.6 },
+        draft: {
+          bookingType: "DAY",
+          pickupDate: "2026-03-01",
+          pickupTime: "09:00",
+          pickupLocation: "Victoria Island",
+          dropoffLocation: "Lekki",
+        },
+      });
+
+      const response = await service.generateResponse(state);
+
+      expect(response.text).toContain("cancel this booking request entirely");
+      expect(response.interactive?.type).toBe("buttons");
+      expect(response.interactive?.buttons).toHaveLength(2);
+      expect(response.interactive?.buttons?.[0].id).toBe("cancel");
+      expect(response.interactive?.buttons?.[1].id).toBe("show_others");
+      expect(claudeMock.invoke).not.toHaveBeenCalled();
+    });
+
     it("prepends availability fallback message when presenting refreshed options", async () => {
       const options = [buildVehicleOption({ id: "2", make: "Lexus", model: "LX570" })];
 

--- a/src/modules/booking-agent/langgraph/langgraph-responder.service.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-responder.service.ts
@@ -13,6 +13,7 @@ import type {
 } from "./langgraph.interface";
 import type { LangGraphAnthropicClient } from "./langgraph.tokens";
 import { LANGGRAPH_ANTHROPIC_CLIENT } from "./langgraph.tokens";
+import { isBareCancelControl, normalizeControlText } from "./langgraph-control-intent.policy";
 import { buildResponderSystemPrompt, buildResponderUserContext } from "./prompts/responder.prompt";
 
 @Injectable()
@@ -22,6 +23,7 @@ export class LangGraphResponderService {
   private static readonly MAX_CONTEXT_FIELD_CHARS = 300;
   private static readonly MAX_DRAFT_CONTEXT_CHARS = 600;
   private static readonly MAX_OPTION_CONTEXT_ITEMS = 5;
+  private static readonly CANCEL_CLARIFICATION_CONFIDENCE_THRESHOLD = 0.85;
 
   constructor(
     @Inject(LANGGRAPH_ANTHROPIC_CLIENT) private readonly claude: LangGraphAnthropicClient,
@@ -120,6 +122,19 @@ export class LangGraphResponderService {
     }
 
     if (stage === "confirming" && selectedOption) {
+      if (this.shouldClarifyCancelIntent(state)) {
+        return {
+          text: "Do you want to cancel this booking request entirely, or see other car options?",
+          interactive: {
+            type: "buttons",
+            buttons: [
+              { id: LANGGRAPH_BUTTON_ID.CANCEL, title: "✕ Cancel Booking" },
+              { id: LANGGRAPH_BUTTON_ID.SHOW_OTHERS, title: "↻ Show Others" },
+            ],
+          },
+        };
+      }
+
       if (error) {
         return {
           text: `${error}\n\nWould you like me to try again or connect you to an agent?`,
@@ -345,5 +360,24 @@ export class LangGraphResponderService {
     }
 
     return undefined;
+  }
+
+  private shouldClarifyCancelIntent(state: BookingAgentState): boolean {
+    if (state.stage !== "confirming" || !state.selectedOption || !state.extraction) {
+      return false;
+    }
+
+    if (state.extraction.intent !== "cancel") {
+      return false;
+    }
+
+    if (
+      state.extraction.confidence >=
+      LangGraphResponderService.CANCEL_CLARIFICATION_CONFIDENCE_THRESHOLD
+    ) {
+      return false;
+    }
+
+    return isBareCancelControl(normalizeControlText(state.inboundMessage));
   }
 }

--- a/src/modules/booking-agent/langgraph/langgraph-responder.service.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-responder.service.ts
@@ -13,7 +13,7 @@ import type {
 } from "./langgraph.interface";
 import type { LangGraphAnthropicClient } from "./langgraph.tokens";
 import { LANGGRAPH_ANTHROPIC_CLIENT } from "./langgraph.tokens";
-import { isBareCancelControl, normalizeControlText } from "./langgraph-control-intent.policy";
+import { shouldClarifyCancelIntent } from "./langgraph-cancel-clarification.policy";
 import { buildResponderSystemPrompt, buildResponderUserContext } from "./prompts/responder.prompt";
 
 @Injectable()
@@ -23,7 +23,6 @@ export class LangGraphResponderService {
   private static readonly MAX_CONTEXT_FIELD_CHARS = 300;
   private static readonly MAX_DRAFT_CONTEXT_CHARS = 600;
   private static readonly MAX_OPTION_CONTEXT_ITEMS = 5;
-  private static readonly CANCEL_CLARIFICATION_CONFIDENCE_THRESHOLD = 0.85;
 
   constructor(
     @Inject(LANGGRAPH_ANTHROPIC_CLIENT) private readonly claude: LangGraphAnthropicClient,
@@ -122,7 +121,7 @@ export class LangGraphResponderService {
     }
 
     if (stage === "confirming" && selectedOption) {
-      if (this.shouldClarifyCancelIntent(state)) {
+      if (shouldClarifyCancelIntent(state)) {
         return {
           text: "Do you want to cancel this booking request entirely, or see other car options?",
           interactive: {
@@ -360,24 +359,5 @@ export class LangGraphResponderService {
     }
 
     return undefined;
-  }
-
-  private shouldClarifyCancelIntent(state: BookingAgentState): boolean {
-    if (state.stage !== "confirming" || !state.selectedOption || !state.extraction) {
-      return false;
-    }
-
-    if (state.extraction.intent !== "cancel") {
-      return false;
-    }
-
-    if (
-      state.extraction.confidence >=
-      LangGraphResponderService.CANCEL_CLARIFICATION_CONFIDENCE_THRESHOLD
-    ) {
-      return false;
-    }
-
-    return isBareCancelControl(normalizeControlText(state.inboundMessage));
   }
 }

--- a/src/modules/booking-agent/langgraph/langgraph-router.policy.spec.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-router.policy.spec.ts
@@ -1,50 +1,6 @@
 import { describe, expect, it } from "vitest";
-import type { BookingAgentState, VehicleSearchOption } from "./langgraph.interface";
+import { buildState, buildVehicleOption } from "./langgraph.factory";
 import { resolveRouteDecision } from "./langgraph-router.policy";
-
-function buildVehicleOption(overrides?: Partial<VehicleSearchOption>): VehicleSearchOption {
-  return {
-    id: "vehicle_1",
-    make: "Toyota",
-    model: "Prado",
-    name: "Toyota Prado",
-    color: "black",
-    vehicleType: "SUV",
-    serviceTier: "EXECUTIVE",
-    imageUrl: null,
-    rates: { day: 65000, night: 70000, fullDay: 110000, airportPickup: 40000 },
-    estimatedTotalInclVat: 150000,
-    ...overrides,
-  };
-}
-
-function buildState(overrides?: Partial<BookingAgentState>): BookingAgentState {
-  return {
-    messages: [],
-    conversationId: "conv_1",
-    customerId: null,
-    inboundMessage: "",
-    inboundMessageId: "msg_1",
-    inboundInteractive: undefined,
-    draft: {},
-    stage: "collecting",
-    turnCount: 1,
-    extraction: { intent: "provide_info", draftPatch: {}, confidence: 0.9 },
-    availableOptions: [],
-    lastShownOptions: [],
-    selectedOption: null,
-    holdId: null,
-    holdExpiresAt: null,
-    bookingId: null,
-    paymentLink: null,
-    preferences: {},
-    response: null,
-    outboxItems: [],
-    nextNode: null,
-    error: null,
-    ...overrides,
-  };
-}
 
 describe("langgraph-router.policy", () => {
   it("routes to search when all required fields exist and options are empty", () => {
@@ -57,6 +13,7 @@ describe("langgraph-router.policy", () => {
         dropoffDate: "2026-03-01",
         dropoffLocation: "Lekki",
       },
+      extraction: { intent: "provide_info", draftPatch: {}, confidence: 0.9 },
     });
 
     const decision = resolveRouteDecision(state);
@@ -75,6 +32,7 @@ describe("langgraph-router.policy", () => {
         dropoffLocation: "Lekki",
       },
       availableOptions: [buildVehicleOption()],
+      extraction: { intent: "provide_info", draftPatch: {}, confidence: 0.9 },
     });
 
     const decision = resolveRouteDecision(state);

--- a/src/modules/booking-agent/langgraph/langgraph-router.policy.spec.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-router.policy.spec.ts
@@ -111,6 +111,36 @@ describe("langgraph-router.policy", () => {
     expect(decision.availableOptions).toEqual([]);
   });
 
+  it("routes to cancelled for cancel intent during confirming", () => {
+    const vehicle = buildVehicleOption();
+    const state = buildState({
+      stage: "confirming",
+      inboundMessage: "cancel",
+      selectedOption: vehicle,
+      availableOptions: [vehicle],
+      extraction: { intent: "cancel", draftPatch: {}, confidence: 0.95 },
+    });
+
+    const decision = resolveRouteDecision(state);
+    expect(decision.nextNode).toBe("respond");
+    expect(decision.stage).toBe("cancelled");
+  });
+
+  it("keeps confirming stage for low-confidence bare cancel intent", () => {
+    const vehicle = buildVehicleOption();
+    const state = buildState({
+      stage: "confirming",
+      inboundMessage: "cancel",
+      selectedOption: vehicle,
+      availableOptions: [vehicle],
+      extraction: { intent: "cancel", draftPatch: {}, confidence: 0.6 },
+    });
+
+    const decision = resolveRouteDecision(state);
+    expect(decision.nextNode).toBe("respond");
+    expect(decision.stage).toBe("confirming");
+  });
+
   it("does not route to create_booking for affirmative response outside confirming stage", () => {
     const state = buildState({
       stage: "awaiting_payment",

--- a/src/modules/booking-agent/langgraph/langgraph-router.policy.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-router.policy.ts
@@ -6,10 +6,13 @@ import type {
   VehicleSearchOption,
 } from "./langgraph.interface";
 import {
+  isBareCancelControl,
   isLikelyAffirmativeControl,
   isLikelyNegativeControl,
   normalizeControlText,
 } from "./langgraph-control-intent.policy";
+
+const CANCEL_CLARIFICATION_CONFIDENCE_THRESHOLD = 0.85;
 
 export function resolveRouteDecision(state: BookingAgentState): LangGraphRouteDecision {
   const { extraction, draft, availableOptions } = state;
@@ -19,14 +22,14 @@ export function resolveRouteDecision(state: BookingAgentState): LangGraphRouteDe
     return { nextNode: LANGGRAPH_NODE_NAMES.RESPOND, stage: "collecting" };
   }
 
-  const stageGuard = getDeterministicStageGuard(state);
-  if (stageGuard) {
-    return stageGuard;
-  }
-
   const intentDecision = resolveIntentDecision(state);
   if (intentDecision) {
     return intentDecision;
+  }
+
+  const stageGuard = getDeterministicStageGuard(state);
+  if (stageGuard) {
+    return stageGuard;
   }
 
   return resolveFallbackDecision(missingFields.length === 0, availableOptions.length === 0);
@@ -114,6 +117,9 @@ function resolveIntentDecision(state: BookingAgentState): LangGraphRouteDecision
     case "request_agent":
       return { nextNode: LANGGRAPH_NODE_NAMES.HANDOFF };
     case "cancel":
+      if (shouldClarifyCancelIntent(state)) {
+        return { nextNode: LANGGRAPH_NODE_NAMES.RESPOND, stage: "confirming" };
+      }
       return { nextNode: LANGGRAPH_NODE_NAMES.RESPOND, stage: "cancelled" };
     case "reset":
       return buildResetDecision();
@@ -130,6 +136,23 @@ function resolveIntentDecision(state: BookingAgentState): LangGraphRouteDecision
     default:
       return null;
   }
+}
+
+function shouldClarifyCancelIntent(state: BookingAgentState): boolean {
+  if (state.stage !== "confirming" || !state.selectedOption || !state.extraction) {
+    return false;
+  }
+
+  if (state.extraction.intent !== "cancel") {
+    return false;
+  }
+
+  if (state.extraction.confidence >= CANCEL_CLARIFICATION_CONFIDENCE_THRESHOLD) {
+    return false;
+  }
+
+  const normalizedMessage = normalizeControlText(state.inboundMessage);
+  return isBareCancelControl(normalizedMessage);
 }
 
 function resolveFallbackDecision(

--- a/src/modules/booking-agent/langgraph/langgraph-router.policy.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-router.policy.ts
@@ -5,14 +5,12 @@ import type {
   LangGraphRouteDecision,
   VehicleSearchOption,
 } from "./langgraph.interface";
+import { shouldClarifyCancelIntent } from "./langgraph-cancel-clarification.policy";
 import {
-  isBareCancelControl,
   isLikelyAffirmativeControl,
   isLikelyNegativeControl,
   normalizeControlText,
 } from "./langgraph-control-intent.policy";
-
-const CANCEL_CLARIFICATION_CONFIDENCE_THRESHOLD = 0.85;
 
 export function resolveRouteDecision(state: BookingAgentState): LangGraphRouteDecision {
   const { extraction, draft, availableOptions } = state;
@@ -136,23 +134,6 @@ function resolveIntentDecision(state: BookingAgentState): LangGraphRouteDecision
     default:
       return null;
   }
-}
-
-function shouldClarifyCancelIntent(state: BookingAgentState): boolean {
-  if (state.stage !== "confirming" || !state.selectedOption || !state.extraction) {
-    return false;
-  }
-
-  if (state.extraction.intent !== "cancel") {
-    return false;
-  }
-
-  if (state.extraction.confidence >= CANCEL_CLARIFICATION_CONFIDENCE_THRESHOLD) {
-    return false;
-  }
-
-  const normalizedMessage = normalizeControlText(state.inboundMessage);
-  return isBareCancelControl(normalizedMessage);
 }
 
 function resolveFallbackDecision(

--- a/src/modules/booking-agent/langgraph/langgraph.factory.ts
+++ b/src/modules/booking-agent/langgraph/langgraph.factory.ts
@@ -1,0 +1,44 @@
+import type { BookingAgentState, VehicleSearchOption } from "./langgraph.interface";
+
+export function buildState(overrides?: Partial<BookingAgentState>): BookingAgentState {
+  return {
+    conversationId: "conv_test",
+    inboundMessage: "I need a car tomorrow",
+    inboundMessageId: "msg_1",
+    customerId: null,
+    stage: "collecting",
+    turnCount: 1,
+    messages: [],
+    draft: {},
+    availableOptions: [],
+    lastShownOptions: [],
+    selectedOption: null,
+    holdId: null,
+    holdExpiresAt: null,
+    bookingId: null,
+    paymentLink: null,
+    preferences: {},
+    response: null,
+    outboxItems: [],
+    extraction: null,
+    nextNode: null,
+    error: null,
+    ...overrides,
+  };
+}
+
+export function buildVehicleOption(overrides?: Partial<VehicleSearchOption>): VehicleSearchOption {
+  return {
+    id: "vehicle_1",
+    make: "Toyota",
+    model: "Prado",
+    name: "Toyota Prado",
+    color: "black",
+    vehicleType: "SUV",
+    serviceTier: "EXECUTIVE",
+    imageUrl: null,
+    rates: { day: 65000, night: 70000, fullDay: 110000, airportPickup: 40000 },
+    estimatedTotalInclVat: 150000,
+    ...overrides,
+  };
+}


### PR DESCRIPTION
Prioritize extractor intent routing over deterministic stage guards, then add explicit ambiguity handling for bare "cancel" in confirming. Bare low-confidence cancel now triggers a clarification prompt ("cancel booking" vs "show others"), while explicit/high-confidence cancel still routes to cancelled. Added regression tests across control-intent, extractor, router, and responder policies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes routing and deterministic handling around cancellations in the confirming stage; mistakes could cause unintended cancellations or extra prompts. Scope is contained to booking-agent LangGraph policies/services with good test coverage.
> 
> **Overview**
> **Disambiguates bare `cancel` while confirming a booking.** A new `shouldClarifyCancelIntent` policy (threshold `0.85`) detects low-confidence *bare* `cancel` in `confirming` and triggers a clarification prompt offering **Cancel Booking** vs **Show Others**.
> 
> The extractor now returns a **low-confidence** `cancel` intent (`0.6`) for bare `cancel` in `confirming`, while explicit cancel phrases remain high-confidence. The router also prioritizes intent-based decisions before deterministic stage guards and keeps the user in `confirming` when cancel is ambiguous; high-confidence cancel still routes to `cancelled`.
> 
> Test helpers were centralized in `langgraph.factory`, and new/updated specs cover control parsing (`isBareCancelControl`), extractor behavior, router decisions, and responder clarification UI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3fdf49e0b053a7726e6dde8d4a9d2f468dd920f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->