### PR TITLE
feat(booking-agent): validate pickup locations with Google Place Details

### DIFF
--- a/src/modules/booking-agent/booking-agent.module.ts
+++ b/src/modules/booking-agent/booking-agent.module.ts
@@ -11,6 +11,7 @@ import type { EnvConfig } from "../../config/env.config";
 import { BookingModule } from "../booking/booking.module";
 import { CarModule } from "../car/car.module";
 import { DatabaseModule } from "../database/database.module";
+import { MapsModule } from "../maps/maps.module";
 import { TwilioWebhookGuard } from "../messaging/guards/twilio-webhook.guard";
 import { OpenAiSdkModule } from "../openai-sdk/openai-sdk.module";
 import { RatesModule } from "../rates/rates.module";
@@ -40,6 +41,7 @@ import { WhatsAppSenderService } from "./whatsapp/whatsapp-sender.service";
     DatabaseModule,
     BookingModule,
     CarModule,
+    MapsModule,
     RatesModule,
     OpenAiSdkModule,
     BullModule.registerQueue({

--- a/src/modules/booking-agent/langgraph/langgraph-graph.service.spec.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-graph.service.spec.ts
@@ -469,6 +469,13 @@ describe("LangGraphGraphService", () => {
         confidence: 0.9,
       });
 
+      // Mock Google Places to return the same address (already specific enough)
+      googlePlacesServiceMock.validateAddressWithSuggestions.mockResolvedValue({
+        isValid: true,
+        normalizedAddress: "5 Glover Road, Ikoyi",
+        suggestions: [],
+      });
+
       toolExecutorServiceMock.searchVehiclesFromExtracted.mockResolvedValue({
         exactMatches: [buildVehicleOption()],
         alternatives: [],
@@ -481,6 +488,99 @@ describe("LangGraphGraphService", () => {
       });
 
       expect(result.draft.dropoffLocation).toBe("5 Glover Road, Ikoyi");
+    });
+
+    it("keeps dropoffLocation in sync when pickupLocation is normalized and they were equal", async () => {
+      const existingState = buildInitialState();
+      existingState.stage = "collecting";
+      existingState.draft = {
+        bookingType: "DAY",
+        pickupDate: "2026-03-01",
+        pickupTime: "09:00",
+        dropoffDate: "2026-03-01",
+        pickupLocation: "Glover Road Ikoyi",
+        dropoffLocation: "Glover Road Ikoyi", // Same as pickup (via "same location" instruction)
+      };
+      stateServiceMock.loadState.mockResolvedValue(existingState);
+      stateServiceMock.mergeWithExisting.mockReturnValue({
+        ...existingState,
+        inboundMessage: "Yes",
+        inboundMessageId: messageId,
+      });
+
+      extractorServiceMock.extract.mockResolvedValue({
+        intent: "confirm",
+        draftPatch: {},
+        confidence: 0.9,
+      });
+
+      // Google Places normalizes the address
+      googlePlacesServiceMock.validateAddressWithSuggestions.mockResolvedValue({
+        isValid: true,
+        normalizedAddress: "12 Glover Road, Ikoyi, Lagos, Nigeria",
+        suggestions: [],
+      });
+
+      toolExecutorServiceMock.searchVehiclesFromExtracted.mockResolvedValue({
+        exactMatches: [buildVehicleOption()],
+        alternatives: [],
+      });
+
+      const result = await service.invoke({
+        conversationId,
+        messageId,
+        message: "Yes",
+      });
+
+      // Both pickup and dropoff should be normalized to the same address
+      expect(result.draft.pickupLocation).toBe("12 Glover Road, Ikoyi, Lagos, Nigeria");
+      expect(result.draft.dropoffLocation).toBe("12 Glover Road, Ikoyi, Lagos, Nigeria");
+    });
+
+    it("does not update dropoffLocation when it differs from pickupLocation before normalization", async () => {
+      const existingState = buildInitialState();
+      existingState.stage = "collecting";
+      existingState.draft = {
+        bookingType: "DAY",
+        pickupDate: "2026-03-01",
+        pickupTime: "09:00",
+        dropoffDate: "2026-03-01",
+        pickupLocation: "Glover Road Ikoyi",
+        dropoffLocation: "Lekki Phase 1", // Different from pickup
+      };
+      stateServiceMock.loadState.mockResolvedValue(existingState);
+      stateServiceMock.mergeWithExisting.mockReturnValue({
+        ...existingState,
+        inboundMessage: "Yes",
+        inboundMessageId: messageId,
+      });
+
+      extractorServiceMock.extract.mockResolvedValue({
+        intent: "confirm",
+        draftPatch: {},
+        confidence: 0.9,
+      });
+
+      googlePlacesServiceMock.validateAddressWithSuggestions.mockResolvedValue({
+        isValid: true,
+        normalizedAddress: "12 Glover Road, Ikoyi, Lagos, Nigeria",
+        suggestions: [],
+      });
+
+      toolExecutorServiceMock.searchVehiclesFromExtracted.mockResolvedValue({
+        exactMatches: [buildVehicleOption()],
+        alternatives: [],
+      });
+
+      const result = await service.invoke({
+        conversationId,
+        messageId,
+        message: "Yes",
+      });
+
+      // Pickup should be normalized, but dropoff should remain unchanged
+      expect(result.draft.pickupLocation).toBe("12 Glover Road, Ikoyi, Lagos, Nigeria");
+      expect(result.draft.dropoffLocation).toBe("Lekki Phase 1");
     });
 
     it("passes availableOptions to responder after search", async () => {

--- a/src/modules/booking-agent/langgraph/langgraph-graph.service.spec.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-graph.service.spec.ts
@@ -71,6 +71,8 @@ describe("LangGraphGraphService", () => {
     extraction: null,
     nextNode: null,
     error: null,
+    locationSuggestions: [],
+    locationLookupTriggered: false,
   });
 
   const buildVehicleOption = (overrides?: Partial<VehicleSearchOption>): VehicleSearchOption => ({
@@ -1439,6 +1441,46 @@ describe("LangGraphGraphService", () => {
       expect(result.outboxItems[1]?.textBody).not.toContain("Did you mean one of these?");
     });
 
+    it("does not re-validate pickup location after NO_MATCH when locationLookupTriggered is true", async () => {
+      const existingState = buildInitialState();
+      existingState.stage = "collecting";
+      existingState.draft = {
+        bookingType: "DAY",
+        pickupDate: "2026-03-05",
+        pickupTime: "09:00",
+        dropoffDate: "2026-03-05",
+        pickupLocation: "Xyzzyville",
+        dropoffLocation: "Xyzzyville",
+      };
+      // After a NO_MATCH, locationLookupTriggered should be true and suggestions empty
+      existingState.locationLookupTriggered = true;
+      existingState.locationSuggestions = [];
+      stateServiceMock.loadState.mockResolvedValue(existingState);
+      stateServiceMock.mergeWithExisting.mockReturnValue({ ...existingState });
+
+      extractorServiceMock.extract.mockResolvedValue({
+        intent: "confirm",
+        draftPatch: {},
+        confidence: 0.9,
+      });
+
+      responderServiceMock.generateResponse.mockResolvedValue({
+        text: "I still need a valid pickup location. Please share a more specific address.",
+      });
+
+      const result = await service.invoke({
+        conversationId,
+        messageId,
+        message: "yes",
+      });
+
+      // Should NOT re-validate because locationLookupTriggered is true and suggestions are empty
+      expect(googlePlacesServiceMock.validateAddressWithSuggestions).not.toHaveBeenCalled();
+      expect(toolExecutorServiceMock.searchVehiclesFromExtracted).not.toHaveBeenCalled();
+      // Should go to responder to ask for valid address
+      expect(result.stage).toBe("collecting");
+    });
+
     it("sets error message when search returns no vehicles", async () => {
       const existingState = buildInitialState();
       existingState.stage = "collecting";
@@ -1523,6 +1565,129 @@ describe("LangGraphGraphService", () => {
       });
 
       expect(result.error).toBeDefined();
+    });
+
+    it("does not reset locationLookupTriggered to false when search fails after validation", async () => {
+      const existingState = buildInitialState();
+      existingState.stage = "collecting";
+      existingState.draft = {
+        bookingType: "DAY",
+        pickupDate: "2026-03-05",
+        pickupTime: "09:00",
+        dropoffDate: "2026-03-05",
+        pickupLocation: "Wheatbaker Hotel, Ikoyi",
+        dropoffLocation: "Ikoyi",
+      };
+      // Location was previously validated
+      existingState.locationLookupTriggered = true;
+      existingState.locationSuggestions = [];
+      stateServiceMock.loadState.mockResolvedValue(existingState);
+      stateServiceMock.mergeWithExisting.mockReturnValue({ ...existingState });
+
+      extractorServiceMock.extract.mockResolvedValue({
+        intent: "provide_info",
+        draftPatch: {},
+        confidence: 0.9,
+      });
+
+      // Search fails after validation succeeded (but validation was skipped due to locationLookupTriggered=true)
+      toolExecutorServiceMock.searchVehiclesFromExtracted.mockRejectedValue(
+        new Error("Database timeout"),
+      );
+
+      responderServiceMock.generateResponse.mockResolvedValue({
+        text: "I couldn't check availability right now.",
+      });
+
+      // Capture the state that gets saved
+      let savedState: BookingAgentState | null = null;
+      stateServiceMock.saveState.mockImplementation((_id: string, state: BookingAgentState) => {
+        savedState = state;
+        return Promise.resolve();
+      });
+
+      await service.invoke({
+        conversationId,
+        messageId,
+        message: "Search",
+      });
+
+      // The catch block should NOT reset locationLookupTriggered to false
+      // (we omit locationLookupTriggered/locationSuggestions from the catch return,
+      // so the existing state is preserved)
+      expect(savedState).not.toBeNull();
+      if (savedState) {
+        expect(savedState.locationLookupTriggered).toBe(true);
+        expect(savedState.stage).toBe("collecting");
+      }
+    });
+
+    it("preserves validated draft and location state when search returns precondition", async () => {
+      const existingState = buildInitialState();
+      existingState.stage = "collecting";
+      existingState.draft = {
+        bookingType: "DAY",
+        pickupDate: "2026-03-05",
+        pickupTime: "09:00",
+        dropoffDate: "2026-03-05",
+        pickupLocation: "Wheatbaker Hotel, Ikoyi",
+        dropoffLocation: "Ikoyi",
+      };
+      existingState.locationLookupTriggered = false;
+      stateServiceMock.loadState.mockResolvedValue(existingState);
+      stateServiceMock.mergeWithExisting.mockReturnValue({ ...existingState });
+
+      extractorServiceMock.extract.mockResolvedValue({
+        intent: "provide_info",
+        draftPatch: {},
+        confidence: 0.9,
+      });
+
+      // Google Places validates and normalizes the address
+      googlePlacesServiceMock.validateAddressWithSuggestions.mockResolvedValue({
+        isValid: true,
+        normalizedAddress: "The Wheatbaker Hotel, 4 Onitolo Rd, Ikoyi, Lagos",
+        placeId: "ChIJ123",
+        suggestions: [],
+      });
+
+      // Search returns precondition (e.g., missing vehicle type for a search that requires it)
+      toolExecutorServiceMock.searchVehiclesFromExtracted.mockResolvedValue({
+        precondition: {
+          field: "vehicleType",
+          prompt: "What type of vehicle would you prefer?",
+        },
+        exactMatches: [],
+        alternatives: [],
+      });
+
+      responderServiceMock.generateResponse.mockResolvedValue({
+        text: "What type of vehicle would you prefer?",
+      });
+
+      // Capture the state that gets saved
+      let savedState: BookingAgentState | null = null;
+      stateServiceMock.saveState.mockImplementation((_id: string, state: BookingAgentState) => {
+        savedState = state;
+        return Promise.resolve();
+      });
+
+      const result = await service.invoke({
+        conversationId,
+        messageId,
+        message: "Search for cars",
+      });
+
+      // Should preserve the validated/normalized address
+      expect(result.draft.pickupLocation).toBe("The Wheatbaker Hotel, 4 Onitolo Rd, Ikoyi, Lagos");
+      expect(result.stage).toBe("collecting");
+      expect(result.error).toContain("type of vehicle");
+      // Should preserve locationLookupTriggered so we don't re-validate on next turn
+      expect(savedState).not.toBeNull();
+      if (savedState) {
+        expect(savedState.locationLookupTriggered).toBe(true);
+        expect(savedState.locationSuggestions).toEqual([]);
+      }
     });
   });
 

--- a/src/modules/booking-agent/langgraph/langgraph-graph.service.spec.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-graph.service.spec.ts
@@ -73,6 +73,7 @@ describe("LangGraphGraphService", () => {
     error: null,
     locationSuggestions: [],
     locationLookupTriggered: false,
+    locationLookupFailed: false,
   });
 
   const buildVehicleOption = (overrides?: Partial<VehicleSearchOption>): VehicleSearchOption => ({
@@ -1441,7 +1442,7 @@ describe("LangGraphGraphService", () => {
       expect(result.outboxItems[1]?.textBody).not.toContain("Did you mean one of these?");
     });
 
-    it("does not re-validate pickup location after NO_MATCH when locationLookupTriggered is true", async () => {
+    it("does not re-validate pickup location after NO_MATCH when locationLookupFailed is true", async () => {
       const existingState = buildInitialState();
       existingState.stage = "collecting";
       existingState.draft = {
@@ -1452,9 +1453,10 @@ describe("LangGraphGraphService", () => {
         pickupLocation: "Xyzzyville",
         dropoffLocation: "Xyzzyville",
       };
-      // After a NO_MATCH, locationLookupTriggered should be true and suggestions empty
+      // After a NO_MATCH, locationLookupTriggered should be true, suggestions empty, and locationLookupFailed true
       existingState.locationLookupTriggered = true;
       existingState.locationSuggestions = [];
+      existingState.locationLookupFailed = true;
       stateServiceMock.loadState.mockResolvedValue(existingState);
       stateServiceMock.mergeWithExisting.mockReturnValue({ ...existingState });
 
@@ -1521,6 +1523,73 @@ describe("LangGraphGraphService", () => {
       // Should go back to collecting stage with error message
       expect(result.stage).toBe("collecting");
       expect(result.error).toContain("No vehicles matching your criteria");
+    });
+
+    it("allows re-search after successful search when user modifies non-location criteria", async () => {
+      // This test verifies the fix for the bug where locationLookupTriggered=true and
+      // locationSuggestions=[] after a successful search incorrectly blocked re-search.
+      const existingState = buildInitialState();
+      existingState.stage = "presenting_options";
+      existingState.draft = {
+        bookingType: "DAY",
+        pickupDate: "2026-03-05",
+        pickupTime: "09:00",
+        dropoffDate: "2026-03-05",
+        pickupLocation: "Wheatbaker Hotel, Ikoyi",
+        dropoffLocation: "Wheatbaker Hotel, Ikoyi",
+        vehicleType: "SUV",
+      };
+      existingState.availableOptions = [buildVehicleOption()];
+      existingState.lastShownOptions = [buildVehicleOption()];
+      // After a successful search, these flags are set:
+      existingState.locationLookupTriggered = true;
+      existingState.locationSuggestions = [];
+      existingState.locationLookupFailed = false; // Key: NOT failed, just completed successfully
+      stateServiceMock.loadState.mockResolvedValue(existingState);
+      stateServiceMock.mergeWithExisting.mockReturnValue({ ...existingState });
+
+      // User wants a different vehicle type (same location)
+      extractorServiceMock.extract.mockResolvedValue({
+        intent: "update_info",
+        draftPatch: { vehicleType: "SEDAN" },
+        confidence: 0.9,
+      });
+
+      // Search returns new results for SEDAN
+      const sedanVehicle = buildVehicleOption({
+        id: "sedan_1",
+        make: "Toyota",
+        model: "Camry",
+        vehicleType: "SEDAN",
+      });
+      toolExecutorServiceMock.searchVehiclesFromExtracted.mockResolvedValue({
+        exactMatches: [sedanVehicle],
+        alternatives: [],
+      });
+
+      responderServiceMock.generateResponse.mockResolvedValue({
+        text: "Here are the sedan options!",
+        vehicleCards: [
+          {
+            vehicleId: sedanVehicle.id,
+            imageUrl: null,
+            caption: "Toyota Camry",
+            buttonId: `select_vehicle:${sedanVehicle.id}`,
+            buttonTitle: "Select",
+          },
+        ],
+      });
+
+      const result = await service.invoke({
+        conversationId,
+        messageId,
+        message: "Show me sedans instead",
+      });
+
+      // Should successfully search and present new options
+      expect(toolExecutorServiceMock.searchVehiclesFromExtracted).toHaveBeenCalled();
+      expect(result.stage).toBe("presenting_options");
+      expect(result.draft.vehicleType).toBe("SEDAN");
     });
   });
 

--- a/src/modules/booking-agent/langgraph/langgraph-graph.service.spec.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-graph.service.spec.ts
@@ -391,7 +391,7 @@ describe("LangGraphGraphService", () => {
 
   describe("graph flow - collecting info", () => {
     it("updates draft with extracted info", async () => {
-      extractorServiceMock.extract.mockResolvedValue({
+      extractorServiceMock.extract.mockResolvedValueOnce({
         intent: "provide_info",
         draftPatch: {
           bookingType: "DAY",
@@ -401,12 +401,21 @@ describe("LangGraphGraphService", () => {
         confidence: 0.9,
       });
 
+      // Explicitly stub the geocoding lookup for this test
+      googlePlacesServiceMock.validateAddressWithSuggestions.mockResolvedValueOnce({
+        isValid: true,
+        normalizedAddress: "Victoria Island, Lagos, Nigeria",
+        suggestions: [],
+      });
+
       const result = await service.invoke({
         conversationId,
         messageId,
         message: "I need a day booking tomorrow in Lagos",
       });
 
+      // Verify normalization lookup was called with the raw pickupLocation
+      expect(googlePlacesServiceMock.validateAddressWithSuggestions).toHaveBeenCalledWith("Lagos");
       expect(result.draft.bookingType).toBe("DAY");
       expect(result.draft.pickupDate).toBe("2026-03-01");
       expect(result.draft.pickupLocation).toBe("Victoria Island, Lagos, Nigeria");
@@ -1680,6 +1689,9 @@ describe("LangGraphGraphService", () => {
         messageId,
         message: "Search",
       });
+
+      // Verify search was actually called (and rejected) so the catch path is exercised
+      expect(toolExecutorServiceMock.searchVehiclesFromExtracted).toHaveBeenCalled();
 
       // The catch block should NOT reset locationLookupTriggered to false
       // (we omit locationLookupTriggered/locationSuggestions from the catch return,

--- a/src/modules/booking-agent/langgraph/langgraph-graph.service.spec.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-graph.service.spec.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CarNotAvailableException } from "../../booking/booking.error";
 import { BookingCreationService } from "../../booking/booking-creation.service";
 import { DatabaseService } from "../../database/database.service";
+import { GooglePlacesService } from "../../maps/google-places.service";
 import { BookingAgentSearchService } from "../booking-agent-search.service";
 import { BookingAgentWindowPolicyService } from "../booking-agent-window-policy.service";
 import type { BookingAgentState, VehicleSearchOption } from "./langgraph.interface";
@@ -40,6 +41,9 @@ describe("LangGraphGraphService", () => {
     whatsAppConversation: {
       findUnique: ReturnType<typeof vi.fn>;
     };
+  };
+  let googlePlacesServiceMock: {
+    validateAddressWithSuggestions: ReturnType<typeof vi.fn>;
   };
 
   const conversationId = "conv_test";
@@ -133,6 +137,14 @@ describe("LangGraphGraphService", () => {
       },
     };
 
+    googlePlacesServiceMock = {
+      validateAddressWithSuggestions: vi.fn().mockResolvedValue({
+        isValid: true,
+        normalizedAddress: "Victoria Island, Lagos, Nigeria",
+        suggestions: [],
+      }),
+    };
+
     moduleRef = await Test.createTestingModule({
       providers: [
         LangGraphGraphService,
@@ -143,6 +155,7 @@ describe("LangGraphGraphService", () => {
         { provide: BookingAgentWindowPolicyService, useValue: windowPolicyServiceMock },
         { provide: BookingCreationService, useValue: bookingCreationServiceMock },
         { provide: DatabaseService, useValue: databaseServiceMock },
+        { provide: GooglePlacesService, useValue: googlePlacesServiceMock },
       ],
     }).compile();
 
@@ -393,7 +406,7 @@ describe("LangGraphGraphService", () => {
 
       expect(result.draft.bookingType).toBe("DAY");
       expect(result.draft.pickupDate).toBe("2026-03-01");
-      expect(result.draft.pickupLocation).toBe("Lagos");
+      expect(result.draft.pickupLocation).toBe("Victoria Island, Lagos, Nigeria");
     });
 
     it("triggers search when all required fields collected", async () => {
@@ -512,6 +525,49 @@ describe("LangGraphGraphService", () => {
       expect(responderArg.availableOptions).toHaveLength(1);
       expect(responderArg.availableOptions[0].id).toBe("veh_search_result");
       expect(responderArg.stage).toBe("presenting_options");
+    });
+
+    it("validates pickup immediately in collecting stage when user provides vague area", async () => {
+      const existingState = buildInitialState();
+      existingState.stage = "collecting";
+      existingState.draft = {
+        bookingType: "DAY",
+        pickupDate: "2026-03-01",
+        pickupTime: "09:00",
+        dropoffDate: "2026-03-01",
+      };
+      stateServiceMock.loadState.mockResolvedValue(existingState);
+      stateServiceMock.mergeWithExisting.mockReturnValue({
+        ...existingState,
+        inboundMessage: "pick me up from Ikoyi",
+        inboundMessageId: messageId,
+      });
+
+      extractorServiceMock.extract.mockResolvedValue({
+        intent: "provide_info",
+        draftPatch: { pickupLocation: "Ikoyi" },
+        confidence: 0.9,
+      });
+
+      googlePlacesServiceMock.validateAddressWithSuggestions.mockResolvedValue({
+        isValid: false,
+        suggestions: [],
+        failureReason: "AREA_ONLY",
+      });
+
+      const result = await service.invoke({
+        conversationId,
+        messageId,
+        message: "pick me up from Ikoyi",
+      });
+
+      expect(googlePlacesServiceMock.validateAddressWithSuggestions).toHaveBeenCalledWith("Ikoyi");
+      expect(toolExecutorServiceMock.searchVehiclesFromExtracted).not.toHaveBeenCalled();
+      expect(result.outboxItems).toHaveLength(2);
+      expect(result.outboxItems[0]?.dedupeKey).toContain(":address-checking");
+      expect(result.outboxItems[1]?.dedupeKey).toContain(":address-suggestions");
+      expect(result.outboxItems[1]?.textBody).toContain("looks like a general area");
+      expect(result.outboxItems[1]?.textBody).not.toContain("Did you mean one of these?");
     });
   });
 
@@ -1194,6 +1250,95 @@ describe("LangGraphGraphService", () => {
   });
 
   describe("search - no results", () => {
+    it("sends checking message and top suggestions when pickup address is not found", async () => {
+      const existingState = buildInitialState();
+      existingState.stage = "collecting";
+      existingState.draft = {
+        bookingType: "DAY",
+        pickupDate: "2026-03-05",
+        pickupTime: "09:00",
+        dropoffDate: "2026-03-05",
+        pickupLocation: "Wheabaker Ikoyi",
+        dropoffLocation: "Wheabaker Ikoyi",
+      };
+      stateServiceMock.loadState.mockResolvedValue(existingState);
+      stateServiceMock.mergeWithExisting.mockReturnValue({ ...existingState });
+
+      extractorServiceMock.extract.mockResolvedValue({
+        intent: "confirm",
+        draftPatch: {},
+        confidence: 0.9,
+      });
+
+      googlePlacesServiceMock.validateAddressWithSuggestions.mockResolvedValue({
+        isValid: false,
+        suggestions: [
+          { placeId: "1", description: "The Wheatbaker, Ikoyi, Lagos" },
+          { placeId: "2", description: "The Wheatbaker Hotel, Onitolo Road, Ikoyi, Lagos" },
+          { placeId: "3", description: "Wheatbaker Street, Ikoyi, Lagos" },
+          { placeId: "4", description: "Wheatbaker Bus Stop, Ikoyi, Lagos" },
+        ],
+      });
+
+      const result = await service.invoke({
+        conversationId,
+        messageId,
+        message: "pickup is wheabaker ikoyi",
+      });
+
+      expect(toolExecutorServiceMock.searchVehiclesFromExtracted).not.toHaveBeenCalled();
+      expect(result.outboxItems).toHaveLength(2);
+      expect(result.outboxItems[0]?.dedupeKey).toContain(":address-checking");
+      expect(result.outboxItems[1]?.dedupeKey).toContain(":address-suggestions");
+      expect(result.outboxItems[1]?.textBody).toContain("Did you mean one of these?");
+      expect(result.outboxItems[1]?.textBody).toContain("1. The Wheatbaker, Ikoyi, Lagos");
+    });
+
+    it("re-validates pickup location on next turn after invalid lookup", async () => {
+      const existingState = buildInitialState();
+      existingState.stage = "collecting";
+      existingState.draft = {
+        bookingType: "DAY",
+        pickupDate: "2026-03-05",
+        pickupTime: "09:00",
+        dropoffDate: "2026-03-05",
+        pickupLocation: "Ikoyi",
+        dropoffLocation: "Ikoyi",
+      };
+      existingState.locationLookupTriggered = true;
+      existingState.locationSuggestions = [
+        { placeId: "1", description: "The Wheatbaker, Ikoyi, Lagos" },
+      ];
+      stateServiceMock.loadState.mockResolvedValue(existingState);
+      stateServiceMock.mergeWithExisting.mockReturnValue({ ...existingState });
+
+      extractorServiceMock.extract.mockResolvedValue({
+        intent: "confirm",
+        draftPatch: {},
+        confidence: 0.9,
+      });
+
+      googlePlacesServiceMock.validateAddressWithSuggestions.mockResolvedValue({
+        isValid: false,
+        suggestions: [],
+        failureReason: "AREA_ONLY",
+      });
+
+      const result = await service.invoke({
+        conversationId,
+        messageId,
+        message: "yes",
+      });
+
+      expect(googlePlacesServiceMock.validateAddressWithSuggestions).toHaveBeenCalledWith("Ikoyi");
+      expect(toolExecutorServiceMock.searchVehiclesFromExtracted).not.toHaveBeenCalled();
+      expect(result.outboxItems).toHaveLength(2);
+      expect(result.outboxItems[0]?.dedupeKey).toContain(":address-checking");
+      expect(result.outboxItems[1]?.dedupeKey).toContain(":address-suggestions");
+      expect(result.outboxItems[1]?.textBody).toContain("looks like a general area");
+      expect(result.outboxItems[1]?.textBody).not.toContain("Did you mean one of these?");
+    });
+
     it("sets error message when search returns no vehicles", async () => {
       const existingState = buildInitialState();
       existingState.stage = "collecting";

--- a/src/modules/booking-agent/langgraph/langgraph-graph.service.spec.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-graph.service.spec.ts
@@ -1488,8 +1488,11 @@ describe("LangGraphGraphService", () => {
       // Should NOT re-validate because locationLookupTriggered is true and suggestions are empty
       expect(googlePlacesServiceMock.validateAddressWithSuggestions).not.toHaveBeenCalled();
       expect(toolExecutorServiceMock.searchVehiclesFromExtracted).not.toHaveBeenCalled();
-      // Should go to responder to ask for valid address
+      // Should go to responder with meaningful error so it can ask for a more precise pickup address
       expect(result.stage).toBe("collecting");
+      expect(result.error).toBeDefined();
+      expect(result.error).toContain("Xyzzyville");
+      expect(result.error).toContain("more specific pickup location");
     });
 
     it("sets error message when search returns no vehicles", async () => {

--- a/src/modules/booking-agent/langgraph/langgraph-graph.service.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-graph.service.ts
@@ -384,6 +384,7 @@ export class LangGraphGraphService {
           error: null,
           locationSuggestions: [],
           locationLookupTriggered: true,
+          locationLookupFailed: false,
         };
       }
 
@@ -416,6 +417,7 @@ export class LangGraphGraphService {
           error: searchResult.precondition.prompt,
           locationSuggestions: [],
           locationLookupTriggered: true,
+          locationLookupFailed: false,
         };
       }
 
@@ -587,20 +589,22 @@ export class LangGraphGraphService {
             ...(locationResult.suggestions ?? []),
           ]);
 
-    // For NO_MATCH and AMBIGUOUS, set locationLookupTriggered to true to prevent infinite
-    // re-validation loops. For AREA_ONLY, keep it false so re-validation occurs when the
-    // user provides a more specific address (since suggestions are empty for AREA_ONLY).
-    const shouldMarkLookupComplete =
-      locationResult.failureReason === "NO_MATCH" || locationResult.failureReason === "AMBIGUOUS";
+    // Set locationLookupTriggered to true for all failure reasons to prevent infinite
+    // re-validation loops. The mergeNode resets this flag when pickupLocationChanged,
+    // so re-validation will occur when the user provides a new address.
+    const shouldMarkLookupComplete = true;
 
-    // NO_MATCH means the address couldn't be found at all - mark as failed so searchNode
-    // blocks until user provides a new address. AMBIGUOUS has suggestions so isn't a failure.
-    const isNoMatchFailure = locationResult.failureReason === "NO_MATCH";
+    // NO_MATCH and AREA_ONLY should mark as failed so searchNode blocks until user provides
+    // a new address. AMBIGUOUS has suggestions for the user to choose from, so isn't a failure.
+    // AREA_ONLY must also set locationLookupFailed to prevent area-only addresses from
+    // bypassing validation and reaching the vehicle search.
+    const isLocationFailure =
+      locationResult.failureReason === "NO_MATCH" || locationResult.failureReason === "AREA_ONLY";
 
     return {
       stage: "collecting",
       locationLookupTriggered: shouldMarkLookupComplete,
-      locationLookupFailed: isNoMatchFailure,
+      locationLookupFailed: isLocationFailure,
       locationSuggestions: (locationResult.suggestions ?? []).map((suggestion) => ({
         placeId: suggestion.placeId,
         description: suggestion.description,

--- a/src/modules/booking-agent/langgraph/langgraph-graph.service.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-graph.service.ts
@@ -352,6 +352,22 @@ export class LangGraphGraphService {
       }
       const validatedDraft = validationResult.draft;
 
+      // If location lookup previously failed (NO_MATCH) and user hasn't provided a new address,
+      // don't proceed to search - stay in collecting stage to get a valid address
+      const locationPreviouslyFailedNoMatch =
+        state.locationLookupTriggered && (state.locationSuggestions ?? []).length === 0;
+      if (locationPreviouslyFailedNoMatch && validatedDraft.pickupLocation) {
+        return {
+          draft: validatedDraft,
+          stage: "collecting",
+          availableOptions: [],
+          lastShownOptions: [],
+          error: null,
+          locationSuggestions: [],
+          locationLookupTriggered: true,
+        };
+      }
+
       const missingFields = getMissingRequiredFields(validatedDraft);
       if (missingFields.length > 0) {
         return {
@@ -385,10 +401,15 @@ export class LangGraphGraphService {
           extractedParams,
         });
         // Go back to collecting stage to ask for the missing field
+        // Preserve the validated draft and location lookup state
         return {
+          draft: validatedDraft,
           availableOptions: [],
+          lastShownOptions: [],
           stage: "collecting",
           error: searchResult.precondition.prompt,
+          locationSuggestions: [],
+          locationLookupTriggered: true,
         };
       }
 
@@ -432,14 +453,15 @@ export class LangGraphGraphService {
         error: error instanceof Error ? error.message : String(error),
         stack: error instanceof Error ? error.stack : undefined,
       });
+      // Preserve locationLookupTriggered state - if we reached the catch block,
+      // validation may have already succeeded before the error occurred.
+      // Setting it to false would cause an unnecessary re-validation on the next turn.
       return {
         stage: "collecting",
         error:
           "I couldn't check availability right now. Please try again or adjust your booking details.",
         availableOptions: [],
         lastShownOptions: [],
-        locationSuggestions: [],
-        locationLookupTriggered: false,
       };
     }
   }
@@ -557,9 +579,15 @@ export class LangGraphGraphService {
             ...(locationResult.suggestions ?? []),
           ]);
 
+    // For NO_MATCH and AMBIGUOUS, set locationLookupTriggered to true to prevent infinite
+    // re-validation loops. For AREA_ONLY, keep it false so re-validation occurs when the
+    // user provides a more specific address (since suggestions are empty for AREA_ONLY).
+    const shouldMarkLookupComplete =
+      locationResult.failureReason === "NO_MATCH" || locationResult.failureReason === "AMBIGUOUS";
+
     return {
       stage: "collecting",
-      locationLookupTriggered: false,
+      locationLookupTriggered: shouldMarkLookupComplete,
       locationSuggestions: (locationResult.suggestions ?? []).map((suggestion) => ({
         placeId: suggestion.placeId,
         description: suggestion.description,

--- a/src/modules/booking-agent/langgraph/langgraph-graph.service.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-graph.service.ts
@@ -3,6 +3,8 @@ import { Injectable, Logger } from "@nestjs/common";
 import { CarNotAvailableException } from "../../booking/booking.error";
 import { BookingCreationService } from "../../booking/booking-creation.service";
 import { DatabaseService } from "../../database/database.service";
+import { GooglePlacesService } from "../../maps/google-places.service";
+import type { AddressLookupResult } from "../../maps/maps.interface";
 import { getMissingRequiredFields } from "../booking-agent.helper";
 import { BookingAgentSearchService } from "../booking-agent-search.service";
 import { LANGGRAPH_NODE_NAMES, LANGGRAPH_OUTBOUND_MODE } from "./langgraph.const";
@@ -104,6 +106,14 @@ const BookingAgentAnnotation = Annotation.Root({
     reducer: (_, update) => update,
     default: () => [],
   }),
+  locationSuggestions: Annotation({
+    reducer: (_, update: BookingAgentState["locationSuggestions"]) => update,
+    default: () => [],
+  }),
+  locationLookupTriggered: Annotation<boolean>({
+    reducer: (_, update) => update,
+    default: () => false,
+  }),
   nextNode: AnnotationWithDefault<string | null>(null),
   error: AnnotationWithDefault<string | null>(null),
 });
@@ -122,6 +132,7 @@ export class LangGraphGraphService {
     private readonly bookingAgentSearchService: BookingAgentSearchService,
     private readonly bookingCreationService: BookingCreationService,
     private readonly databaseService: DatabaseService,
+    private readonly googlePlacesService: GooglePlacesService,
   ) {}
 
   async invoke(input: LangGraphInvokeInput): Promise<LangGraphInvokeResult> {
@@ -266,6 +277,7 @@ export class LangGraphGraphService {
     }
 
     const draftChanged = hasDraftChanged(draft, newDraft);
+    const pickupLocationChanged = draft.pickupLocation !== newDraft.pickupLocation;
     const shouldClearOptions = draftChanged && state.availableOptions.length > 0;
 
     this.logger.debug("Merge node completed", {
@@ -279,6 +291,8 @@ export class LangGraphGraphService {
       preferences: newPreferences,
       availableOptions: shouldClearOptions ? [] : state.availableOptions,
       lastShownOptions: shouldClearOptions ? [] : state.lastShownOptions,
+      locationSuggestions: pickupLocationChanged ? [] : (state.locationSuggestions ?? []),
+      locationLookupTriggered: pickupLocationChanged ? false : !!state.locationLookupTriggered,
     };
   }
 
@@ -303,6 +317,26 @@ export class LangGraphGraphService {
     });
 
     const decision = resolveRouteDecision(state as BookingAgentState);
+    const isControlIntent =
+      extraction?.intent === "new_booking" ||
+      extraction?.intent === "reset" ||
+      extraction?.intent === "greeting" ||
+      extraction?.intent === "cancel" ||
+      extraction?.intent === "request_agent";
+    const shouldRunEarlyPickupValidation =
+      !isControlIntent &&
+      (decision.nextNode ?? LANGGRAPH_NODE_NAMES.RESPOND) === LANGGRAPH_NODE_NAMES.RESPOND &&
+      (decision.stage ?? stage) === "collecting" &&
+      !!draft.pickupLocation &&
+      (!state.locationLookupTriggered || (state.locationSuggestions ?? []).length > 0);
+    if (shouldRunEarlyPickupValidation) {
+      return {
+        ...decision,
+        nextNode: LANGGRAPH_NODE_NAMES.SEARCH,
+        stage: "collecting",
+      };
+    }
+
     return decision;
   }
 
@@ -312,7 +346,41 @@ export class LangGraphGraphService {
 
   private async searchNode(state: AnnotationState): Promise<Partial<AnnotationState>> {
     try {
-      const extractedParams = convertToExtractedParams(state.draft);
+      let validatedDraft = state.draft;
+      const shouldValidatePickupLocation =
+        !!state.draft.pickupLocation &&
+        (!state.locationLookupTriggered || (state.locationSuggestions ?? []).length > 0);
+      if (shouldValidatePickupLocation) {
+        const locationResult = await this.googlePlacesService.validateAddressWithSuggestions(
+          state.draft.pickupLocation,
+        );
+
+        if (!locationResult.isValid) {
+          return this.buildInvalidPickupLocationResult(state, locationResult);
+        }
+
+        if (locationResult.normalizedAddress) {
+          validatedDraft = {
+            ...state.draft,
+            pickupLocation: locationResult.normalizedAddress,
+          };
+        }
+      }
+
+      const missingFields = getMissingRequiredFields(validatedDraft);
+      if (missingFields.length > 0) {
+        return {
+          draft: validatedDraft,
+          stage: "collecting",
+          availableOptions: [],
+          lastShownOptions: [],
+          error: null,
+          locationSuggestions: [],
+          locationLookupTriggered: true,
+        };
+      }
+
+      const extractedParams = convertToExtractedParams(validatedDraft);
       this.logger.log(
         {
           draft: state.draft,
@@ -366,10 +434,13 @@ export class LangGraphGraphService {
           : null;
 
       return {
+        draft: validatedDraft,
         availableOptions: options,
         lastShownOptions: options,
         stage: newStage,
         error: noResultsError,
+        locationSuggestions: [],
+        locationLookupTriggered: true,
       };
     } catch (error) {
       this.logger.error("Search node failed", {
@@ -382,12 +453,18 @@ export class LangGraphGraphService {
           "I couldn't check availability right now. Please try again or adjust your booking details.",
         availableOptions: [],
         lastShownOptions: [],
+        locationSuggestions: [],
+        locationLookupTriggered: false,
       };
     }
   }
 
   private async respondNode(state: AnnotationState): Promise<Partial<AnnotationState>> {
     try {
+      if (state.outboxItems.length > 0 && state.response) {
+        return {};
+      }
+
       this.logger.log(
         {
           stage: state.stage,
@@ -413,6 +490,71 @@ export class LangGraphGraphService {
         error: error instanceof Error ? error.message : String(error),
       };
     }
+  }
+
+  private buildLocationSuggestionText(
+    pickupLocation: string,
+    suggestions: BookingAgentState["locationSuggestions"] = [],
+  ): string {
+    if (suggestions.length === 0) {
+      return `I couldn't find "${pickupLocation}" on Google Maps. Please share a more specific pickup location (for example: street + area in Lagos).`;
+    }
+
+    const list = suggestions.slice(0, 4).map((suggestion, index) => {
+      return `${index + 1}. ${suggestion.description}`;
+    });
+    return [
+      `I couldn't find an exact Google Maps match for "${pickupLocation}".`,
+      "",
+      "Did you mean one of these?",
+      ...list,
+      "",
+      "Reply with the full address you want from the list, or send a clearer pickup address.",
+    ].join("\n");
+  }
+
+  private buildAreaOnlyLocationPrompt(pickupLocation: string): string {
+    return [
+      `"${pickupLocation}" looks like a general area, not a full pickup address.`,
+      "",
+      "Please share a specific pickup address (for example: building number + street, or a hotel/landmark name in Lagos).",
+    ].join("\n");
+  }
+
+  private buildInvalidPickupLocationResult(
+    state: AnnotationState,
+    locationResult: AddressLookupResult,
+  ): Partial<AnnotationState> {
+    const suggestionText =
+      locationResult.failureReason === "AREA_ONLY"
+        ? this.buildAreaOnlyLocationPrompt(state.draft.pickupLocation ?? "that location")
+        : this.buildLocationSuggestionText(state.draft.pickupLocation ?? "that location", [
+            ...(locationResult.suggestions ?? []),
+          ]);
+
+    return {
+      stage: "collecting",
+      locationLookupTriggered: false,
+      locationSuggestions: (locationResult.suggestions ?? []).map((suggestion) => ({
+        placeId: suggestion.placeId,
+        description: suggestion.description,
+      })),
+      response: { text: suggestionText },
+      outboxItems: [
+        {
+          conversationId: state.conversationId,
+          dedupeKey: `langgraph:${state.inboundMessageId}:address-checking`,
+          mode: LANGGRAPH_OUTBOUND_MODE.FREE_FORM,
+          textBody: "Thanks - I'm checking that pickup address on Google Maps now...",
+        },
+        {
+          conversationId: state.conversationId,
+          dedupeKey: `langgraph:${state.inboundMessageId}:address-suggestions`,
+          mode: LANGGRAPH_OUTBOUND_MODE.FREE_FORM,
+          textBody: suggestionText,
+        },
+      ],
+    };
   }
 
   private async createBookingNode(state: AnnotationState): Promise<Partial<AnnotationState>> {

--- a/src/modules/booking-agent/langgraph/langgraph-graph.service.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-graph.service.ts
@@ -361,14 +361,18 @@ export class LangGraphGraphService {
       // don't proceed to search - stay in collecting stage to get a valid address.
       // Note: We use the explicit `locationLookupFailed` flag rather than inferring from
       // empty suggestions, because a successful search also clears suggestions.
+      // Provide a meaningful error so the responder can craft a specific prompt for a more precise pickup address.
       if (state.locationLookupFailed && validatedDraft.pickupLocation) {
         return {
           draft: validatedDraft,
           stage: "collecting",
           availableOptions: [],
           lastShownOptions: [],
-          error: null,
-          locationSuggestions: [],
+          error: this.buildLocationSuggestionText(
+            validatedDraft.pickupLocation,
+            state.locationSuggestions ?? [],
+          ),
+          locationSuggestions: state.locationSuggestions ?? [],
           locationLookupTriggered: true,
           locationLookupFailed: true,
         };

--- a/src/modules/booking-agent/langgraph/langgraph-graph.service.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-graph.service.ts
@@ -114,6 +114,10 @@ const BookingAgentAnnotation = Annotation.Root({
     reducer: (_, update) => update,
     default: () => false,
   }),
+  locationLookupFailed: Annotation<boolean>({
+    reducer: (_, update) => update,
+    default: () => false,
+  }),
   nextNode: AnnotationWithDefault<string | null>(null),
   error: AnnotationWithDefault<string | null>(null),
 });
@@ -293,6 +297,7 @@ export class LangGraphGraphService {
       lastShownOptions: shouldClearOptions ? [] : state.lastShownOptions,
       locationSuggestions: pickupLocationChanged ? [] : (state.locationSuggestions ?? []),
       locationLookupTriggered: pickupLocationChanged ? false : !!state.locationLookupTriggered,
+      locationLookupFailed: pickupLocationChanged ? false : !!state.locationLookupFailed,
     };
   }
 
@@ -353,10 +358,10 @@ export class LangGraphGraphService {
       const validatedDraft = validationResult.draft;
 
       // If location lookup previously failed (NO_MATCH) and user hasn't provided a new address,
-      // don't proceed to search - stay in collecting stage to get a valid address
-      const locationPreviouslyFailedNoMatch =
-        state.locationLookupTriggered && (state.locationSuggestions ?? []).length === 0;
-      if (locationPreviouslyFailedNoMatch && validatedDraft.pickupLocation) {
+      // don't proceed to search - stay in collecting stage to get a valid address.
+      // Note: We use the explicit `locationLookupFailed` flag rather than inferring from
+      // empty suggestions, because a successful search also clears suggestions.
+      if (state.locationLookupFailed && validatedDraft.pickupLocation) {
         return {
           draft: validatedDraft,
           stage: "collecting",
@@ -365,6 +370,7 @@ export class LangGraphGraphService {
           error: null,
           locationSuggestions: [],
           locationLookupTriggered: true,
+          locationLookupFailed: true,
         };
       }
 
@@ -447,6 +453,8 @@ export class LangGraphGraphService {
         error: noResultsError,
         locationSuggestions: [],
         locationLookupTriggered: true,
+        // Clear failed state on successful search - this allows re-search with same location
+        locationLookupFailed: false,
       };
     } catch (error) {
       this.logger.error("Search node failed", {
@@ -585,14 +593,20 @@ export class LangGraphGraphService {
     const shouldMarkLookupComplete =
       locationResult.failureReason === "NO_MATCH" || locationResult.failureReason === "AMBIGUOUS";
 
+    // NO_MATCH means the address couldn't be found at all - mark as failed so searchNode
+    // blocks until user provides a new address. AMBIGUOUS has suggestions so isn't a failure.
+    const isNoMatchFailure = locationResult.failureReason === "NO_MATCH";
+
     return {
       stage: "collecting",
       locationLookupTriggered: shouldMarkLookupComplete,
+      locationLookupFailed: isNoMatchFailure,
       locationSuggestions: (locationResult.suggestions ?? []).map((suggestion) => ({
         placeId: suggestion.placeId,
         description: suggestion.description,
       })),
       response: { text: suggestionText },
+      error: null,
       outboxItems: [
         {
           conversationId: state.conversationId,

--- a/src/modules/booking-agent/langgraph/langgraph-graph.service.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-graph.service.ts
@@ -346,26 +346,11 @@ export class LangGraphGraphService {
 
   private async searchNode(state: AnnotationState): Promise<Partial<AnnotationState>> {
     try {
-      let validatedDraft = state.draft;
-      const shouldValidatePickupLocation =
-        !!state.draft.pickupLocation &&
-        (!state.locationLookupTriggered || (state.locationSuggestions ?? []).length > 0);
-      if (shouldValidatePickupLocation) {
-        const locationResult = await this.googlePlacesService.validateAddressWithSuggestions(
-          state.draft.pickupLocation,
-        );
-
-        if (!locationResult.isValid) {
-          return this.buildInvalidPickupLocationResult(state, locationResult);
-        }
-
-        if (locationResult.normalizedAddress) {
-          validatedDraft = {
-            ...state.draft,
-            pickupLocation: locationResult.normalizedAddress,
-          };
-        }
+      const validationResult = await this.validateAndNormalizePickupLocation(state);
+      if (validationResult.earlyReturn) {
+        return validationResult.earlyReturn;
       }
+      const validatedDraft = validationResult.draft;
 
       const missingFields = getMissingRequiredFields(validatedDraft);
       if (missingFields.length > 0) {
@@ -519,6 +504,46 @@ export class LangGraphGraphService {
       "",
       "Please share a specific pickup address (for example: building number + street, or a hotel/landmark name in Lagos).",
     ].join("\n");
+  }
+
+  private async validateAndNormalizePickupLocation(state: AnnotationState): Promise<{
+    draft: BookingDraft;
+    earlyReturn?: Partial<AnnotationState>;
+  }> {
+    const shouldValidate =
+      !!state.draft.pickupLocation &&
+      (!state.locationLookupTriggered || (state.locationSuggestions ?? []).length > 0);
+
+    if (!shouldValidate) {
+      return { draft: state.draft };
+    }
+
+    const locationResult = await this.googlePlacesService.validateAddressWithSuggestions(
+      state.draft.pickupLocation,
+    );
+
+    if (!locationResult.isValid) {
+      return {
+        draft: state.draft,
+        earlyReturn: this.buildInvalidPickupLocationResult(state, locationResult),
+      };
+    }
+
+    if (!locationResult.normalizedAddress) {
+      return { draft: state.draft };
+    }
+
+    const wasDropoffSameAsPickup = state.draft.dropoffLocation === state.draft.pickupLocation;
+    return {
+      draft: {
+        ...state.draft,
+        pickupLocation: locationResult.normalizedAddress,
+        // Keep dropoff in sync if it was auto-filled from pickup via "same location"
+        ...(wasDropoffSameAsPickup && {
+          dropoffLocation: locationResult.normalizedAddress,
+        }),
+      },
+    };
   }
 
   private buildInvalidPickupLocationResult(

--- a/src/modules/booking-agent/langgraph/langgraph-state.service.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-state.service.ts
@@ -53,6 +53,8 @@ export class LangGraphStateService {
         holdId: persisted.holdId ?? null,
         holdExpiresAt: persisted.holdExpiresAt ?? null,
         bookingId: persisted.bookingId ?? null,
+        locationSuggestions: persisted.locationSuggestions ?? [],
+        locationLookupTriggered: persisted.locationLookupTriggered ?? false,
       };
     } catch (error) {
       this.logger.error("Failed to load LangGraph state", {
@@ -82,6 +84,8 @@ export class LangGraphStateService {
       holdId: state.holdId,
       holdExpiresAt: state.holdExpiresAt,
       bookingId: state.bookingId,
+      locationSuggestions: state.locationSuggestions ?? [],
+      locationLookupTriggered: state.locationLookupTriggered ?? false,
       updatedAt: new Date().toISOString(),
     };
 
@@ -146,6 +150,8 @@ export class LangGraphStateService {
       outboxItems: [],
       nextNode: null,
       error: null,
+      locationSuggestions: [],
+      locationLookupTriggered: false,
     };
   }
 
@@ -179,6 +185,8 @@ export class LangGraphStateService {
       outboxItems: [],
       nextNode: null,
       error: null,
+      locationSuggestions: existingState.locationSuggestions ?? [],
+      locationLookupTriggered: existingState.locationLookupTriggered ?? false,
     };
   }
 

--- a/src/modules/booking-agent/langgraph/langgraph-state.service.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-state.service.ts
@@ -55,6 +55,7 @@ export class LangGraphStateService {
         bookingId: persisted.bookingId ?? null,
         locationSuggestions: persisted.locationSuggestions ?? [],
         locationLookupTriggered: persisted.locationLookupTriggered ?? false,
+        locationLookupFailed: persisted.locationLookupFailed ?? false,
       };
     } catch (error) {
       this.logger.error("Failed to load LangGraph state", {
@@ -86,6 +87,7 @@ export class LangGraphStateService {
       bookingId: state.bookingId,
       locationSuggestions: state.locationSuggestions ?? [],
       locationLookupTriggered: state.locationLookupTriggered ?? false,
+      locationLookupFailed: state.locationLookupFailed ?? false,
       updatedAt: new Date().toISOString(),
     };
 
@@ -152,6 +154,7 @@ export class LangGraphStateService {
       error: null,
       locationSuggestions: [],
       locationLookupTriggered: false,
+      locationLookupFailed: false,
     };
   }
 
@@ -187,6 +190,7 @@ export class LangGraphStateService {
       error: null,
       locationSuggestions: existingState.locationSuggestions ?? [],
       locationLookupTriggered: existingState.locationLookupTriggered ?? false,
+      locationLookupFailed: existingState.locationLookupFailed ?? false,
     };
   }
 

--- a/src/modules/booking-agent/langgraph/langgraph.interface.ts
+++ b/src/modules/booking-agent/langgraph/langgraph.interface.ts
@@ -148,6 +148,8 @@ export interface BookingAgentState {
   error: string | null;
   locationSuggestions?: LocationSuggestionOption[];
   locationLookupTriggered?: boolean;
+  /** True when location lookup failed with NO_MATCH (no suggestions available) */
+  locationLookupFailed?: boolean;
 }
 
 export interface LangGraphInvokeInput {
@@ -205,6 +207,8 @@ export interface PersistedState {
   bookingId: string | null;
   locationSuggestions?: LocationSuggestionOption[];
   locationLookupTriggered?: boolean;
+  /** True when location lookup failed with NO_MATCH (no suggestions available) */
+  locationLookupFailed?: boolean;
   updatedAt: string;
 }
 

--- a/src/modules/booking-agent/langgraph/langgraph.interface.ts
+++ b/src/modules/booking-agent/langgraph/langgraph.interface.ts
@@ -107,6 +107,11 @@ export interface AgentResponse {
   vehicleCards?: VehicleCard[];
 }
 
+export interface LocationSuggestionOption {
+  placeId: string;
+  description: string;
+}
+
 export interface LangGraphOutboxItem {
   conversationId: string;
   dedupeKey: string;
@@ -141,6 +146,8 @@ export interface BookingAgentState {
   outboxItems: LangGraphOutboxItem[];
   nextNode: string | null;
   error: string | null;
+  locationSuggestions?: LocationSuggestionOption[];
+  locationLookupTriggered?: boolean;
 }
 
 export interface LangGraphInvokeInput {
@@ -196,6 +203,8 @@ export interface PersistedState {
   holdId: string | null;
   holdExpiresAt: string | null;
   bookingId: string | null;
+  locationSuggestions?: LocationSuggestionOption[];
+  locationLookupTriggered?: boolean;
   updatedAt: string;
 }
 

--- a/src/modules/booking-agent/whatsapp/whatsapp-ingress.service.ts
+++ b/src/modules/booking-agent/whatsapp/whatsapp-ingress.service.ts
@@ -1,6 +1,6 @@
 import { InjectQueue } from "@nestjs/bullmq";
 import { Injectable, Logger } from "@nestjs/common";
-import { Queue } from "bullmq";
+import type { Queue } from "bullmq";
 import { PROCESS_WHATSAPP_INBOUND_JOB, WHATSAPP_AGENT_QUEUE } from "../../../config/constants";
 import { WHATSAPP_QUEUE_DEFAULT_JOB_OPTIONS } from "../booking-agent.const";
 import type {

--- a/src/modules/booking-agent/whatsapp/whatsapp-sender.service.ts
+++ b/src/modules/booking-agent/whatsapp/whatsapp-sender.service.ts
@@ -2,7 +2,7 @@ import { InjectQueue } from "@nestjs/bullmq";
 import { Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { Prisma, WhatsAppMessageKind, WhatsAppOutboxStatus } from "@prisma/client";
-import { Queue } from "bullmq";
+import type { Queue } from "bullmq";
 import twilio, { Twilio } from "twilio";
 import type { MessageInstance } from "twilio/lib/rest/api/v2010/account/message";
 import { PROCESS_WHATSAPP_OUTBOX_JOB, WHATSAPP_AGENT_QUEUE } from "../../../config/constants";

--- a/src/modules/maps/google-places.service.spec.ts
+++ b/src/modules/maps/google-places.service.spec.ts
@@ -119,6 +119,39 @@ describe("GooglePlacesService", () => {
     expect(result.placeId).toBe("place_glover_12");
   });
 
+  it("marks route-only address as area-only (no street number)", async () => {
+    mockHttpClient.post.mockResolvedValueOnce({
+      data: {
+        suggestions: [
+          {
+            placePrediction: {
+              placeId: "place_glover_road",
+              text: { text: "Glover Road, Ikoyi, Lagos, Nigeria" },
+              types: ["route"],
+            },
+          },
+        ],
+      },
+    });
+    mockHttpClient.get.mockResolvedValueOnce({
+      data: {
+        id: "place_glover_road",
+        types: ["route"],
+        formattedAddress: "Glover Road, Ikoyi, Lagos, Nigeria",
+        addressComponents: [
+          { longText: "Glover Road", types: ["route"] },
+          { longText: "Ikoyi", types: ["neighborhood", "political"] },
+          { longText: "Lagos", types: ["locality", "political"] },
+        ],
+      },
+    });
+
+    const result = await service.validateAddressWithSuggestions("Glover Road Ikoyi");
+
+    expect(result.isValid).toBe(false);
+    expect(result.failureReason).toBe("AREA_ONLY");
+  });
+
   it("accepts venue address when place details include street number and route", async () => {
     mockHttpClient.post.mockResolvedValueOnce({
       data: {

--- a/src/modules/maps/google-places.service.spec.ts
+++ b/src/modules/maps/google-places.service.spec.ts
@@ -1,0 +1,156 @@
+import { ConfigService } from "@nestjs/config";
+import { Test, type TestingModule } from "@nestjs/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createMockAxiosInstance,
+  createMockHttpClientService,
+} from "../http-client/http-client.fixtures";
+import { HttpClientService } from "../http-client/http-client.service";
+import { GooglePlacesService } from "./google-places.service";
+
+describe("GooglePlacesService", () => {
+  let service: GooglePlacesService;
+  let mockHttpClient: ReturnType<typeof createMockAxiosInstance>;
+
+  const createService = async (apiKey: string | undefined) => {
+    const mockConfigService = {
+      get: vi.fn((key: string) => {
+        if (key === "GOOGLE_DISTANCE_MATRIX_API_KEY") return apiKey;
+        return undefined;
+      }),
+    };
+
+    mockHttpClient = createMockAxiosInstance();
+    const mockHttpClientService = createMockHttpClientService(mockHttpClient);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GooglePlacesService,
+        { provide: ConfigService, useValue: mockConfigService },
+        { provide: HttpClientService, useValue: mockHttpClientService },
+      ],
+    }).compile();
+
+    return module.get<GooglePlacesService>(GooglePlacesService);
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    service = await createService("test-api-key");
+  });
+
+  it("marks area-only input as invalid even when autocomplete returns a match", async () => {
+    mockHttpClient.post.mockResolvedValueOnce({
+      data: {
+        suggestions: [
+          {
+            placePrediction: {
+              placeId: "place_ikoyi",
+              text: { text: "Ikoyi, Lagos, Nigeria" },
+              types: ["neighborhood", "political"],
+            },
+          },
+          {
+            placePrediction: {
+              placeId: "place_obalende",
+              text: { text: "Obalende, Lagos, Nigeria" },
+              types: ["sublocality_level_1", "political"],
+            },
+          },
+        ],
+      },
+    });
+    mockHttpClient.get.mockResolvedValueOnce({
+      data: {
+        id: "place_ikoyi",
+        types: ["island", "natural_feature", "establishment"],
+        formattedAddress: "Ikoyi, Lagos 106104, Lagos, Nigeria",
+        addressComponents: [
+          { longText: "Ikoyi", types: ["island", "natural_feature", "establishment"] },
+          { longText: "Ikoyi", types: ["neighborhood", "political"] },
+          { longText: "Lagos", types: ["locality", "political"] },
+          { longText: "Eti Osa", types: ["administrative_area_level_2", "political"] },
+          { longText: "Lagos", types: ["administrative_area_level_1", "political"] },
+          { longText: "Nigeria", types: ["country", "political"] },
+        ],
+      },
+    });
+
+    const result = await service.validateAddressWithSuggestions("Ikoyi");
+
+    expect(result.isValid).toBe(false);
+    expect(result.normalizedAddress).toBeUndefined();
+    expect(result.placeId).toBeUndefined();
+    expect(result.failureReason).toBe("AREA_ONLY");
+    expect(result.suggestions).toHaveLength(0);
+  });
+
+  it("accepts numbered street addresses as valid", async () => {
+    mockHttpClient.post.mockResolvedValueOnce({
+      data: {
+        suggestions: [
+          {
+            placePrediction: {
+              placeId: "place_glover_12",
+              text: { text: "12 Glover Road, Ikoyi, Lagos, Nigeria" },
+              types: ["street_address"],
+            },
+          },
+        ],
+      },
+    });
+    mockHttpClient.get.mockResolvedValueOnce({
+      data: {
+        id: "place_glover_12",
+        types: ["street_address"],
+        formattedAddress: "12 Glover Road, Ikoyi, Lagos, Nigeria",
+        addressComponents: [
+          { longText: "12", types: ["street_number"] },
+          { longText: "Glover Road", types: ["route"] },
+          { longText: "Ikoyi", types: ["neighborhood", "political"] },
+        ],
+      },
+    });
+
+    const result = await service.validateAddressWithSuggestions("12 Glover Road Ikoyi");
+
+    expect(result.isValid).toBe(true);
+    expect(result.normalizedAddress).toBe("12 Glover Road, Ikoyi, Lagos, Nigeria");
+    expect(result.placeId).toBe("place_glover_12");
+  });
+
+  it("accepts venue address when place details include street number and route", async () => {
+    mockHttpClient.post.mockResolvedValueOnce({
+      data: {
+        suggestions: [
+          {
+            placePrediction: {
+              placeId: "place_wheatbaker",
+              text: { text: "The Wheatbaker Hotel, Ikoyi, Lagos" },
+              types: ["lodging", "establishment"],
+            },
+          },
+        ],
+      },
+    });
+    mockHttpClient.get.mockResolvedValueOnce({
+      data: {
+        id: "place_wheatbaker",
+        types: ["hotel", "lodging", "point_of_interest", "establishment"],
+        formattedAddress: "30 Lugard Ave, Ikoyi, Lagos 106104, Lagos, Nigeria",
+        addressComponents: [
+          { longText: "30", types: ["street_number"] },
+          { longText: "Lugard Avenue", types: ["route"] },
+          { longText: "Ikoyi", types: ["neighborhood", "political"] },
+          { longText: "Lagos", types: ["locality", "political"] },
+        ],
+      },
+    });
+
+    const result = await service.validateAddressWithSuggestions("Wheatbaker Hotel Ikoyi");
+
+    expect(result.isValid).toBe(true);
+    expect(result.normalizedAddress).toBe("30 Lugard Ave, Ikoyi, Lagos 106104, Lagos, Nigeria");
+    expect(result.placeId).toBe("place_wheatbaker");
+  });
+});

--- a/src/modules/maps/google-places.service.ts
+++ b/src/modules/maps/google-places.service.ts
@@ -259,7 +259,7 @@ export class GooglePlacesService {
     );
     const hasStreetNumber = componentTypes.has("street_number");
     const hasRoute = componentTypes.has("route");
-    if (hasStreetNumber || hasRoute) {
+    if (hasStreetNumber && hasRoute) {
       return false;
     }
 

--- a/src/modules/maps/google-places.service.ts
+++ b/src/modules/maps/google-places.service.ts
@@ -1,0 +1,303 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import type { AxiosInstance } from "axios";
+import type { EnvConfig } from "src/config/env.config";
+import { HttpClientService } from "../http-client/http-client.service";
+import { LAGOS_VIEWPORT_BOUNDS } from "./maps.const";
+import type {
+  AddressLookupResult,
+  PlaceDetailsResponse,
+  PlaceSuggestion,
+  PlacesAutocompleteNewResponse,
+} from "./maps.interface";
+
+@Injectable()
+export class GooglePlacesService {
+  private readonly logger = new Logger(GooglePlacesService.name);
+  private readonly apiKey: string | undefined;
+  private readonly maxSuggestions = 4;
+  private readonly autocompleteUrl = "https://places.googleapis.com/v1/places:autocomplete";
+  private readonly placeDetailsBaseUrl = "https://places.googleapis.com/v1/places";
+  private readonly httpClient: AxiosInstance;
+  private readonly areaPlaceTypes = new Set([
+    "locality",
+    "sublocality",
+    "sublocality_level_1",
+    "sublocality_level_2",
+    "sublocality_level_3",
+    "sublocality_level_4",
+    "sublocality_level_5",
+    "neighborhood",
+    "administrative_area_level_1",
+    "administrative_area_level_2",
+    "administrative_area_level_3",
+    "postal_town",
+  ]);
+  private readonly precisePlaceTypes = new Set([
+    "street_address",
+    "premise",
+    "subpremise",
+    "establishment",
+    "point_of_interest",
+    "airport",
+    "lodging",
+  ]);
+
+  constructor(
+    private readonly configService: ConfigService<EnvConfig>,
+    private readonly httpClientService: HttpClientService,
+  ) {
+    this.apiKey = this.configService.get("GOOGLE_DISTANCE_MATRIX_API_KEY", { infer: true });
+    this.httpClient = this.httpClientService.createClient({
+      timeout: 10000,
+      headers: {
+        "Content-Type": "application/json",
+        "X-Goog-Api-Key": this.apiKey,
+        "X-Goog-FieldMask":
+          "suggestions.placePrediction.placeId,suggestions.placePrediction.text.text,suggestions.placePrediction.types",
+      },
+      serviceName: "GooglePlaces",
+    });
+  }
+
+  async validateAddressWithSuggestions(input: string): Promise<AddressLookupResult> {
+    const query = input.trim();
+    if (!query) {
+      return { isValid: false, suggestions: [] };
+    }
+
+    const suggestions = await this.fetchAutocompleteSuggestions(query);
+    if (suggestions.length === 0) {
+      return { isValid: false, suggestions: [], failureReason: "NO_MATCH" };
+    }
+
+    const topMatch = suggestions[0];
+    const details = topMatch?.placeId ? await this.fetchPlaceDetails(topMatch.placeId) : null;
+
+    if (details && this.isAreaOnlyFromPlaceDetails(details)) {
+      return {
+        isValid: false,
+        suggestions: [],
+        failureReason: "AREA_ONLY",
+      };
+    }
+
+    if (details && this.isSpecificAddressFromPlaceDetails(details)) {
+      return {
+        isValid: true,
+        normalizedAddress: details.formattedAddress ?? topMatch?.description,
+        placeId: topMatch?.placeId,
+        suggestions,
+      };
+    }
+
+    if (!details && this.isAreaOnlyInput(query, suggestions)) {
+      return {
+        isValid: false,
+        suggestions: [],
+        failureReason: "AREA_ONLY",
+      };
+    }
+
+    const isValid =
+      this.isSpecificAddressQuery(query) &&
+      this.isLikelyExactAddressMatch(query, topMatch?.description ?? "");
+
+    return {
+      isValid,
+      normalizedAddress: isValid ? topMatch?.description : undefined,
+      placeId: isValid ? topMatch?.placeId : undefined,
+      suggestions: isValid ? suggestions : suggestions.slice(0, this.maxSuggestions),
+      failureReason: isValid ? undefined : "AMBIGUOUS",
+    };
+  }
+
+  private async fetchAutocompleteSuggestions(query: string): Promise<PlaceSuggestion[]> {
+    try {
+      const { data } = await this.httpClient.post<PlacesAutocompleteNewResponse>(
+        this.autocompleteUrl,
+        {
+          input: query,
+          includedRegionCodes: ["ng"],
+          locationRestriction: {
+            rectangle: LAGOS_VIEWPORT_BOUNDS,
+          },
+          includeQueryPredictions: false,
+        },
+      );
+
+      return (data.suggestions ?? [])
+        .map((suggestion) => suggestion.placePrediction)
+        .filter((prediction): prediction is NonNullable<typeof prediction> => !!prediction)
+        .filter((prediction) => prediction.text?.text && prediction.placeId)
+        .slice(0, this.maxSuggestions)
+        .map((prediction) => ({
+          placeId: prediction.placeId,
+          description: prediction.text?.text ?? "",
+          types: prediction.types ?? [],
+        }));
+    } catch (error) {
+      const info = this.httpClientService.handleError(
+        error,
+        "fetchAutocompleteSuggestions",
+        "GooglePlaces",
+      );
+      this.logger.warn("Autocomplete suggestions failed", {
+        query,
+        status: info.status,
+        error: info.message,
+      });
+      return [];
+    }
+  }
+
+  private async fetchPlaceDetails(placeId: string): Promise<PlaceDetailsResponse | null> {
+    try {
+      const { data } = await this.httpClient.get<PlaceDetailsResponse>(
+        `${this.placeDetailsBaseUrl}/${encodeURIComponent(placeId)}`,
+        {
+          headers: {
+            "X-Goog-FieldMask":
+              "id,types,formattedAddress,addressComponents,displayName.text,displayName.languageCode",
+          },
+        },
+      );
+      return data ?? null;
+    } catch (error) {
+      const info = this.httpClientService.handleError(error, "fetchPlaceDetails", "GooglePlaces");
+      this.logger.warn("Place details fetch failed", {
+        placeId,
+        status: info.status,
+        error: info.message,
+      });
+      return null;
+    }
+  }
+
+  private isLikelyExactAddressMatch(input: string, topSuggestion: string): boolean {
+    const normalize = (value: string) =>
+      value
+        .trim()
+        .toLowerCase()
+        .replaceAll(/[^\w\s]/g, " ")
+        .replaceAll(/\s+/g, " ");
+
+    const normalizedInput = normalize(input);
+    const normalizedSuggestion = normalize(topSuggestion);
+    if (!normalizedInput || !normalizedSuggestion) {
+      return false;
+    }
+
+    return (
+      normalizedSuggestion === normalizedInput ||
+      normalizedSuggestion.includes(normalizedInput) ||
+      normalizedInput.includes(normalizedSuggestion)
+    );
+  }
+
+  /**
+   * Require concrete pickup detail:
+   * - a named place (hotel/airport/etc), OR
+   * - a street-style address that includes a number.
+   */
+  private isSpecificAddressQuery(input: string): boolean {
+    const normalized = input.trim().toLowerCase();
+    if (!normalized) {
+      return false;
+    }
+
+    const hasVenueKeyword =
+      /\b(hotel|airport|mall|hospital|plaza|tower|estate|school|university|resort|lounge|terminal)\b/.test(
+        normalized,
+      );
+    if (hasVenueKeyword) {
+      return true;
+    }
+
+    const hasStreetToken =
+      /\b(street|st|road|rd|avenue|ave|close|crescent|lane|drive|boulevard|way|expressway)\b/.test(
+        normalized,
+      );
+    const hasBuildingNumber = /\b\d+[a-z]?\b/.test(normalized);
+
+    return hasStreetToken && hasBuildingNumber;
+  }
+
+  private isAreaOnlyInput(input: string, suggestions: PlaceSuggestion[]): boolean {
+    const tokens = input
+      .trim()
+      .toLowerCase()
+      .replaceAll(/[^\w\s]/g, " ")
+      .split(/\s+/)
+      .filter(Boolean);
+    if (tokens.length === 0 || tokens.length > 2) {
+      return false;
+    }
+
+    if (this.isSpecificAddressQuery(input)) {
+      return false;
+    }
+
+    const topSuggestions = suggestions.slice(0, 3);
+    if (topSuggestions.length === 0) {
+      return false;
+    }
+
+    const allLookAreaLike = topSuggestions.every((suggestion) =>
+      (suggestion.types ?? []).some((type) => this.areaPlaceTypes.has(type)),
+    );
+    const anyLookPrecise = topSuggestions.some((suggestion) =>
+      (suggestion.types ?? []).some((type) => this.precisePlaceTypes.has(type)),
+    );
+
+    return allLookAreaLike && !anyLookPrecise;
+  }
+
+  private isAreaOnlyFromPlaceDetails(details: PlaceDetailsResponse): boolean {
+    const componentTypes = new Set(
+      (details.addressComponents ?? []).flatMap((component) => component.types ?? []),
+    );
+    const hasStreetNumber = componentTypes.has("street_number");
+    const hasRoute = componentTypes.has("route");
+    if (hasStreetNumber || hasRoute) {
+      return false;
+    }
+
+    const placeTypes = new Set(details.types ?? []);
+    const allTypes = new Set([...placeTypes, ...componentTypes]);
+    const hasAreaSignals = [...allTypes].some((type) => this.areaPlaceTypes.has(type));
+    const hasGeoOnlyTopType =
+      placeTypes.has("island") ||
+      placeTypes.has("natural_feature") ||
+      placeTypes.has("locality") ||
+      placeTypes.has("sublocality") ||
+      placeTypes.has("postal_town");
+    const hasVenueTopType =
+      placeTypes.has("lodging") ||
+      placeTypes.has("airport") ||
+      placeTypes.has("point_of_interest") ||
+      placeTypes.has("premise") ||
+      placeTypes.has("subpremise");
+    const hasPreciseSignals = [...allTypes].some(
+      (type) => this.precisePlaceTypes.has(type) && type !== "establishment",
+    );
+
+    return hasGeoOnlyTopType || (hasAreaSignals && !hasVenueTopType && !hasPreciseSignals);
+  }
+
+  private isSpecificAddressFromPlaceDetails(details: PlaceDetailsResponse): boolean {
+    const componentTypes = new Set(
+      (details.addressComponents ?? []).flatMap((component) => component.types ?? []),
+    );
+    const hasStreetNumber = componentTypes.has("street_number");
+    const hasRoute = componentTypes.has("route");
+    if (hasStreetNumber && hasRoute) {
+      return true;
+    }
+
+    const placeTypes = new Set(details.types ?? []);
+    const isAirport = placeTypes.has("airport");
+
+    return isAirport && !!details.formattedAddress;
+  }
+}

--- a/src/modules/maps/maps.const.ts
+++ b/src/modules/maps/maps.const.ts
@@ -7,6 +7,21 @@ export const LAGOS_AIRPORT_COORDS = {
 };
 
 /**
+ * Lagos service bounds used to restrict Places suggestions to Lagos only.
+ * Viewport corners follow Google Places rectangle format.
+ */
+export const LAGOS_VIEWPORT_BOUNDS = {
+  low: {
+    latitude: 6.23,
+    longitude: 3,
+  },
+  high: {
+    latitude: 6.7,
+    longitude: 3.7,
+  },
+};
+
+/**
  * Default fallback duration when API fails (3 hours)
  */
 export const FALLBACK_DURATION_MINUTES = 180;

--- a/src/modules/maps/maps.interface.ts
+++ b/src/modules/maps/maps.interface.ts
@@ -14,6 +14,48 @@ export interface DriveTimeResult {
   isEstimate: boolean;
 }
 
+export interface PlaceSuggestion {
+  placeId: string;
+  description: string;
+  types?: string[];
+}
+
+export interface AddressLookupResult {
+  isValid: boolean;
+  normalizedAddress?: string;
+  placeId?: string;
+  suggestions: PlaceSuggestion[];
+  failureReason?: "AREA_ONLY" | "NO_MATCH" | "AMBIGUOUS";
+}
+
 export type GoogleRoutesOrigin = {
   location: { latLng: { latitude: number; longitude: number } };
 };
+
+export type PlacesAutocompleteNewResponse = {
+  suggestions?: Array<{
+    placePrediction?: {
+      placeId?: string;
+      types?: string[];
+      text?: {
+        text?: string;
+      };
+    };
+  }>;
+};
+
+export interface PlaceDetailsResponse {
+  id?: string;
+  types?: string[];
+  formattedAddress?: string;
+  displayName?: {
+    text?: string;
+    languageCode?: string;
+  };
+  addressComponents?: Array<{
+    longText?: string;
+    shortText?: string;
+    types?: string[];
+    languageCode?: string;
+  }>;
+}

--- a/src/modules/maps/maps.module.ts
+++ b/src/modules/maps/maps.module.ts
@@ -1,12 +1,13 @@
 import { Module } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
+import { GooglePlacesService } from "./google-places.service";
 import { MapsController } from "./maps.controller";
 import { MapsService } from "./maps.service";
 
 @Module({
   imports: [ConfigModule],
   controllers: [MapsController],
-  providers: [MapsService],
-  exports: [MapsService],
+  providers: [MapsService, GooglePlacesService],
+  exports: [MapsService, GooglePlacesService],
 })
 export class MapsModule {}


### PR DESCRIPTION
Add GooglePlacesService to validate pickup addresses via Places Autocomplete + Place Details
Classify area-only inputs (e.g. Ikoyi/Ikeja) as AREA_ONLY and prompt for a full pickup address instead of sending suggestions
require specific address signals (street_number + route) for valid address normalization
Run validation earlier in the collecting flow and persist lookup state across turns to prevent bypass on re-validation
Integrate MapsModule into the booking agent module and add comprehensive unit tests for area-only, street address, and venue scenarios

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new external Google Places integration and changes core booking-agent routing/search behavior, which could affect conversion/search flow if validation logic or state flags misbehave.
> 
> **Overview**
> The booking agent now validates and normalizes `pickupLocation` via a new `GooglePlacesService` (Places Autocomplete + Place Details) before running vehicle searches, and prompts users for a more specific address when they provide an area-only or unresolvable location.
> 
> LangGraph state is extended to persist location lookup progress (`locationLookupTriggered`, `locationLookupFailed`, `locationSuggestions`) to avoid validation loops, keep pickup/dropoff in sync when auto-filled, and allow re-searches when non-location criteria change. `MapsModule` now exports `GooglePlacesService`, is imported by `BookingAgentModule`, and adds unit coverage for the new validation/flow behavior (plus minor type-only `bullmq` import cleanup).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8c067229d22eade5da278210db04d9b17c6b1d5. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->