### PR TITLE
feat(booking-agent): strengthen location validation and deterministic WhatsApp/LangGraph flow

### DIFF
--- a/src/modules/booking-agent/langgraph/langgraph-graph.service.spec.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-graph.service.spec.ts
@@ -538,7 +538,7 @@ describe("LangGraphGraphService", () => {
       expect(result.draft.dropoffLocation).toBe("12 Glover Road, Ikoyi, Lagos, Nigeria");
     });
 
-    it("does not update dropoffLocation when it differs from pickupLocation before normalization", async () => {
+    it("normalizes dropoffLocation separately when it differs from pickupLocation", async () => {
       const existingState = buildInitialState();
       existingState.stage = "collecting";
       existingState.draft = {
@@ -562,11 +562,17 @@ describe("LangGraphGraphService", () => {
         confidence: 0.9,
       });
 
-      googlePlacesServiceMock.validateAddressWithSuggestions.mockResolvedValue({
-        isValid: true,
-        normalizedAddress: "12 Glover Road, Ikoyi, Lagos, Nigeria",
-        suggestions: [],
-      });
+      googlePlacesServiceMock.validateAddressWithSuggestions
+        .mockResolvedValueOnce({
+          isValid: true,
+          normalizedAddress: "12 Glover Road, Ikoyi, Lagos, Nigeria",
+          suggestions: [],
+        })
+        .mockResolvedValueOnce({
+          isValid: true,
+          normalizedAddress: "Lekki Phase 1, Lagos, Nigeria",
+          suggestions: [],
+        });
 
       toolExecutorServiceMock.searchVehiclesFromExtracted.mockResolvedValue({
         exactMatches: [buildVehicleOption()],
@@ -579,9 +585,101 @@ describe("LangGraphGraphService", () => {
         message: "Yes",
       });
 
-      // Pickup should be normalized, but dropoff should remain unchanged
+      // Pickup and dropoff should both be normalized independently.
       expect(result.draft.pickupLocation).toBe("12 Glover Road, Ikoyi, Lagos, Nigeria");
-      expect(result.draft.dropoffLocation).toBe("Lekki Phase 1");
+      expect(result.draft.dropoffLocation).toBe("Lekki Phase 1, Lagos, Nigeria");
+    });
+
+    it("validates dropoffLocation when it differs from pickupLocation", async () => {
+      const existingState = buildInitialState();
+      existingState.stage = "collecting";
+      existingState.draft = {
+        bookingType: "DAY",
+        pickupDate: "2026-03-01",
+        pickupTime: "09:00",
+        dropoffDate: "2026-03-01",
+        pickupLocation: "Wheatbaker Hotel, Ikoyi",
+        dropoffLocation: "Fagba",
+      };
+      stateServiceMock.loadState.mockResolvedValue(existingState);
+      stateServiceMock.mergeWithExisting.mockReturnValue({ ...existingState });
+
+      extractorServiceMock.extract.mockResolvedValue({
+        intent: "confirm",
+        draftPatch: {},
+        confidence: 0.9,
+      });
+
+      googlePlacesServiceMock.validateAddressWithSuggestions
+        .mockResolvedValueOnce({
+          isValid: true,
+          normalizedAddress: "Wheatbaker Hotel, Ikoyi, Lagos, Nigeria",
+          suggestions: [],
+        })
+        .mockResolvedValueOnce({
+          isValid: false,
+          suggestions: [],
+          failureReason: "AREA_ONLY",
+        });
+
+      const result = await service.invoke({
+        conversationId,
+        messageId,
+        message: "Yes",
+      });
+
+      expect(googlePlacesServiceMock.validateAddressWithSuggestions).toHaveBeenNthCalledWith(
+        1,
+        "Wheatbaker Hotel, Ikoyi",
+      );
+      expect(googlePlacesServiceMock.validateAddressWithSuggestions).toHaveBeenNthCalledWith(
+        2,
+        "Fagba",
+      );
+      expect(toolExecutorServiceMock.searchVehiclesFromExtracted).not.toHaveBeenCalled();
+      expect(result.stage).toBe("collecting");
+      expect(result.outboxItems[1]?.dedupeKey).toContain(":dropoff-address-suggestions");
+      expect(result.outboxItems[1]?.textBody).toContain("drop-off address");
+    });
+
+    it("skips dropoff validation when dropoff matches pickup", async () => {
+      const existingState = buildInitialState();
+      existingState.stage = "collecting";
+      existingState.draft = {
+        bookingType: "DAY",
+        pickupDate: "2026-03-01",
+        pickupTime: "09:00",
+        dropoffDate: "2026-03-01",
+        pickupLocation: "Glover Road Ikoyi",
+        dropoffLocation: "Glover Road Ikoyi",
+      };
+      stateServiceMock.loadState.mockResolvedValue(existingState);
+      stateServiceMock.mergeWithExisting.mockReturnValue({ ...existingState });
+
+      extractorServiceMock.extract.mockResolvedValue({
+        intent: "confirm",
+        draftPatch: {},
+        confidence: 0.9,
+      });
+
+      googlePlacesServiceMock.validateAddressWithSuggestions.mockResolvedValue({
+        isValid: true,
+        normalizedAddress: "12 Glover Road, Ikoyi, Lagos, Nigeria",
+        suggestions: [],
+      });
+
+      toolExecutorServiceMock.searchVehiclesFromExtracted.mockResolvedValue({
+        exactMatches: [buildVehicleOption()],
+        alternatives: [],
+      });
+
+      await service.invoke({
+        conversationId,
+        messageId,
+        message: "Proceed",
+      });
+
+      expect(googlePlacesServiceMock.validateAddressWithSuggestions).toHaveBeenCalledTimes(1);
     });
 
     it("passes availableOptions to responder after search", async () => {
@@ -1541,6 +1639,45 @@ describe("LangGraphGraphService", () => {
       expect(savedState?.statusMessage).toContain("No vehicles matching your criteria");
     });
 
+    it("sets alternatives message when no exact match but alternatives exist", async () => {
+      const existingState = buildInitialState();
+      existingState.stage = "collecting";
+      existingState.draft = {
+        bookingType: "NIGHT",
+        pickupDate: "2026-03-05",
+        pickupTime: "23:00",
+        dropoffDate: "2026-03-06",
+        pickupLocation: "Wheatbaker, Ikoyi",
+        dropoffLocation: "6 Glover Road, Ikoyi",
+        vehicleType: "SEDAN",
+      };
+      stateServiceMock.loadState.mockResolvedValue(existingState);
+      stateServiceMock.mergeWithExisting.mockReturnValue({ ...existingState });
+
+      extractorServiceMock.extract.mockResolvedValue({
+        intent: "confirm",
+        draftPatch: {},
+        confidence: 0.9,
+      });
+
+      toolExecutorServiceMock.searchVehiclesFromExtracted.mockResolvedValue({
+        exactMatches: [],
+        alternatives: [buildVehicleOption({ id: "alt-1" })],
+      });
+
+      const result = await service.invoke({
+        conversationId,
+        messageId,
+        message: "Search for me",
+      });
+
+      expect(result.stage).toBe("presenting_options");
+      expect(responderServiceMock.generateResponse).toHaveBeenCalled();
+      const responderArg = responderServiceMock.generateResponse.mock.calls[0][0];
+      expect(responderArg.availableOptions).toHaveLength(1);
+      expect(responderArg.statusMessage).toContain("I couldn't find an exact match");
+    });
+
     it("allows re-search after successful search when user modifies non-location criteria", async () => {
       // This test verifies the fix for the bug where locationLookupTriggered=true and
       // locationSuggestions=[] after a successful search incorrectly blocked re-search.
@@ -1650,6 +1787,7 @@ describe("LangGraphGraphService", () => {
       });
 
       expect(result.error).toBeDefined();
+      expect(result.stage).toBe("collecting");
     });
 
     it("does not reset locationLookupTriggered to false when search fails after validation", async () => {

--- a/src/modules/booking-agent/langgraph/langgraph-graph.service.spec.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-graph.service.spec.ts
@@ -1286,6 +1286,39 @@ describe("LangGraphGraphService", () => {
 
       expect(result.draft).toBeDefined();
     });
+
+    it("does not duplicate preference notes when hint already exists", async () => {
+      const existingState = buildInitialState();
+      existingState.stage = "collecting";
+      existingState.preferences = {
+        pricePreference: "budget",
+        notes: ["budget"],
+      };
+      stateServiceMock.loadState.mockResolvedValue(existingState);
+      stateServiceMock.mergeWithExisting.mockReturnValue({ ...existingState });
+
+      extractorServiceMock.extract.mockResolvedValue({
+        intent: "provide_info",
+        draftPatch: {},
+        preferenceHint: "budget",
+        confidence: 0.9,
+      });
+
+      await service.invoke({
+        conversationId,
+        messageId,
+        message: "I still want a budget option",
+      });
+
+      expect(stateServiceMock.saveState).toHaveBeenCalledWith(
+        conversationId,
+        expect.objectContaining({
+          preferences: expect.objectContaining({
+            notes: ["budget"],
+          }),
+        }),
+      );
+    });
   });
 
   describe("vehicle card template sending", () => {

--- a/src/modules/booking-agent/langgraph/langgraph-graph.service.spec.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-graph.service.spec.ts
@@ -638,6 +638,7 @@ describe("LangGraphGraphService", () => {
       );
       expect(toolExecutorServiceMock.searchVehiclesFromExtracted).not.toHaveBeenCalled();
       expect(result.stage).toBe("collecting");
+      expect(result.draft.pickupLocation).toBe("Wheatbaker Hotel, Ikoyi, Lagos, Nigeria");
       expect(result.outboxItems[1]?.dedupeKey).toContain(":dropoff-address-suggestions");
       expect(result.outboxItems[1]?.textBody).toContain("drop-off address");
     });

--- a/src/modules/booking-agent/langgraph/langgraph-graph.service.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-graph.service.ts
@@ -282,21 +282,7 @@ export class LangGraphGraphService {
       : { ...draft };
     const newDraft = applyDerivedDraftFields(baseDraft, state.inboundMessage);
 
-    const newPreferences = { ...preferences };
-    if (extraction.preferenceHint) {
-      if (extraction.preferenceHint === "cheaper" || extraction.preferenceHint === "budget") {
-        newPreferences.pricePreference = "budget";
-      } else if (
-        extraction.preferenceHint === "premium" ||
-        extraction.preferenceHint === "luxury"
-      ) {
-        newPreferences.pricePreference = "premium";
-      }
-      if (!newPreferences.notes) {
-        newPreferences.notes = [];
-      }
-      newPreferences.notes.push(extraction.preferenceHint);
-    }
+    const newPreferences = this.mergePreferencesWithHint(preferences, extraction.preferenceHint);
 
     const draftChanged = hasDraftChanged(draft, newDraft);
     const pickupLocationChanged = draft.pickupLocation !== newDraft.pickupLocation;
@@ -317,6 +303,26 @@ export class LangGraphGraphService {
       locationLookupTriggered: pickupLocationChanged ? false : !!state.locationLookupTriggered,
       locationLookupFailed: pickupLocationChanged ? false : !!state.locationLookupFailed,
     };
+  }
+
+  private mergePreferencesWithHint(
+    preferences: BookingAgentState["preferences"],
+    preferenceHint: string | undefined,
+  ): BookingAgentState["preferences"] {
+    const newPreferences = { ...preferences };
+    if (!preferenceHint) {
+      return newPreferences;
+    }
+
+    if (preferenceHint === "cheaper" || preferenceHint === "budget") {
+      newPreferences.pricePreference = "budget";
+    } else if (preferenceHint === "premium" || preferenceHint === "luxury") {
+      newPreferences.pricePreference = "premium";
+    }
+
+    const existingNotes = newPreferences.notes ?? [];
+    newPreferences.notes = [...existingNotes, preferenceHint];
+    return newPreferences;
   }
 
   private routeNode(state: AnnotationState): Partial<AnnotationState> {
@@ -376,7 +382,7 @@ export class LangGraphGraphService {
 
   private async searchNode(state: AnnotationState): Promise<Partial<AnnotationState>> {
     try {
-      const validationResult = await this.validateAndNormalizePickupLocation(state);
+      const validationResult = await this.validateAndNormalizeLocations(state);
       if (validationResult.earlyReturn) {
         return validationResult.earlyReturn;
       }
@@ -395,6 +401,7 @@ export class LangGraphGraphService {
           lastShownOptions: [],
           statusMessage: this.buildLocationSuggestionText(
             validatedDraft.pickupLocation,
+            "pickup",
             state.locationSuggestions ?? [],
           ),
           locationSuggestions: state.locationSuggestions ?? [],
@@ -472,10 +479,10 @@ export class LangGraphGraphService {
       });
 
       // If no vehicles found, set a status message so the responder can inform the user
-      const noResultsMessage =
-        options.length === 0
-          ? "No vehicles matching your criteria are available for the selected date. Would you like to try a different date, vehicle type, or booking type?"
-          : null;
+      const noResultsMessage = this.buildSearchStatusMessage(
+        options.length,
+        searchResult.exactMatches.length,
+      );
 
       return {
         draft: validatedDraft,
@@ -502,8 +509,22 @@ export class LangGraphGraphService {
         error: LANGGRAPH_SERVICE_UNAVAILABLE_MESSAGE,
         availableOptions: [],
         lastShownOptions: [],
+        statusMessage:
+          "I couldn't complete the car search right now. Please try again in a moment, and I'll search again.",
       };
     }
+  }
+
+  private buildSearchStatusMessage(optionsCount: number, exactMatchCount: number): string | null {
+    if (optionsCount === 0) {
+      return "No vehicles matching your criteria are available for the selected date. Would you like to try a different date, vehicle type, or booking type?";
+    }
+
+    if (exactMatchCount === 0) {
+      return "I couldn't find an exact match, but I found close alternatives you can choose from.";
+    }
+
+    return null;
   }
 
   private async respondNode(state: AnnotationState): Promise<Partial<AnnotationState>> {
@@ -540,32 +561,50 @@ export class LangGraphGraphService {
   }
 
   private buildLocationSuggestionText(
-    pickupLocation: string,
+    locationValue: string,
+    locationLabel: "pickup" | "drop-off" = "pickup",
     suggestions: BookingAgentState["locationSuggestions"] = [],
   ): string {
+    const locationNoun = locationLabel === "pickup" ? "pickup location" : "drop-off location";
     if (suggestions.length === 0) {
-      return `I couldn't find "${pickupLocation}" on Google Maps. Please share a more specific pickup location (for example: street + area in Lagos).`;
+      return `I couldn't find "${locationValue}" on Google Maps. Please share a more specific ${locationNoun} (for example: street + area in Lagos).`;
     }
 
     const list = suggestions.slice(0, 4).map((suggestion, index) => {
       return `${index + 1}. ${suggestion.description}`;
     });
     return [
-      `I couldn't find an exact Google Maps match for "${pickupLocation}".`,
+      `I couldn't find an exact Google Maps match for "${locationValue}".`,
       "",
       "Did you mean one of these?",
       ...list,
       "",
-      "Reply with the full address you want from the list, or send a clearer pickup address.",
+      `Reply with the full address you want from the list, or send a clearer ${locationNoun}.`,
     ].join("\n");
   }
 
-  private buildAreaOnlyLocationPrompt(pickupLocation: string): string {
+  private buildAreaOnlyLocationPrompt(
+    locationValue: string,
+    locationLabel: "pickup" | "drop-off" = "pickup",
+  ): string {
+    const locationNoun = locationLabel === "pickup" ? "pickup address" : "drop-off address";
     return [
-      `"${pickupLocation}" looks like a general area, not a full pickup address.`,
+      `"${locationValue}" looks like a general area, not a full ${locationNoun}.`,
       "",
-      "Please share a specific pickup address (for example: building number + street, or a hotel/landmark name in Lagos).",
+      `Please share a specific ${locationNoun} (for example: building number + street, or a hotel/landmark name in Lagos).`,
     ].join("\n");
+  }
+
+  private async validateAndNormalizeLocations(state: AnnotationState): Promise<{
+    draft: BookingDraft;
+    earlyReturn?: Partial<AnnotationState>;
+  }> {
+    const pickupResult = await this.validateAndNormalizePickupLocation(state);
+    if (pickupResult.earlyReturn) {
+      return pickupResult;
+    }
+
+    return this.validateAndNormalizeDropoffLocation(state, pickupResult.draft);
   }
 
   private async validateAndNormalizePickupLocation(state: AnnotationState): Promise<{
@@ -608,6 +647,41 @@ export class LangGraphGraphService {
     };
   }
 
+  private async validateAndNormalizeDropoffLocation(
+    state: AnnotationState,
+    draft: BookingDraft,
+  ): Promise<{
+    draft: BookingDraft;
+    earlyReturn?: Partial<AnnotationState>;
+  }> {
+    const pickupLocation = draft.pickupLocation?.trim();
+    const dropoffLocation = draft.dropoffLocation?.trim();
+
+    if (!pickupLocation || !dropoffLocation || pickupLocation === dropoffLocation) {
+      return { draft };
+    }
+
+    const locationResult =
+      await this.googlePlacesService.validateAddressWithSuggestions(dropoffLocation);
+    if (!locationResult.isValid) {
+      return {
+        draft,
+        earlyReturn: this.buildInvalidDropoffLocationResult(state, dropoffLocation, locationResult),
+      };
+    }
+
+    if (!locationResult.normalizedAddress) {
+      return { draft };
+    }
+
+    return {
+      draft: {
+        ...draft,
+        dropoffLocation: locationResult.normalizedAddress,
+      },
+    };
+  }
+
   private buildInvalidPickupLocationResult(
     state: AnnotationState,
     locationResult: AddressLookupResult,
@@ -615,9 +689,11 @@ export class LangGraphGraphService {
     const suggestionText =
       locationResult.failureReason === "AREA_ONLY"
         ? this.buildAreaOnlyLocationPrompt(state.draft.pickupLocation ?? "that location")
-        : this.buildLocationSuggestionText(state.draft.pickupLocation ?? "that location", [
-            ...(locationResult.suggestions ?? []),
-          ]);
+        : this.buildLocationSuggestionText(
+            state.draft.pickupLocation ?? "that location",
+            "pickup",
+            [...(locationResult.suggestions ?? [])],
+          );
 
     // Set locationLookupTriggered to true for all failure reasons to prevent infinite
     // re-validation loops. The mergeNode resets this flag when pickupLocationChanged,
@@ -651,6 +727,39 @@ export class LangGraphGraphService {
         {
           conversationId: state.conversationId,
           dedupeKey: `langgraph:${state.inboundMessageId}:address-suggestions`,
+          mode: LANGGRAPH_OUTBOUND_MODE.FREE_FORM,
+          textBody: suggestionText,
+        },
+      ],
+    };
+  }
+
+  private buildInvalidDropoffLocationResult(
+    state: AnnotationState,
+    dropoffLocation: string,
+    locationResult: AddressLookupResult,
+  ): Partial<AnnotationState> {
+    const suggestionText =
+      locationResult.failureReason === "AREA_ONLY"
+        ? this.buildAreaOnlyLocationPrompt(dropoffLocation, "drop-off")
+        : this.buildLocationSuggestionText(dropoffLocation, "drop-off", [
+            ...(locationResult.suggestions ?? []),
+          ]);
+
+    return {
+      stage: "collecting",
+      response: { text: suggestionText },
+      error: null,
+      outboxItems: [
+        {
+          conversationId: state.conversationId,
+          dedupeKey: `langgraph:${state.inboundMessageId}:dropoff-address-checking`,
+          mode: LANGGRAPH_OUTBOUND_MODE.FREE_FORM,
+          textBody: "Thanks - I'm checking that drop-off address on Google Maps now...",
+        },
+        {
+          conversationId: state.conversationId,
+          dedupeKey: `langgraph:${state.inboundMessageId}:dropoff-address-suggestions`,
           mode: LANGGRAPH_OUTBOUND_MODE.FREE_FORM,
           textBody: suggestionText,
         },

--- a/src/modules/booking-agent/langgraph/langgraph-graph.service.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-graph.service.ts
@@ -321,7 +321,9 @@ export class LangGraphGraphService {
     }
 
     const existingNotes = newPreferences.notes ?? [];
-    newPreferences.notes = [...existingNotes, preferenceHint];
+    newPreferences.notes = existingNotes.includes(preferenceHint)
+      ? existingNotes
+      : [...existingNotes, preferenceHint];
     return newPreferences;
   }
 

--- a/src/modules/booking-agent/langgraph/langgraph-graph.service.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-graph.service.ts
@@ -386,7 +386,10 @@ export class LangGraphGraphService {
     try {
       const validationResult = await this.validateAndNormalizeLocations(state);
       if (validationResult.earlyReturn) {
-        return validationResult.earlyReturn;
+        return {
+          ...validationResult.earlyReturn,
+          draft: validationResult.draft,
+        };
       }
       const validatedDraft = validationResult.draft;
 

--- a/src/modules/booking-agent/langgraph/langgraph-responder.service.spec.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-responder.service.spec.ts
@@ -308,6 +308,22 @@ describe("LangGraphResponderService", () => {
       expect(response.interactive?.buttons?.[1].id).toBe("agent");
     });
 
+    it("returns deterministic awaiting payment response with controls when payment link exists", async () => {
+      const state = buildState({
+        stage: "awaiting_payment",
+        paymentLink: "https://pay.example.com/invoice/123",
+      });
+
+      const response = await service.generateResponse(state);
+
+      expect(response.text).toContain("Booking Created");
+      expect(response.interactive?.type).toBe("buttons");
+      expect(response.interactive?.buttons).toHaveLength(2);
+      expect(response.interactive?.buttons?.[0].id).toBe("cancel");
+      expect(response.interactive?.buttons?.[1].id).toBe("agent");
+      expect(claudeMock.invoke).not.toHaveBeenCalled();
+    });
+
     it("returns booking type buttons when collecting without booking type", async () => {
       claudeMock.invoke.mockResolvedValue({ content: "What type of booking?" });
 

--- a/src/modules/booking-agent/langgraph/langgraph-responder.service.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-responder.service.ts
@@ -107,12 +107,30 @@ export class LangGraphResponderService {
       statusMessage,
     } = state;
 
-    if (extraction?.intent === "reset") {
+    return (
+      this.buildResetResponse(extraction?.intent) ??
+      this.buildGreetingErrorResponse(stage, availableOptions, error) ??
+      this.buildCollectingStatusResponse(stage, availableOptions, statusMessage) ??
+      this.buildPresentingOptionsResponse(stage, availableOptions, statusMessage, draft) ??
+      this.buildConfirmingResponse(state, error, draft, selectedOption) ??
+      this.buildAwaitingPaymentResponse(stage, paymentLink, selectedOption)
+    );
+  }
+
+  private buildResetResponse(intent?: string): AgentResponse | null {
+    if (intent === "reset") {
       return {
         text: "Done — I've cleared your booking details. Ready to start fresh! What do you need?",
       };
     }
+    return null;
+  }
 
+  private buildGreetingErrorResponse(
+    stage: BookingStage,
+    availableOptions: VehicleSearchOption[],
+    error: string | null,
+  ): AgentResponse | null {
     // Surface user-safe outage messages deterministically in greeting.
     // Keep confirming-stage errors on the confirming path so retry/agent actions are preserved.
     if (
@@ -121,60 +139,87 @@ export class LangGraphResponderService {
       stage === "greeting" &&
       error === LANGGRAPH_SERVICE_UNAVAILABLE_MESSAGE
     ) {
-      return {
-        text: error,
-      };
+      return { text: error };
     }
+    return null;
+  }
 
+  private buildCollectingStatusResponse(
+    stage: BookingStage,
+    availableOptions: VehicleSearchOption[],
+    statusMessage: string | null,
+  ): AgentResponse | null {
     // Business status updates are scoped to collecting stage without options.
     if (statusMessage && availableOptions.length === 0 && stage === "collecting") {
+      return { text: statusMessage };
+    }
+    return null;
+  }
+
+  private buildPresentingOptionsResponse(
+    stage: BookingStage,
+    availableOptions: VehicleSearchOption[],
+    statusMessage: string | null,
+    draft: BookingDraft,
+  ): AgentResponse | null {
+    if (stage !== "presenting_options" || availableOptions.length === 0) {
+      return null;
+    }
+
+    return {
+      text: statusMessage
+        ? `${statusMessage}\n\nHere are your options! Tap Select on the one you'd like to book.`
+        : "Here are your options! Tap Select on the one you'd like to book.",
+      vehicleCards: this.buildVehicleCards(stage, availableOptions, draft),
+    };
+  }
+
+  private buildConfirmingResponse(
+    state: BookingAgentState,
+    error: string | null,
+    draft: BookingDraft,
+    selectedOption: VehicleSearchOption | null,
+  ): AgentResponse | null {
+    if (state.stage !== "confirming" || !selectedOption) {
+      return null;
+    }
+
+    if (shouldClarifyCancelIntent(state)) {
       return {
-        text: statusMessage,
+        text: "Do you want to cancel this booking request entirely, or see other car options?",
+        interactive: {
+          type: "buttons",
+          buttons: [
+            { id: LANGGRAPH_BUTTON_ID.CANCEL, title: "✕ Cancel Booking" },
+            { id: LANGGRAPH_BUTTON_ID.SHOW_OTHERS, title: "↻ Show Others" },
+          ],
+        },
       };
     }
 
-    if (stage === "presenting_options" && availableOptions.length > 0) {
+    if (error) {
       return {
-        text: statusMessage
-          ? `${statusMessage}\n\nHere are your options! Tap Select on the one you'd like to book.`
-          : "Here are your options! Tap Select on the one you'd like to book.",
-        vehicleCards: this.buildVehicleCards(stage, availableOptions, draft),
+        text: `${error}\n\nWould you like me to try again or connect you to an agent?`,
+        interactive: this.determineInteractive(state.stage, draft, selectedOption, error),
       };
     }
 
-    if (stage === "confirming" && selectedOption) {
-      if (shouldClarifyCancelIntent(state)) {
-        return {
-          text: "Do you want to cancel this booking request entirely, or see other car options?",
-          interactive: {
-            type: "buttons",
-            buttons: [
-              { id: LANGGRAPH_BUTTON_ID.CANCEL, title: "✕ Cancel Booking" },
-              { id: LANGGRAPH_BUTTON_ID.SHOW_OTHERS, title: "↻ Show Others" },
-            ],
-          },
-        };
-      }
+    return {
+      text: this.buildBookingSummary(draft, selectedOption),
+      interactive: this.determineInteractive(state.stage, draft, selectedOption, error),
+    };
+  }
 
-      if (error) {
-        return {
-          text: `${error}\n\nWould you like me to try again or connect you to an agent?`,
-          interactive: this.determineInteractive(stage, draft, selectedOption, error),
-        };
-      }
-
-      return {
-        text: this.buildBookingSummary(draft, selectedOption),
-        interactive: this.determineInteractive(stage, draft, selectedOption, error),
-      };
-    }
-
+  private buildAwaitingPaymentResponse(
+    stage: BookingStage,
+    paymentLink: string | null,
+    selectedOption: VehicleSearchOption | null,
+  ): AgentResponse | null {
     if (stage === "awaiting_payment" && paymentLink) {
       return {
         text: this.buildPaymentMessage(selectedOption),
       };
     }
-
     return null;
   }
 

--- a/src/modules/booking-agent/langgraph/langgraph-responder.service.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-responder.service.ts
@@ -113,7 +113,7 @@ export class LangGraphResponderService {
       this.buildCollectingStatusResponse(stage, availableOptions, statusMessage) ??
       this.buildPresentingOptionsResponse(stage, availableOptions, statusMessage, draft) ??
       this.buildConfirmingResponse(state, error, draft, selectedOption) ??
-      this.buildAwaitingPaymentResponse(stage, paymentLink, selectedOption)
+      this.buildAwaitingPaymentResponse(stage, paymentLink, selectedOption, draft)
     );
   }
 
@@ -214,10 +214,12 @@ export class LangGraphResponderService {
     stage: BookingStage,
     paymentLink: string | null,
     selectedOption: VehicleSearchOption | null,
+    draft: BookingDraft,
   ): AgentResponse | null {
     if (stage === "awaiting_payment" && paymentLink) {
       return {
         text: this.buildPaymentMessage(selectedOption),
+        interactive: this.determineInteractive(stage, draft, selectedOption, null),
       };
     }
     return null;

--- a/src/modules/booking-agent/whatsapp/whatsapp-persistence.service.ts
+++ b/src/modules/booking-agent/whatsapp/whatsapp-persistence.service.ts
@@ -5,6 +5,31 @@ import { DatabaseService } from "../../database/database.service";
 import { WHATSAPP_PROCESSING_LOCK_TTL_MS } from "../booking-agent.const";
 import type { CreateOutboxInput, TwilioInboundWebhookPayload } from "../booking-agent.interface";
 
+export const INBOUND_MESSAGE_CONTEXT_SELECT = Prisma.validator<Prisma.WhatsAppMessageSelect>()({
+  id: true,
+  conversationId: true,
+  direction: true,
+  kind: true,
+  body: true,
+  mediaUrl: true,
+  mediaContentType: true,
+  status: true,
+  rawPayload: true,
+  conversation: {
+    select: {
+      id: true,
+      phoneE164: true,
+      status: true,
+      windowExpiresAt: true,
+      lastInboundAt: true,
+    },
+  },
+});
+
+export type InboundMessageContextRecord = Prisma.WhatsAppMessageGetPayload<{
+  select: typeof INBOUND_MESSAGE_CONTEXT_SELECT;
+}>;
+
 @Injectable()
 export class WhatsAppPersistenceService {
   private readonly logger = new Logger(WhatsAppPersistenceService.name);
@@ -279,29 +304,10 @@ export class WhatsAppPersistenceService {
     });
   }
 
-  async getInboundMessageContext(messageId: string) {
+  async getInboundMessageContext(messageId: string): Promise<InboundMessageContextRecord | null> {
     const message = await this.databaseService.whatsAppMessage.findUnique({
       where: { id: messageId },
-      select: {
-        id: true,
-        conversationId: true,
-        direction: true,
-        kind: true,
-        body: true,
-        mediaUrl: true,
-        mediaContentType: true,
-        status: true,
-        rawPayload: true,
-        conversation: {
-          select: {
-            id: true,
-            phoneE164: true,
-            status: true,
-            windowExpiresAt: true,
-            lastInboundAt: true,
-          },
-        },
-      },
+      select: INBOUND_MESSAGE_CONTEXT_SELECT,
     });
 
     if (!message) {

--- a/src/modules/booking-agent/whatsapp/whatsapp.processor.spec.ts
+++ b/src/modules/booking-agent/whatsapp/whatsapp.processor.spec.ts
@@ -189,6 +189,11 @@ describe("WhatsAppProcessor", () => {
       "conv-1",
       "USER_REQUESTED_AGENT",
     );
+    expect(whatsappAgentQueue.add).not.toHaveBeenCalledWith(
+      PROCESS_WHATSAPP_INACTIVITY_NUDGE_JOB,
+      expect.anything(),
+      expect.anything(),
+    );
     expect(persistenceService.markInboundMessageProcessed).toHaveBeenCalledWith("msg-1");
     expect(persistenceService.releaseProcessingLock).toHaveBeenCalledWith(
       "conv-1",

--- a/src/modules/booking-agent/whatsapp/whatsapp.processor.ts
+++ b/src/modules/booking-agent/whatsapp/whatsapp.processor.ts
@@ -194,7 +194,7 @@ export class WhatsAppProcessor extends WorkerHost {
       );
     }
 
-    if (this.isNudgeableStage(result.resultingStage)) {
+    if (!result.markAsHandoff && this.isNudgeableStage(result.resultingStage)) {
       await this.scheduleInactivityNudge(conversationId, messageId);
     }
   }

--- a/src/modules/booking-agent/whatsapp/whatsapp.processor.ts
+++ b/src/modules/booking-agent/whatsapp/whatsapp.processor.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { randomInt, randomUUID } from "node:crypto";
 import { InjectQueue, OnWorkerEvent, Processor, WorkerHost } from "@nestjs/bullmq";
 import { Injectable, Logger } from "@nestjs/common";
 import { WhatsAppDeliveryMode, WhatsAppMessageKind } from "@prisma/client";
@@ -24,6 +24,7 @@ import {
 } from "../booking-agent.error";
 import type {
   InboundMessageContext,
+  OrchestratorResult,
   ProcessWhatsAppInactivityClearJobData,
   ProcessWhatsAppInactivityNudgeJobData,
   ProcessWhatsAppInboundJobData,
@@ -33,6 +34,7 @@ import { BookingAgentOrchestratorService } from "../booking-agent-orchestrator.s
 import { LangGraphStateService } from "../langgraph/langgraph-state.service";
 import { parseInteractiveReply } from "./whatsapp-agent.utils";
 import { WhatsAppAudioTranscriptionService } from "./whatsapp-audio-transcription.service";
+import type { InboundMessageContextRecord } from "./whatsapp-persistence.service";
 import { WhatsAppPersistenceService } from "./whatsapp-persistence.service";
 import { WhatsAppSenderService } from "./whatsapp-sender.service";
 
@@ -106,56 +108,10 @@ export class WhatsAppProcessor extends WorkerHost {
       }
 
       await this.cancelPendingInactivityJobs(conversationId);
-
-      // Parse interactive reply data from rawPayload if present
-      const interactive = parseInteractiveReply(context.rawPayload);
-      let inboundBody = context.body ?? undefined;
-      let inboundKind = context.kind;
-
-      if (context.kind === WhatsAppMessageKind.AUDIO) {
-        try {
-          const transcript = await this.audioTranscriptionService.transcribeInboundAudio({
-            mediaUrl: context.mediaUrl,
-            mediaContentType: context.mediaContentType,
-            traceId,
-          });
-          if (transcript) {
-            inboundBody = transcript;
-            inboundKind = WhatsAppMessageKind.TEXT;
-          }
-        } catch (error) {
-          this.logger.warn("Audio transcription failed; falling back to media flow", {
-            traceId,
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
-      }
-
-      const orchestratorContext: InboundMessageContext & { windowExpiresAt?: Date | null } = {
-        messageId: context.id,
-        conversationId: context.conversationId,
-        body: inboundBody,
-        kind: inboundKind,
-        windowExpiresAt: context.conversation.windowExpiresAt,
-        interactive: interactive ?? undefined,
-      };
+      const orchestratorContext = await this.buildOrchestratorContext(context, traceId);
 
       const result = await this.bookingAgentOrchestratorService.decide(orchestratorContext);
-
-      for (const outbound of result.enqueueOutbox) {
-        await this.senderService.enqueueOutbound(outbound);
-      }
-
-      if (result.markAsHandoff) {
-        await this.persistenceService.markConversationHandoff(
-          context.conversationId,
-          result.markAsHandoff.reason,
-        );
-      }
-
-      if (this.isNudgeableStage(result.resultingStage)) {
-        await this.scheduleInactivityNudge(conversationId, messageId);
-      }
+      await this.handleInboundOrchestratorResult(result, context.conversationId, messageId);
 
       await this.persistenceService.markInboundMessageProcessed(messageId);
       this.logger.log("Processed inbound WhatsApp message", {
@@ -174,6 +130,72 @@ export class WhatsAppProcessor extends WorkerHost {
       throw error;
     } finally {
       await this.persistenceService.releaseProcessingLock(conversationId, lockToken);
+    }
+  }
+
+  private async buildOrchestratorContext(
+    context: InboundMessageContextRecord,
+    traceId: string,
+  ): Promise<InboundMessageContext & { windowExpiresAt?: Date | null }> {
+    const interactive = parseInteractiveReply(context.rawPayload);
+    const resolvedInbound = await this.resolveInboundMessageContent(context, traceId);
+
+    return {
+      messageId: context.id,
+      conversationId: context.conversationId,
+      body: resolvedInbound.body,
+      kind: resolvedInbound.kind,
+      windowExpiresAt: context.conversation.windowExpiresAt,
+      interactive: interactive ?? undefined,
+    };
+  }
+
+  private async resolveInboundMessageContent(
+    context: InboundMessageContextRecord,
+    traceId: string,
+  ): Promise<{ body?: string; kind: WhatsAppMessageKind }> {
+    if (context.kind !== WhatsAppMessageKind.AUDIO) {
+      return { body: context.body ?? undefined, kind: context.kind };
+    }
+
+    try {
+      const transcript = await this.audioTranscriptionService.transcribeInboundAudio({
+        mediaUrl: context.mediaUrl,
+        mediaContentType: context.mediaContentType,
+        traceId,
+      });
+      if (!transcript) {
+        return { body: context.body ?? undefined, kind: context.kind };
+      }
+
+      return { body: transcript, kind: WhatsAppMessageKind.TEXT };
+    } catch (error) {
+      this.logger.warn("Audio transcription failed; falling back to media flow", {
+        traceId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return { body: context.body ?? undefined, kind: context.kind };
+    }
+  }
+
+  private async handleInboundOrchestratorResult(
+    result: OrchestratorResult,
+    conversationId: string,
+    messageId: string,
+  ): Promise<void> {
+    for (const outbound of result.enqueueOutbox) {
+      await this.senderService.enqueueOutbound(outbound);
+    }
+
+    if (result.markAsHandoff) {
+      await this.persistenceService.markConversationHandoff(
+        conversationId,
+        result.markAsHandoff.reason,
+      );
+    }
+
+    if (this.isNudgeableStage(result.resultingStage)) {
+      await this.scheduleInactivityNudge(conversationId, messageId);
     }
   }
 
@@ -199,7 +221,7 @@ export class WhatsAppProcessor extends WorkerHost {
         break;
       }
 
-      const jitterMs = Math.floor(Math.random() * WHATSAPP_LOCK_ACQUIRE_JITTER_MS);
+      const jitterMs = randomInt(WHATSAPP_LOCK_ACQUIRE_JITTER_MS);
       const sleepMs = Math.min(delayMs + jitterMs, remainingMs);
       await this.sleep(sleepMs);
       delayMs = Math.min(delayMs * 2, WHATSAPP_LOCK_ACQUIRE_MAX_BACKOFF_MS);


### PR DESCRIPTION
- Add drop-off validation parity with pickup, while skipping re-validation when drop-off equals validated pickup.
- Improve deterministic responder/search outcomes for alternatives, no-results, and failure fallback messaging.
- Refactor processor/responder/graph flows to reduce cognitive complexity and improve maintainability.
- Replace Math.random jitter with crypto.randomInt and simplify typing using explicit shared payload/result types.
- Add/update tests covering location validation behavior and deterministic response/search paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core booking-agent conversation flow (location validation, search-stage transitions, and WhatsApp job scheduling), so regressions could affect booking completion or user prompts, though changes are well-covered by new/updated tests.
> 
> **Overview**
> Adds **drop-off location validation/normalization parity** with pickup during the LangGraph `search` flow, including separate normalization when pickup/drop-off differ, user-facing suggestion prompts scoped to *pickup vs drop-off*, and skipping drop-off validation when it matches the validated pickup.
> 
> Makes search/responder outcomes more deterministic by (1) emitting clearer `statusMessage`s for *no results* vs *alternatives-only* searches, (2) returning a consistent fallback `statusMessage` on search service failure while keeping stage at `collecting`, and (3) refactoring `LangGraphResponderService` into ordered deterministic-response builders (including deterministic `awaiting_payment` responses with controls).
> 
> Improves WhatsApp processing maintainability and correctness by extracting inbound-context selection into a shared Prisma `select` + typed payload, refactoring inbound processing into helper methods, switching lock jitter to `crypto.randomInt`, and **preventing inactivity nudge scheduling when a conversation is handed off to an agent**. Tests are expanded/updated to cover these behaviors (drop-off validation paths, preference note de-duplication, alternatives messaging, awaiting-payment determinism, and handoff scheduling).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a15be140e94bda558fb4c98be38124e82b7014a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->