### PR TITLE
feat: harden ai-search, twilio media fetch, and document response headers

### DIFF
--- a/src/modules/ai-search/ai-search-throttler.guard.spec.ts
+++ b/src/modules/ai-search/ai-search-throttler.guard.spec.ts
@@ -1,0 +1,66 @@
+import type { ExecutionContext } from "@nestjs/common";
+import { Test, type TestingModule } from "@nestjs/testing";
+import { ThrottlerModule } from "@nestjs/throttler";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AiSearchRateLimitExceededException } from "./ai-search.error";
+import { AiSearchThrottlerGuard } from "./ai-search-throttler.guard";
+import { AI_SEARCH_THROTTLE_CONFIG } from "./ai-search-throttling.config";
+
+describe("AiSearchThrottlerGuard", () => {
+  let guard: AiSearchThrottlerGuard;
+  let setHeader: ReturnType<typeof vi.fn>;
+  let context: ExecutionContext;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        ThrottlerModule.forRoot([
+          {
+            name: AI_SEARCH_THROTTLE_CONFIG.name,
+            ttl: AI_SEARCH_THROTTLE_CONFIG.ttlMs,
+            limit: AI_SEARCH_THROTTLE_CONFIG.limit,
+          },
+        ]),
+      ],
+      providers: [AiSearchThrottlerGuard],
+    }).compile();
+
+    guard = module.get<AiSearchThrottlerGuard>(AiSearchThrottlerGuard);
+    setHeader = vi.fn();
+
+    const request = {
+      ip: "203.0.113.10",
+      method: "POST",
+      route: { path: "/ai-search" },
+      headers: {},
+    };
+    const response = { setHeader };
+
+    context = {
+      switchToHttp: () => ({
+        getRequest: () => request,
+        getResponse: () => response,
+      }),
+    } as unknown as ExecutionContext;
+  });
+
+  it("allows requests under the configured limit", async () => {
+    for (let count = 0; count < AI_SEARCH_THROTTLE_CONFIG.limit; count += 1) {
+      await expect(guard.canActivate(context)).resolves.toBe(true);
+    }
+  });
+
+  it("blocks requests above the configured limit and sets rate-limit headers", async () => {
+    for (let count = 0; count < AI_SEARCH_THROTTLE_CONFIG.limit; count += 1) {
+      await guard.canActivate(context);
+    }
+
+    await expect(guard.canActivate(context)).rejects.toThrow(AiSearchRateLimitExceededException);
+
+    expect(setHeader).toHaveBeenCalledWith("Retry-After", expect.any(String));
+    expect(setHeader).toHaveBeenCalledWith(
+      "RateLimit-Policy",
+      `${AI_SEARCH_THROTTLE_CONFIG.limit};w=${AI_SEARCH_THROTTLE_CONFIG.ttlSeconds}`,
+    );
+  });
+});

--- a/src/modules/ai-search/ai-search-throttler.guard.ts
+++ b/src/modules/ai-search/ai-search-throttler.guard.ts
@@ -1,0 +1,51 @@
+import { CanActivate, ExecutionContext, Injectable } from "@nestjs/common";
+import type { ThrottlerStorage } from "@nestjs/throttler";
+import { InjectThrottlerStorage } from "@nestjs/throttler";
+import type { Request, Response } from "express";
+import {
+  getClientIp,
+  getRetryAfterSeconds,
+  isThrottled,
+  setRateLimitHeaders,
+} from "../../common/throttling/throttling.helper";
+import { AiSearchRateLimitExceededException } from "./ai-search.error";
+import { AI_SEARCH_THROTTLE_CONFIG } from "./ai-search-throttling.config";
+
+@Injectable()
+export class AiSearchThrottlerGuard implements CanActivate {
+  constructor(
+    @InjectThrottlerStorage()
+    private readonly throttlerStorage: ThrottlerStorage,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<Request>();
+    const response = context.switchToHttp().getResponse<Response>();
+    const tracker = getClientIp(request);
+    const routePath = request.route?.path || "ai-search";
+    const method = request.method || "POST";
+    const key = `${AI_SEARCH_THROTTLE_CONFIG.name}:${method}:${routePath}:${tracker}`;
+
+    const hit = await this.throttlerStorage.increment(
+      key,
+      AI_SEARCH_THROTTLE_CONFIG.ttlMs,
+      AI_SEARCH_THROTTLE_CONFIG.limit,
+      AI_SEARCH_THROTTLE_CONFIG.ttlMs,
+      AI_SEARCH_THROTTLE_CONFIG.name,
+    );
+    const blocked = isThrottled(hit, AI_SEARCH_THROTTLE_CONFIG.limit);
+    if (!blocked) {
+      return true;
+    }
+
+    const retryAfterSeconds = getRetryAfterSeconds(hit, AI_SEARCH_THROTTLE_CONFIG.ttlSeconds);
+    setRateLimitHeaders(response, {
+      limit: AI_SEARCH_THROTTLE_CONFIG.limit,
+      windowSeconds: AI_SEARCH_THROTTLE_CONFIG.ttlSeconds,
+      retryAfterSeconds,
+      remaining: 0,
+    });
+
+    throw new AiSearchRateLimitExceededException();
+  }
+}

--- a/src/modules/ai-search/ai-search-throttling.config.ts
+++ b/src/modules/ai-search/ai-search-throttling.config.ts
@@ -1,0 +1,6 @@
+export const AI_SEARCH_THROTTLE_CONFIG = {
+  name: "ai-search-public",
+  ttlMs: 60 * 1000,
+  ttlSeconds: 60,
+  limit: 10,
+} as const;

--- a/src/modules/ai-search/ai-search.controller.spec.ts
+++ b/src/modules/ai-search/ai-search.controller.spec.ts
@@ -1,8 +1,12 @@
+import { GUARDS_METADATA } from "@nestjs/common/constants";
 import { Test, type TestingModule } from "@nestjs/testing";
+import { ThrottlerModule } from "@nestjs/throttler";
 import type { Response } from "express";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AiSearchController } from "./ai-search.controller";
 import { AiSearchService } from "./ai-search.service";
+import { AiSearchThrottlerGuard } from "./ai-search-throttler.guard";
+import { AI_SEARCH_THROTTLE_CONFIG } from "./ai-search-throttling.config";
 
 describe("AiSearchController", () => {
   let controller: AiSearchController;
@@ -14,8 +18,17 @@ describe("AiSearchController", () => {
     };
 
     const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        ThrottlerModule.forRoot([
+          {
+            name: AI_SEARCH_THROTTLE_CONFIG.name,
+            ttl: AI_SEARCH_THROTTLE_CONFIG.ttlMs,
+            limit: AI_SEARCH_THROTTLE_CONFIG.limit,
+          },
+        ]),
+      ],
       controllers: [AiSearchController],
-      providers: [{ provide: AiSearchService, useValue: aiSearchService }],
+      providers: [AiSearchThrottlerGuard, { provide: AiSearchService, useValue: aiSearchService }],
     }).compile();
 
     controller = module.get<AiSearchController>(AiSearchController);
@@ -37,5 +50,13 @@ describe("AiSearchController", () => {
     expect(response.setHeader).toHaveBeenCalledWith("Cache-Control", "no-store");
     expect(aiSearchService.search).toHaveBeenCalledWith("toyota");
     expect(result.params.make).toBe("Toyota");
+  });
+
+  it("applies AiSearchThrottlerGuard on search endpoint", () => {
+    const guards = Reflect.getMetadata(
+      GUARDS_METADATA,
+      AiSearchController.prototype.search,
+    ) as unknown[];
+    expect(guards).toContain(AiSearchThrottlerGuard);
   });
 });

--- a/src/modules/ai-search/ai-search.controller.ts
+++ b/src/modules/ai-search/ai-search.controller.ts
@@ -1,7 +1,8 @@
-import { Controller, Post, Res } from "@nestjs/common";
+import { Controller, Post, Res, UseGuards } from "@nestjs/common";
 import type { Response } from "express";
 import { ZodBody } from "../../common/decorators/zod-validation.decorator";
 import { AiSearchService } from "./ai-search.service";
+import { AiSearchThrottlerGuard } from "./ai-search-throttler.guard";
 import { type AiSearchBodyDto, aiSearchBodySchema } from "./dto/ai-search.dto";
 
 @Controller("api")
@@ -9,6 +10,7 @@ export class AiSearchController {
   constructor(private readonly aiSearchService: AiSearchService) {}
 
   @Post("ai-search")
+  @UseGuards(AiSearchThrottlerGuard)
   async search(
     @ZodBody(aiSearchBodySchema) body: AiSearchBodyDto,
     @Res({ passthrough: true }) response: Response,

--- a/src/modules/ai-search/ai-search.error.ts
+++ b/src/modules/ai-search/ai-search.error.ts
@@ -6,6 +6,7 @@ export const AiSearchErrorCode = {
   AI_SEARCH_TIMEOUT: "AI_SEARCH_TIMEOUT",
   AI_SEARCH_PROVIDER_RESPONSE_INVALID: "AI_SEARCH_PROVIDER_RESPONSE_INVALID",
   AI_SEARCH_PROVIDER_AUTHENTICATION_FAILED: "AI_SEARCH_PROVIDER_AUTHENTICATION_FAILED",
+  AI_SEARCH_RATE_LIMIT_EXCEEDED: "AI_SEARCH_RATE_LIMIT_EXCEEDED",
 } as const;
 
 export class AiSearchException extends AppException {}
@@ -57,6 +58,19 @@ export class AiSearchProviderAuthenticationException extends AiSearchException {
       HttpStatus.BAD_GATEWAY,
       {
         title: "AI Provider Authentication Failed",
+      },
+    );
+  }
+}
+
+export class AiSearchRateLimitExceededException extends AiSearchException {
+  constructor() {
+    super(
+      AiSearchErrorCode.AI_SEARCH_RATE_LIMIT_EXCEEDED,
+      "Too many AI search requests. Please try again shortly.",
+      HttpStatus.TOO_MANY_REQUESTS,
+      {
+        title: "Too Many Requests",
       },
     );
   }

--- a/src/modules/ai-search/ai-search.module.ts
+++ b/src/modules/ai-search/ai-search.module.ts
@@ -1,13 +1,25 @@
 import { Module } from "@nestjs/common";
+import { ThrottlerModule } from "@nestjs/throttler";
 import { OpenAiSdkModule } from "../openai-sdk/openai-sdk.module";
 import { AiSearchController } from "./ai-search.controller";
 import { AiSearchService } from "./ai-search.service";
+import { AiSearchThrottlerGuard } from "./ai-search-throttler.guard";
+import { AI_SEARCH_THROTTLE_CONFIG } from "./ai-search-throttling.config";
 import { OpenAiAiSearchExtractorService } from "./openai-ai-search-extractor.service";
 
 @Module({
-  imports: [OpenAiSdkModule],
+  imports: [
+    OpenAiSdkModule,
+    ThrottlerModule.forRoot([
+      {
+        name: AI_SEARCH_THROTTLE_CONFIG.name,
+        ttl: AI_SEARCH_THROTTLE_CONFIG.ttlMs,
+        limit: AI_SEARCH_THROTTLE_CONFIG.limit,
+      },
+    ]),
+  ],
   controllers: [AiSearchController],
-  providers: [AiSearchService, OpenAiAiSearchExtractorService],
+  providers: [AiSearchService, OpenAiAiSearchExtractorService, AiSearchThrottlerGuard],
   exports: [AiSearchService],
 })
 export class AiSearchModule {}

--- a/src/modules/booking-agent/whatsapp/whatsapp-audio-transcription.service.spec.ts
+++ b/src/modules/booking-agent/whatsapp/whatsapp-audio-transcription.service.spec.ts
@@ -1,6 +1,6 @@
 import { ConfigService } from "@nestjs/config";
 import { Test, type TestingModule } from "@nestjs/testing";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { OPENAI_SDK_CLIENT } from "../../openai-sdk/openai-sdk.tokens";
 import { WhatsAppAudioTranscriptionService } from "./whatsapp-audio-transcription.service";
 
@@ -15,6 +15,10 @@ type TranscriptionServiceInternals = {
 describe("WhatsAppAudioTranscriptionService", () => {
   let moduleRef: TestingModule;
   let service: WhatsAppAudioTranscriptionService;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
   beforeEach(async () => {
     moduleRef = await Test.createTestingModule({
@@ -90,5 +94,38 @@ describe("WhatsAppAudioTranscriptionService", () => {
         traceId: "conv-1:msg-1",
       }),
     ).resolves.toBeNull();
+  });
+
+  it("rejects media URL with non-Twilio domain", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const transcribeSpy = vi.spyOn(
+      service as unknown as TranscriptionServiceInternals,
+      "transcribeAudioBinary",
+    );
+
+    await expect(
+      service.transcribeInboundAudio({
+        mediaUrl: "https://example.com/media/123",
+        mediaContentType: "audio/ogg",
+        traceId: "conv-1:msg-1",
+      }),
+    ).rejects.toThrow("Invalid WhatsApp media URL domain");
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(transcribeSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects media URL with non-HTTPS protocol", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await expect(
+      service.transcribeInboundAudio({
+        mediaUrl: "http://api.twilio.com/media/123",
+        mediaContentType: "audio/ogg",
+        traceId: "conv-1:msg-1",
+      }),
+    ).rejects.toThrow("Invalid WhatsApp media URL protocol");
+
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/booking-agent/whatsapp/whatsapp-audio-transcription.service.ts
+++ b/src/modules/booking-agent/whatsapp/whatsapp-audio-transcription.service.ts
@@ -53,6 +53,7 @@ export class WhatsAppAudioTranscriptionService {
   }
 
   private async downloadMediaBinary(mediaUrl: string): Promise<Uint8Array> {
+    this.validateTwilioMediaUrl(mediaUrl);
     const basicAuth = Buffer.from(`${this.twilioAccountSid}:${this.twilioAuthToken}`).toString(
       "base64",
     );
@@ -88,6 +89,26 @@ export class WhatsAppAudioTranscriptionService {
 
     const arrayBuffer = await response.arrayBuffer();
     return new Uint8Array(arrayBuffer);
+  }
+
+  private validateTwilioMediaUrl(mediaUrl: string): void {
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(mediaUrl);
+    } catch {
+      throw new Error(`Invalid WhatsApp media URL: ${mediaUrl}`);
+    }
+
+    if (parsedUrl.protocol !== "https:") {
+      throw new Error(`Invalid WhatsApp media URL protocol: ${parsedUrl.protocol}`);
+    }
+
+    const host = parsedUrl.hostname.toLowerCase();
+    const isTwilioHost =
+      host === "twilio.com" || host.endsWith(".twilio.com") || host.endsWith(".twiliocdn.com");
+    if (!isTwilioHost) {
+      throw new Error(`Invalid WhatsApp media URL domain: ${parsedUrl.hostname}`);
+    }
   }
 
   private async transcribeAudioBinary(

--- a/src/modules/documents/documents.controller.spec.ts
+++ b/src/modules/documents/documents.controller.spec.ts
@@ -71,4 +71,32 @@ describe("DocumentsController", () => {
       expect.stringContaining("sample.pdf"),
     );
   });
+
+  it("escapes filename content before writing Content-Disposition header", async () => {
+    const stream = {
+      on: vi.fn(),
+      pipe: vi.fn(),
+    };
+    vi.mocked(documentProxyService.getPdfByDocumentId).mockResolvedValue({
+      stream: stream as unknown as Readable,
+      fileName: 'report\\final"2026\r\n.pdf',
+      contentType: "application/pdf",
+      contentLength: undefined,
+    });
+
+    const response = {
+      setHeader: vi.fn(),
+      status: vi.fn().mockReturnThis(),
+      end: vi.fn(),
+      headersSent: false,
+    };
+
+    await controller.proxyPdf("doc-1", response as unknown as Response);
+
+    const escapedFileName = String.raw`report\\final\"2026.pdf`;
+    expect(response.setHeader).toHaveBeenCalledWith(
+      "Content-Disposition",
+      `inline; filename="${escapedFileName}"`,
+    );
+  });
 });

--- a/src/modules/documents/documents.controller.ts
+++ b/src/modules/documents/documents.controller.ts
@@ -22,7 +22,10 @@ export class DocumentsController {
     const proxiedFile = await this.documentProxyService.getPdfByDocumentId(documentId);
 
     response.setHeader("Content-Type", proxiedFile.contentType);
-    response.setHeader("Content-Disposition", `inline; filename="${proxiedFile.fileName}"`);
+    response.setHeader(
+      "Content-Disposition",
+      `inline; filename="${this.escapeFilenameForHeader(proxiedFile.fileName)}"`,
+    );
     response.setHeader("Cache-Control", "max-age=300");
 
     if (proxiedFile.contentLength !== undefined) {
@@ -38,5 +41,9 @@ export class DocumentsController {
     });
 
     proxiedFile.stream.pipe(response);
+  }
+
+  private escapeFilenameForHeader(fileName: string): string {
+    return fileName.replaceAll(/[\r\n]/g, "").replaceAll(/["\\]/g, String.raw`\$&`);
   }
 }


### PR DESCRIPTION
- add Twilio media URL validation (HTTPS + trusted Twilio domains) before audio fetch
- add rate limiting guard for public /api/ai-search with consistent rate-limit headers and custom exception
- escape/normalize Content-Disposition filename output in documents proxy endpoint
- extend unit/e2e coverage for new throttling and header/url hardening behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces request throttling on a public endpoint and tightens input/header handling; misconfiguration or edge cases could block legitimate traffic or change client-visible behavior.
> 
> **Overview**
> Adds rate limiting to `POST /api/ai-search` via a new `AiSearchThrottlerGuard`, backed by `@nestjs/throttler`, emitting standard `RateLimit-*`/`Retry-After` headers and a new `AiSearchRateLimitExceededException` (configurable via `AI_SEARCH_THROTTLE_CONFIG`).
> 
> Hardens external-input handling by validating WhatsApp media URLs are HTTPS and on trusted Twilio domains before fetching, and by escaping CR/LF, quotes, and backslashes in the `Content-Disposition` filename for the documents PDF proxy. Tests are extended to cover the new throttling, URL validation, and header escaping behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 030635810b0d9a4f06697491a86ce0b0fa21754a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->