### PR TITLE
chore(migration): harden prisma migration recovery and pre-deploy validation

### DIFF
--- a/.github/workflows/fly-validate.yml
+++ b/.github/workflows/fly-validate.yml
@@ -8,10 +8,38 @@ jobs:
   validate:
     name: Validate deployment config and build
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_HOST_AUTH_METHOD: trust
+          POSTGRES_DB: prisma_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d prisma_ci"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
     # if: false  # Temporarily disabled - remove this line to re-enable
     steps:
       # Pin to v6.0.1 - check for updates with: gh api repos/actions/checkout/tags --jq '.[0].name'
       - uses: actions/checkout@v6.0.1
+
+      # Pin to v4 - check for updates with: gh api repos/pnpm/action-setup/tags --jq '.[0].name'
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      # Pin to v4 - check for updates with: gh api repos/actions/setup-node/tags --jq '.[0].name'
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
       
       # Pin to v3.12.0 - check for updates with: gh api repos/docker/setup-buildx-action/tags --jq '.[0].name'
       - name: Setup Docker Buildx
@@ -25,6 +53,11 @@ jobs:
         run: flyctl config validate
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+      - name: Validate Prisma migrations on clean Postgres
+        run: npx prisma migrate deploy
+        env:
+          DATABASE_URL: postgresql://postgres@localhost:5432/prisma_ci?schema=public
       
       - name: Build Docker image (dry run)
         uses: docker/build-push-action@v5

--- a/.github/workflows/fly-validate.yml
+++ b/.github/workflows/fly-validate.yml
@@ -55,7 +55,7 @@ jobs:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
       - name: Validate Prisma migrations on clean Postgres
-        run: npx prisma migrate deploy
+        run: pnpm exec prisma migrate deploy
         env:
           DATABASE_URL: postgresql://postgres@localhost:5432/prisma_ci?schema=public
       

--- a/prisma/migrations/20260314110500_harden_sync_schema_recovery/migration.sql
+++ b/prisma/migrations/20260314110500_harden_sync_schema_recovery/migration.sql
@@ -1,0 +1,76 @@
+-- Defensive follow-up migration for partially-applied index/default changes.
+-- This migration is intentionally idempotent and non-destructive to table data.
+
+-- Keep only the intended non-unique index for payout transaction booking lookups.
+DROP INDEX IF EXISTS "PayoutTransaction_bookingId_key";
+
+DO $$
+BEGIN
+  IF to_regclass('"PayoutTransaction"') IS NOT NULL
+     AND to_regclass('"PayoutTransaction_bookingId_idx"') IS NULL THEN
+    EXECUTE 'CREATE INDEX "PayoutTransaction_bookingId_idx" ON "PayoutTransaction"("bookingId")';
+  END IF;
+END $$;
+
+-- Ensure this column no longer has a default.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'Car'
+      AND column_name = 'airportPickupRate'
+      AND column_default IS NOT NULL
+  ) THEN
+    EXECUTE 'ALTER TABLE "Car" ALTER COLUMN "airportPickupRate" DROP DEFAULT';
+  END IF;
+END $$;
+
+-- Ensure expected supporting indexes exist for Flight and Session.
+DO $$
+BEGIN
+  IF to_regclass('"Flight"') IS NOT NULL
+     AND to_regclass('"Flight_flightNumber_flightDate_idx"') IS NULL THEN
+    EXECUTE 'CREATE INDEX "Flight_flightNumber_flightDate_idx" ON "Flight"("flightNumber", "flightDate")';
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF to_regclass('"Flight"') IS NOT NULL
+     AND to_regclass('"Flight_alertId_idx"') IS NULL THEN
+    EXECUTE 'CREATE INDEX "Flight_alertId_idx" ON "Flight"("alertId")';
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF to_regclass('"session"') IS NOT NULL
+     AND to_regclass('"session_token_idx"') IS NULL THEN
+    EXECUTE 'CREATE INDEX "session_token_idx" ON "session"("token")';
+  END IF;
+END $$;
+
+-- Ensure dedupe uniqueness for status events when safe to enforce.
+DO $$
+DECLARE
+  duplicate_count INTEGER;
+BEGIN
+  IF to_regclass('"FlightStatusEvent"') IS NOT NULL
+     AND to_regclass('"FlightStatusEvent_flightId_eventType_eventTime_key"') IS NULL THEN
+    SELECT COUNT(*) INTO duplicate_count
+    FROM (
+      SELECT "flightId", "eventType", "eventTime"
+      FROM "FlightStatusEvent"
+      GROUP BY "flightId", "eventType", "eventTime"
+      HAVING COUNT(*) > 1
+    ) duplicates;
+
+    IF duplicate_count > 0 THEN
+      RAISE EXCEPTION 'Cannot create unique index FlightStatusEvent_flightId_eventType_eventTime_key: % duplicate key groups found', duplicate_count;
+    END IF;
+
+    EXECUTE 'CREATE UNIQUE INDEX "FlightStatusEvent_flightId_eventType_eventTime_key" ON "FlightStatusEvent"("flightId", "eventType", "eventTime")';
+  END IF;
+END $$;

--- a/prisma/migrations/20260314110500_harden_sync_schema_recovery/migration.sql
+++ b/prisma/migrations/20260314110500_harden_sync_schema_recovery/migration.sql
@@ -68,9 +68,9 @@ BEGIN
     ) duplicates;
 
     IF duplicate_count > 0 THEN
-      RAISE EXCEPTION 'Cannot create unique index FlightStatusEvent_flightId_eventType_eventTime_key: % duplicate key groups found', duplicate_count;
+      RAISE WARNING 'Skipping unique index FlightStatusEvent_flightId_eventType_eventTime_key: % duplicate key groups found', duplicate_count;
+    ELSE
+      EXECUTE 'CREATE UNIQUE INDEX "FlightStatusEvent_flightId_eventType_eventTime_key" ON "FlightStatusEvent"("flightId", "eventType", "eventTime")';
     END IF;
-
-    EXECUTE 'CREATE UNIQUE INDEX "FlightStatusEvent_flightId_eventType_eventTime_key" ON "FlightStatusEvent"("flightId", "eventType", "eventTime")';
   END IF;
 END $$;


### PR DESCRIPTION
Add a non-destructive follow-up migration that safely reconciles partially applied index/default changes, and update Fly validation CI to run prisma migrate deploy against an ephemeral Postgres instance so migration failures are caught before production deploys.