### PR TITLE
chore(ci): add per-PR preview environment with Neon branch and Fly Redis

### DIFF
--- a/.github/workflows/fly-preview.yml
+++ b/.github/workflows/fly-preview.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       db_url: ${{ steps.create_neon_branch.outputs.db_url }}
-      db_url_pooled: ${{ steps.create_neon_branch.outputs.db_url_pooled }}
+      db_url_pooled: ${{ steps.create_neon_branch.outputs.db_url_pooled || steps.create_neon_branch.outputs.db_url_pooler || steps.create_neon_branch.outputs.db_url_with_pooler || steps.create_neon_branch.outputs.db_url }}
     permissions:
       contents: read
       pull-requests: write
@@ -155,6 +155,13 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Ensure DATABASE_URL is available
+        run: |
+          if [ -z "${DATABASE_URL}" ]; then
+            echo "DATABASE_URL is empty. Neon branch output may have changed or branch creation failed."
+            exit 1
+          fi
 
       - name: Run Prisma migrations on preview branch
         run: pnpm exec prisma migrate deploy

--- a/.github/workflows/fly-preview.yml
+++ b/.github/workflows/fly-preview.yml
@@ -116,6 +116,10 @@ jobs:
         id: redis
         run: |
           REDIS_APP="hyre-worker-redis-pr-${{ github.event.number }}"
+          app_exists() {
+            flyctl status -a "$REDIS_APP" >/dev/null 2>&1
+          }
+
           if [ -z "${PREVIEW_REDIS_PASSWORD:-}" ]; then
             echo "Missing required secret PREVIEW_REDIS_PASSWORD"
             exit 1
@@ -123,18 +127,19 @@ jobs:
           REDIS_PASSWORD="$PREVIEW_REDIS_PASSWORD"
           echo "::add-mask::$REDIS_PASSWORD"
 
-          if ! flyctl apps show "$REDIS_APP" > /dev/null 2>&1; then
+          if ! app_exists; then
+            echo "Redis app '$REDIS_APP' does not exist yet; creating..."
             if [ -n "${FLY_ORG:-}" ]; then
-              flyctl apps create "$REDIS_APP" --org "$FLY_ORG"
+              flyctl apps create "$REDIS_APP" --org "$FLY_ORG" --yes
             else
-              flyctl apps create "$REDIS_APP"
+              flyctl apps create "$REDIS_APP" --yes
             fi
           fi
 
           # Fly app creation can be eventually consistent; wait until app is visible.
           APP_READY=false
           for i in {1..10}; do
-            if flyctl apps show "$REDIS_APP" > /dev/null 2>&1; then
+            if app_exists; then
               APP_READY=true
               break
             fi
@@ -144,6 +149,7 @@ jobs:
 
           if [ "$APP_READY" != "true" ]; then
             echo "Redis app '$REDIS_APP' is not available after creation."
+            flyctl apps list || true
             exit 1
           fi
 

--- a/.github/workflows/fly-preview.yml
+++ b/.github/workflows/fly-preview.yml
@@ -227,7 +227,6 @@ jobs:
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     env:
-      REDIS_URL: redis://default:${{ secrets.PREVIEW_REDIS_PASSWORD }}@hyre-worker-redis-pr-${{ github.event.number }}.internal:6379
       DOMAIN: ${{ needs.setup.outputs.preview_url }}
       TWILIO_WEBHOOK_URL: ${{ needs.setup.outputs.preview_url }}/api/webhook/twilio
       FLUTTERWAVE_WEBHOOK_URL: ${{ needs.setup.outputs.preview_url }}/api/webhook/flutterwave
@@ -244,6 +243,13 @@ jobs:
 
       - name: Checkout repo
         uses: actions/checkout@v4
+
+      - name: Build REDIS_URL for validation and migrations
+        run: |
+          ENCODED_REDIS_PASSWORD="$(python3 -c 'import os, urllib.parse; print(urllib.parse.quote(os.environ["PREVIEW_REDIS_PASSWORD"], safe=""))')"
+          REDIS_URL_VALUE="redis://default:${ENCODED_REDIS_PASSWORD}@hyre-worker-redis-pr-${{ github.event.number }}.internal:6379"
+          echo "::add-mask::$REDIS_URL_VALUE"
+          echo "REDIS_URL=$REDIS_URL_VALUE" >> "$GITHUB_ENV"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -306,6 +312,14 @@ jobs:
           branch_name: ${{ needs.setup.outputs.neon_branch }}
           api_key: ${{ secrets.NEON_API_KEY }}
 
+      - name: Build encoded REDIS_URL for deploy
+        id: redis_url
+        run: |
+          ENCODED_REDIS_PASSWORD="$(python3 -c 'import os, urllib.parse; print(urllib.parse.quote(os.environ["PREVIEW_REDIS_PASSWORD"], safe=""))')"
+          REDIS_URL_VALUE="redis://default:${ENCODED_REDIS_PASSWORD}@hyre-worker-redis-pr-${{ github.event.number }}.internal:6379"
+          echo "::add-mask::$REDIS_URL_VALUE"
+          echo "redis_url=$REDIS_URL_VALUE" >> "$GITHUB_OUTPUT"
+
       - name: Deploy PR app to Fly.io
         id: deploy
         uses: superfly/fly-pr-review-apps@6f79ec3a7d017082ed11e7c464dae298ca75b21b
@@ -315,7 +329,7 @@ jobs:
           secrets: >-
             NODE_ENV=${{ env.NODE_ENV }}
             DATABASE_URL=${{ steps.neon_db.outputs.db_url_pooled }}
-            REDIS_URL=redis://default:${{ secrets.PREVIEW_REDIS_PASSWORD }}@hyre-worker-redis-pr-${{ github.event.number }}.internal:6379
+            REDIS_URL=${{ steps.redis_url.outputs.redis_url }}
             RESEND_API_KEY=${{ env.RESEND_API_KEY }}
             RESEND_FROM_EMAIL=${{ env.RESEND_FROM_EMAIL }}
             APP_NAME=Tripdly_API_Preview

--- a/.github/workflows/fly-preview.yml
+++ b/.github/workflows/fly-preview.yml
@@ -42,6 +42,7 @@ env:
   BULL_BOARD_USERNAME: ${{ secrets.BULL_BOARD_USERNAME }}
   BULL_BOARD_PASSWORD: ${{ secrets.BULL_BOARD_PASSWORD }}
   PREVIEW_REDIS_PASSWORD: ${{ secrets.PREVIEW_REDIS_PASSWORD }}
+  FLY_ORG: ${{ vars.FLY_ORG }}
 
 jobs:
   setup:
@@ -147,7 +148,20 @@ jobs:
           fi
 
           # Ensure a Redis machine is running. Start stopped machine if present, otherwise create one.
-          MACHINES_JSON="$(flyctl machine list -a "$REDIS_APP" --json)"
+          MACHINES_JSON=""
+          for i in {1..10}; do
+            if MACHINES_JSON="$(flyctl machine list -a "$REDIS_APP" --json 2>/dev/null)"; then
+              break
+            fi
+            echo "Waiting for machine API on '$REDIS_APP'... (${i}/10)"
+            sleep 2
+          done
+
+          if [ -z "$MACHINES_JSON" ]; then
+            echo "Failed to list Redis machines for app '$REDIS_APP' after retries."
+            exit 1
+          fi
+
           RUNNING_COUNT="$(printf '%s' "$MACHINES_JSON" | jq '[.[] | select(.state == "started")] | length')"
           if [ "$RUNNING_COUNT" = "0" ]; then
             STOPPED_MACHINE_ID="$(

--- a/.github/workflows/fly-preview.yml
+++ b/.github/workflows/fly-preview.yml
@@ -206,7 +206,7 @@ jobs:
             if [ -n "$STOPPED_MACHINE_ID" ]; then
               flyctl machine start "$STOPPED_MACHINE_ID" -a "$REDIS_APP"
             else
-              flyctl machine run flyio/redis:7.2 \
+              flyctl machine run redis:7.2-alpine3.21 \
                 --app "$REDIS_APP" \
                 --region lhr \
                 --name redis \

--- a/.github/workflows/fly-preview.yml
+++ b/.github/workflows/fly-preview.yml
@@ -123,7 +123,27 @@ jobs:
           echo "::add-mask::$REDIS_PASSWORD"
 
           if ! flyctl apps show "$REDIS_APP" > /dev/null 2>&1; then
-            flyctl apps create "$REDIS_APP"
+            if [ -n "${FLY_ORG:-}" ]; then
+              flyctl apps create "$REDIS_APP" --org "$FLY_ORG"
+            else
+              flyctl apps create "$REDIS_APP"
+            fi
+          fi
+
+          # Fly app creation can be eventually consistent; wait until app is visible.
+          APP_READY=false
+          for i in {1..10}; do
+            if flyctl apps show "$REDIS_APP" > /dev/null 2>&1; then
+              APP_READY=true
+              break
+            fi
+            echo "Waiting for Redis app '$REDIS_APP' to become available... (${i}/10)"
+            sleep 2
+          done
+
+          if [ "$APP_READY" != "true" ]; then
+            echo "Redis app '$REDIS_APP' is not available after creation."
+            exit 1
           fi
 
           # Ensure a Redis machine is running. Start stopped machine if present, otherwise create one.
@@ -141,11 +161,11 @@ jobs:
               flyctl machine start "$STOPPED_MACHINE_ID" -a "$REDIS_APP"
             else
               flyctl machine run flyio/redis:7.2 \
-              --app "$REDIS_APP" \
-              --region lhr \
-              --name redis \
-              --env REDIS_PASSWORD="$REDIS_PASSWORD" \
-              --env PRIMARY_REGION=lhr
+                --app "$REDIS_APP" \
+                --region lhr \
+                --name redis \
+                --env REDIS_PASSWORD="$REDIS_PASSWORD" \
+                --env PRIMARY_REGION=lhr
             fi
           fi
 

--- a/.github/workflows/fly-preview.yml
+++ b/.github/workflows/fly-preview.yml
@@ -65,9 +65,6 @@ jobs:
     needs: setup
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
-    outputs:
-      db_url: ${{ steps.create_neon_branch.outputs.db_url }}
-      db_url_with_pooler: ${{ steps.create_neon_branch.outputs.db_url_pooled }}
     permissions:
       contents: read
       pull-requests: write
@@ -92,8 +89,10 @@ jobs:
           api_key: ${{ secrets.NEON_API_KEY }}
 
       - name: Verify Neon pooled URL output
+        env:
+          DB_URL_POOLED: ${{ steps.create_neon_branch.outputs.db_url_pooled }}
         run: |
-          if [ -z "${{ steps.create_neon_branch.outputs.db_url_pooled }}" ]; then
+          if [ -z "$DB_URL_POOLED" ]; then
             echo "Neon action did not return db_url_pooled output."
             exit 1
           fi
@@ -179,7 +178,10 @@ jobs:
             exit 1
           fi
 
-          # Ensure a Redis machine is running. Start stopped machine if present, otherwise create one.
+          # Ensure a Redis machine is running with the current REDIS_PASSWORD value.
+          # REDIS_PASSWORD is sourced from PREVIEW_REDIS_PASSWORD above.
+          # Do not `flyctl machine start` a STOPPED_MACHINE_ID because it preserves old env vars.
+          # Instead, destroy stopped machines and recreate with `flyctl machine run --env REDIS_PASSWORD=...`.
           MACHINES_JSON=""
           for i in {1..10}; do
             if MACHINES_JSON="$(flyctl machine list -a "$REDIS_APP" --json 2>/dev/null)"; then
@@ -204,15 +206,16 @@ jobs:
             )"
 
             if [ -n "$STOPPED_MACHINE_ID" ]; then
-              flyctl machine start "$STOPPED_MACHINE_ID" -a "$REDIS_APP"
-            else
-              flyctl machine run redis:7.2-alpine3.21 \
-                --app "$REDIS_APP" \
-                --region lhr \
-                --name redis \
-                --env REDIS_PASSWORD="$REDIS_PASSWORD" \
-                --env PRIMARY_REGION=lhr
+              echo "Destroying stopped Redis machine '$STOPPED_MACHINE_ID' to apply current REDIS_PASSWORD."
+              flyctl machine destroy "$STOPPED_MACHINE_ID" -a "$REDIS_APP" --force
             fi
+
+            flyctl machine run redis:7.2-alpine3.21 \
+              --app "$REDIS_APP" \
+              --region lhr \
+              --name redis \
+              --env REDIS_PASSWORD="$REDIS_PASSWORD" \
+              --env PRIMARY_REGION=lhr
           fi
 
           echo "redis_app=$REDIS_APP" >> "$GITHUB_OUTPUT"
@@ -224,7 +227,6 @@ jobs:
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     env:
-      DATABASE_URL: ${{ needs.create_neon_branch.outputs.db_url_with_pooler }}
       REDIS_URL: ${{ needs.provision_redis.outputs.redis_url }}
       DOMAIN: ${{ needs.setup.outputs.preview_url }}
       TWILIO_WEBHOOK_URL: ${{ needs.setup.outputs.preview_url }}/api/webhook/twilio
@@ -232,6 +234,14 @@ jobs:
       AUTH_BASE_URL: ${{ needs.setup.outputs.preview_url }}
       TRUSTED_ORIGINS: ${{ needs.setup.outputs.preview_url }}
     steps:
+      - name: Resolve Neon pooled DATABASE_URL
+        id: neon_db
+        uses: neondatabase/create-branch-action@72ed4f69a12b6be9c16aebfad893f6a21e9aba8b
+        with:
+          project_id: ${{ vars.NEON_PROJECT_ID }}
+          branch_name: ${{ needs.setup.outputs.neon_branch }}
+          api_key: ${{ secrets.NEON_API_KEY }}
+
       - name: Checkout repo
         uses: actions/checkout@v4
 
@@ -250,19 +260,25 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Ensure DATABASE_URL is available
+        env:
+          DATABASE_URL: ${{ steps.neon_db.outputs.db_url_pooled }}
         run: |
           if [ -z "${DATABASE_URL}" ]; then
-            echo "DATABASE_URL is empty. Neon branch output may have changed or branch creation failed."
+            echo "DATABASE_URL is empty. Neon pooled URL could not be resolved in preflight."
             exit 1
           fi
 
       - name: Run Prisma migrations on preview branch
+        env:
+          DATABASE_URL: ${{ steps.neon_db.outputs.db_url_pooled }}
         run: pnpm exec prisma migrate deploy
 
       - name: Build app
         run: pnpm build
 
       - name: Validate required env keys from canonical schema
+        env:
+          DATABASE_URL: ${{ steps.neon_db.outputs.db_url_pooled }}
         run: |
           node -e "const fs = require('fs'); const path = './dist/config/env.config.js'; if (!fs.existsSync(path)) { console.error('Missing build output: ' + path + '. Ensure build step succeeded before env validation.'); process.exit(1); } const { validateEnvironment } = require(path); validateEnvironment(process.env); console.log('Environment schema validation passed.');"
 
@@ -280,6 +296,14 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      - name: Resolve Neon pooled DATABASE_URL
+        id: neon_db
+        uses: neondatabase/create-branch-action@72ed4f69a12b6be9c16aebfad893f6a21e9aba8b
+        with:
+          project_id: ${{ vars.NEON_PROJECT_ID }}
+          branch_name: ${{ needs.setup.outputs.neon_branch }}
+          api_key: ${{ secrets.NEON_API_KEY }}
+
       - name: Deploy PR app to Fly.io
         id: deploy
         uses: superfly/fly-pr-review-apps@6f79ec3a7d017082ed11e7c464dae298ca75b21b
@@ -288,11 +312,11 @@ jobs:
           config: fly.preview.toml
           secrets: >-
             NODE_ENV=${{ env.NODE_ENV }}
-            DATABASE_URL=${{ needs.create_neon_branch.outputs.db_url_with_pooler }}
+            DATABASE_URL=${{ steps.neon_db.outputs.db_url_pooled }}
             REDIS_URL=${{ needs.provision_redis.outputs.redis_url }}
             RESEND_API_KEY=${{ env.RESEND_API_KEY }}
             RESEND_FROM_EMAIL=${{ env.RESEND_FROM_EMAIL }}
-            APP_NAME=${{ env.APP_NAME }}
+            APP_NAME=Tripdly_API_Preview
             DOMAIN=${{ needs.setup.outputs.preview_url }}
             TWILIO_ACCOUNT_SID=${{ env.TWILIO_ACCOUNT_SID }}
             TWILIO_AUTH_TOKEN=${{ env.TWILIO_AUTH_TOKEN }}

--- a/.github/workflows/fly-preview.yml
+++ b/.github/workflows/fly-preview.yml
@@ -98,9 +98,35 @@ jobs:
             exit 1
           fi
 
+  fly_auth_check:
+    name: Verify Fly auth and org permissions
+    needs: setup
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    env:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+    steps:
+      - name: Setup Fly.io CLI
+        uses: superfly/flyctl-actions/setup-flyctl@v1.4
+
+      - name: Verify token can access apps list
+        run: flyctl apps list >/dev/null
+
+      - name: Verify app create/destroy permission in org
+        run: |
+          TEST_APP="hyre-worker-auth-check-${{ github.run_id }}-${{ github.run_attempt }}"
+          if [ -z "${FLY_ORG:-}" ]; then
+            echo "FLY_ORG is not set. Add repository variable FLY_ORG (e.g., personal)."
+            exit 1
+          fi
+
+          echo "Checking app create permission in org '${FLY_ORG}'..."
+          flyctl apps create "$TEST_APP" --org "$FLY_ORG" --yes
+          flyctl apps destroy "$TEST_APP" --yes
+
   provision_redis:
     name: Provision Redis per PR
-    needs: setup
+    needs: [setup, fly_auth_check]
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/fly-preview.yml
+++ b/.github/workflows/fly-preview.yml
@@ -227,7 +227,7 @@ jobs:
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     env:
-      REDIS_URL: ${{ needs.provision_redis.outputs.redis_url }}
+      REDIS_URL: redis://default:${{ secrets.PREVIEW_REDIS_PASSWORD }}@hyre-worker-redis-pr-${{ github.event.number }}.internal:6379
       DOMAIN: ${{ needs.setup.outputs.preview_url }}
       TWILIO_WEBHOOK_URL: ${{ needs.setup.outputs.preview_url }}/api/webhook/twilio
       FLUTTERWAVE_WEBHOOK_URL: ${{ needs.setup.outputs.preview_url }}/api/webhook/flutterwave
@@ -280,6 +280,8 @@ jobs:
         env:
           DATABASE_URL: ${{ steps.neon_db.outputs.db_url_pooled }}
         run: |
+          if [ -z "${BULL_BOARD_PASSWORD:-}" ]; then unset BULL_BOARD_PASSWORD; fi
+          if [ -z "${BULL_BOARD_USERNAME:-}" ]; then unset BULL_BOARD_USERNAME; fi
           node -e "const fs = require('fs'); const path = './dist/config/env.config.js'; if (!fs.existsSync(path)) { console.error('Missing build output: ' + path + '. Ensure build step succeeded before env validation.'); process.exit(1); } const { validateEnvironment } = require(path); validateEnvironment(process.env); console.log('Environment schema validation passed.');"
 
   deploy_preview:
@@ -313,7 +315,7 @@ jobs:
           secrets: >-
             NODE_ENV=${{ env.NODE_ENV }}
             DATABASE_URL=${{ steps.neon_db.outputs.db_url_pooled }}
-            REDIS_URL=${{ needs.provision_redis.outputs.redis_url }}
+            REDIS_URL=redis://default:${{ secrets.PREVIEW_REDIS_PASSWORD }}@hyre-worker-redis-pr-${{ github.event.number }}.internal:6379
             RESEND_API_KEY=${{ env.RESEND_API_KEY }}
             RESEND_FROM_EMAIL=${{ env.RESEND_FROM_EMAIL }}
             APP_NAME=Tripdly_API_Preview

--- a/.github/workflows/fly-preview.yml
+++ b/.github/workflows/fly-preview.yml
@@ -12,6 +12,37 @@ concurrency:
   group: preview-pr-${{ github.event.number }}
   cancel-in-progress: true
 
+env:
+  NODE_ENV: production
+  APP_NAME: Tripdly API Preview
+  SENDER_NAME: Yomide
+  AWS_REGION: eu-west-2
+  AWS_BUCKET_NAME: s3-car-rentals-dev-bucket
+  FLUTTERWAVE_BASE_URL: https://api.flutterwave.com
+  ENABLE_MANUAL_TRIGGERS: "false"
+  RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+  RESEND_FROM_EMAIL: ${{ secrets.RESEND_FROM_EMAIL }}
+  TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
+  TWILIO_AUTH_TOKEN: ${{ secrets.TWILIO_AUTH_TOKEN }}
+  TWILIO_SECRET: ${{ secrets.TWILIO_SECRET }}
+  TWILIO_WHATSAPP_NUMBER: ${{ secrets.TWILIO_WHATSAPP_NUMBER }}
+  FLUTTERWAVE_SECRET_KEY: ${{ secrets.FLUTTERWAVE_SECRET_KEY }}
+  FLUTTERWAVE_PUBLIC_KEY: ${{ secrets.FLUTTERWAVE_PUBLIC_KEY }}
+  FLUTTERWAVE_WEBHOOK_SECRET: ${{ secrets.FLUTTERWAVE_WEBHOOK_SECRET }}
+  HMAC_KEY: ${{ secrets.HMAC_KEY }}
+  FLIGHTAWARE_API_KEY: ${{ secrets.FLIGHTAWARE_API_KEY }}
+  FLIGHTAWARE_WEBHOOK_SECRET: ${{ secrets.FLIGHTAWARE_WEBHOOK_SECRET }}
+  GOOGLE_DISTANCE_MATRIX_API_KEY: ${{ secrets.GOOGLE_DISTANCE_MATRIX_API_KEY }}
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+  API_KEY: ${{ secrets.API_KEY }}
+  BULL_BOARD_USERNAME: ${{ secrets.BULL_BOARD_USERNAME }}
+  BULL_BOARD_PASSWORD: ${{ secrets.BULL_BOARD_PASSWORD }}
+  PREVIEW_REDIS_PASSWORD: ${{ secrets.PREVIEW_REDIS_PASSWORD }}
+
 jobs:
   setup:
     name: Setup
@@ -35,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       db_url: ${{ steps.create_neon_branch.outputs.db_url }}
-      db_url_pooled: ${{ steps.create_neon_branch.outputs.db_url_pooled || steps.create_neon_branch.outputs.db_url_pooler || steps.create_neon_branch.outputs.db_url_with_pooler || steps.create_neon_branch.outputs.db_url }}
+      db_url_with_pooler: ${{ steps.create_neon_branch.outputs.db_url_pooled }}
     permissions:
       contents: read
       pull-requests: write
@@ -59,6 +90,13 @@ jobs:
           compare_branch: ${{ needs.setup.outputs.neon_branch }}
           api_key: ${{ secrets.NEON_API_KEY }}
 
+      - name: Verify Neon pooled URL output
+        run: |
+          if [ -z "${{ steps.create_neon_branch.outputs.db_url_pooled }}" ]; then
+            echo "Neon action did not return db_url_pooled output."
+            exit 1
+          fi
+
   provision_redis:
     name: Provision Redis per PR
     needs: setup
@@ -77,21 +115,38 @@ jobs:
         id: redis
         run: |
           REDIS_APP="hyre-worker-redis-pr-${{ github.event.number }}"
-          REDIS_PASSWORD="$(printf '%s' '${{ github.repository }}-pr-${{ github.event.number }}-redis' | sha256sum | cut -c1-32)"
+          if [ -z "${PREVIEW_REDIS_PASSWORD:-}" ]; then
+            echo "Missing required secret PREVIEW_REDIS_PASSWORD"
+            exit 1
+          fi
+          REDIS_PASSWORD="$PREVIEW_REDIS_PASSWORD"
+          echo "::add-mask::$REDIS_PASSWORD"
 
           if ! flyctl apps show "$REDIS_APP" > /dev/null 2>&1; then
             flyctl apps create "$REDIS_APP"
           fi
 
-          # Ensure a machine exists for this Redis app.
-          MACHINE_COUNT="$(flyctl machine list -a "$REDIS_APP" --json | jq 'length')"
-          if [ "$MACHINE_COUNT" = "0" ]; then
-            flyctl machine run flyio/redis:6.2 \
+          # Ensure a Redis machine is running. Start stopped machine if present, otherwise create one.
+          MACHINES_JSON="$(flyctl machine list -a "$REDIS_APP" --json)"
+          RUNNING_COUNT="$(printf '%s' "$MACHINES_JSON" | jq '[.[] | select(.state == "started")] | length')"
+          if [ "$RUNNING_COUNT" = "0" ]; then
+            STOPPED_MACHINE_ID="$(
+              printf '%s' "$MACHINES_JSON" | jq -r '
+                [.[] | select(.state == "stopped" or .state == "created" or .state == "suspended")] |
+                .[0].id // empty
+              '
+            )"
+
+            if [ -n "$STOPPED_MACHINE_ID" ]; then
+              flyctl machine start "$STOPPED_MACHINE_ID" -a "$REDIS_APP"
+            else
+              flyctl machine run flyio/redis:7.2 \
               --app "$REDIS_APP" \
               --region lhr \
               --name redis \
               --env REDIS_PASSWORD="$REDIS_PASSWORD" \
               --env PRIMARY_REGION=lhr
+            fi
           fi
 
           echo "redis_app=$REDIS_APP" >> "$GITHUB_OUTPUT"
@@ -103,41 +158,13 @@ jobs:
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     env:
-      NODE_ENV: production
-      DATABASE_URL: ${{ needs.create_neon_branch.outputs.db_url_pooled }}
+      DATABASE_URL: ${{ needs.create_neon_branch.outputs.db_url_with_pooler }}
       REDIS_URL: ${{ needs.provision_redis.outputs.redis_url }}
-      RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
-      RESEND_FROM_EMAIL: ${{ secrets.RESEND_FROM_EMAIL }}
-      APP_NAME: Tripdly API Preview
       DOMAIN: ${{ needs.setup.outputs.preview_url }}
-      TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
-      TWILIO_AUTH_TOKEN: ${{ secrets.TWILIO_AUTH_TOKEN }}
-      TWILIO_SECRET: ${{ secrets.TWILIO_SECRET }}
-      TWILIO_WHATSAPP_NUMBER: ${{ secrets.TWILIO_WHATSAPP_NUMBER }}
       TWILIO_WEBHOOK_URL: ${{ needs.setup.outputs.preview_url }}/api/webhook/twilio
-      FLUTTERWAVE_SECRET_KEY: ${{ secrets.FLUTTERWAVE_SECRET_KEY }}
-      FLUTTERWAVE_PUBLIC_KEY: ${{ secrets.FLUTTERWAVE_PUBLIC_KEY }}
-      FLUTTERWAVE_BASE_URL: https://api.flutterwave.com
-      FLUTTERWAVE_WEBHOOK_SECRET: ${{ secrets.FLUTTERWAVE_WEBHOOK_SECRET }}
       FLUTTERWAVE_WEBHOOK_URL: ${{ needs.setup.outputs.preview_url }}/api/webhook/flutterwave
-      HMAC_KEY: ${{ secrets.HMAC_KEY }}
-      FLIGHTAWARE_API_KEY: ${{ secrets.FLIGHTAWARE_API_KEY }}
-      FLIGHTAWARE_WEBHOOK_SECRET: ${{ secrets.FLIGHTAWARE_WEBHOOK_SECRET }}
-      GOOGLE_DISTANCE_MATRIX_API_KEY: ${{ secrets.GOOGLE_DISTANCE_MATRIX_API_KEY }}
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
       AUTH_BASE_URL: ${{ needs.setup.outputs.preview_url }}
       TRUSTED_ORIGINS: ${{ needs.setup.outputs.preview_url }}
-      SENDER_NAME: Yomide
-      AWS_REGION: eu-west-2
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_BUCKET_NAME: s3-car-rentals-dev-bucket
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      ENABLE_MANUAL_TRIGGERS: "false"
-      API_KEY: ${{ secrets.API_KEY }}
-      BULL_BOARD_USERNAME: ${{ secrets.BULL_BOARD_USERNAME }}
-      BULL_BOARD_PASSWORD: ${{ secrets.BULL_BOARD_PASSWORD }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -171,7 +198,7 @@ jobs:
 
       - name: Validate required env keys from canonical schema
         run: |
-          node -e "const { validateEnvironment } = require('./dist/config/env.config.js'); validateEnvironment(process.env); console.log('Environment schema validation passed.');"
+          node -e "const fs = require('fs'); const path = './dist/config/env.config.js'; if (!fs.existsSync(path)) { console.error('Missing build output: ' + path + '. Ensure build step succeeded before env validation.'); process.exit(1); } const { validateEnvironment } = require(path); validateEnvironment(process.env); console.log('Environment schema validation passed.');"
 
   deploy_preview:
     name: Deploy Fly preview app
@@ -189,46 +216,46 @@ jobs:
 
       - name: Deploy PR app to Fly.io
         id: deploy
-        uses: superfly/fly-pr-review-apps@1.2.1
+        uses: superfly/fly-pr-review-apps@6f79ec3a7d017082ed11e7c464dae298ca75b21b
         with:
           name: ${{ needs.setup.outputs.preview_app }}
           config: fly.preview.toml
           secrets: >-
-            NODE_ENV=production
-            DATABASE_URL=${{ needs.create_neon_branch.outputs.db_url_pooled }}
+            NODE_ENV=${{ env.NODE_ENV }}
+            DATABASE_URL=${{ needs.create_neon_branch.outputs.db_url_with_pooler }}
             REDIS_URL=${{ needs.provision_redis.outputs.redis_url }}
-            RESEND_API_KEY=${{ secrets.RESEND_API_KEY }}
-            RESEND_FROM_EMAIL=${{ secrets.RESEND_FROM_EMAIL }}
-            APP_NAME=Tripdly API Preview
+            RESEND_API_KEY=${{ env.RESEND_API_KEY }}
+            RESEND_FROM_EMAIL=${{ env.RESEND_FROM_EMAIL }}
+            APP_NAME=${{ env.APP_NAME }}
             DOMAIN=${{ needs.setup.outputs.preview_url }}
-            TWILIO_ACCOUNT_SID=${{ secrets.TWILIO_ACCOUNT_SID }}
-            TWILIO_AUTH_TOKEN=${{ secrets.TWILIO_AUTH_TOKEN }}
-            TWILIO_SECRET=${{ secrets.TWILIO_SECRET }}
-            TWILIO_WHATSAPP_NUMBER=${{ secrets.TWILIO_WHATSAPP_NUMBER }}
+            TWILIO_ACCOUNT_SID=${{ env.TWILIO_ACCOUNT_SID }}
+            TWILIO_AUTH_TOKEN=${{ env.TWILIO_AUTH_TOKEN }}
+            TWILIO_SECRET=${{ env.TWILIO_SECRET }}
+            TWILIO_WHATSAPP_NUMBER=${{ env.TWILIO_WHATSAPP_NUMBER }}
             TWILIO_WEBHOOK_URL=${{ needs.setup.outputs.preview_url }}/api/webhook/twilio
-            FLUTTERWAVE_SECRET_KEY=${{ secrets.FLUTTERWAVE_SECRET_KEY }}
-            FLUTTERWAVE_PUBLIC_KEY=${{ secrets.FLUTTERWAVE_PUBLIC_KEY }}
-            FLUTTERWAVE_BASE_URL=https://api.flutterwave.com
-            FLUTTERWAVE_WEBHOOK_SECRET=${{ secrets.FLUTTERWAVE_WEBHOOK_SECRET }}
+            FLUTTERWAVE_SECRET_KEY=${{ env.FLUTTERWAVE_SECRET_KEY }}
+            FLUTTERWAVE_PUBLIC_KEY=${{ env.FLUTTERWAVE_PUBLIC_KEY }}
+            FLUTTERWAVE_BASE_URL=${{ env.FLUTTERWAVE_BASE_URL }}
+            FLUTTERWAVE_WEBHOOK_SECRET=${{ env.FLUTTERWAVE_WEBHOOK_SECRET }}
             FLUTTERWAVE_WEBHOOK_URL=${{ needs.setup.outputs.preview_url }}/api/webhook/flutterwave
-            HMAC_KEY=${{ secrets.HMAC_KEY }}
-            FLIGHTAWARE_API_KEY=${{ secrets.FLIGHTAWARE_API_KEY }}
-            FLIGHTAWARE_WEBHOOK_SECRET=${{ secrets.FLIGHTAWARE_WEBHOOK_SECRET }}
-            GOOGLE_DISTANCE_MATRIX_API_KEY=${{ secrets.GOOGLE_DISTANCE_MATRIX_API_KEY }}
-            OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
-            SESSION_SECRET=${{ secrets.SESSION_SECRET }}
+            HMAC_KEY=${{ env.HMAC_KEY }}
+            FLIGHTAWARE_API_KEY=${{ env.FLIGHTAWARE_API_KEY }}
+            FLIGHTAWARE_WEBHOOK_SECRET=${{ env.FLIGHTAWARE_WEBHOOK_SECRET }}
+            GOOGLE_DISTANCE_MATRIX_API_KEY=${{ env.GOOGLE_DISTANCE_MATRIX_API_KEY }}
+            OPENAI_API_KEY=${{ env.OPENAI_API_KEY }}
+            SESSION_SECRET=${{ env.SESSION_SECRET }}
             AUTH_BASE_URL=${{ needs.setup.outputs.preview_url }}
             TRUSTED_ORIGINS=${{ needs.setup.outputs.preview_url }}
-            SENDER_NAME=Yomide
-            AWS_REGION=eu-west-2
-            AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
-            AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
-            AWS_BUCKET_NAME=s3-car-rentals-dev-bucket
-            ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
-            ENABLE_MANUAL_TRIGGERS=false
-            API_KEY=${{ secrets.API_KEY }}
-            BULL_BOARD_USERNAME=${{ secrets.BULL_BOARD_USERNAME }}
-            BULL_BOARD_PASSWORD=${{ secrets.BULL_BOARD_PASSWORD }}
+            SENDER_NAME=${{ env.SENDER_NAME }}
+            AWS_REGION=${{ env.AWS_REGION }}
+            AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}
+            AWS_BUCKET_NAME=${{ env.AWS_BUCKET_NAME }}
+            ANTHROPIC_API_KEY=${{ env.ANTHROPIC_API_KEY }}
+            ENABLE_MANUAL_TRIGGERS=${{ env.ENABLE_MANUAL_TRIGGERS }}
+            API_KEY=${{ env.API_KEY }}
+            BULL_BOARD_USERNAME=${{ env.BULL_BOARD_USERNAME }}
+            BULL_BOARD_PASSWORD=${{ env.BULL_BOARD_PASSWORD }}
 
   cleanup:
     name: Delete preview resources
@@ -249,7 +276,19 @@ jobs:
         uses: superfly/flyctl-actions/setup-flyctl@v1.4
 
       - name: Destroy Fly preview app
-        run: flyctl apps destroy "${{ needs.setup.outputs.preview_app }}" --yes || true
+        run: |
+          if flyctl apps destroy "${{ needs.setup.outputs.preview_app }}" --yes; then
+            echo "Destroyed preview app '${{ needs.setup.outputs.preview_app }}'."
+          else
+            status=$?
+            echo "Failed to destroy preview app '${{ needs.setup.outputs.preview_app }}' (exit=${status})."
+          fi
 
       - name: Destroy PR Redis app
-        run: flyctl apps destroy "hyre-worker-redis-pr-${{ github.event.number }}" --yes || true
+        run: |
+          if flyctl apps destroy "hyre-worker-redis-pr-${{ github.event.number }}" --yes; then
+            echo "Destroyed redis app 'hyre-worker-redis-pr-${{ github.event.number }}'."
+          else
+            status=$?
+            echo "Failed to destroy redis app 'hyre-worker-redis-pr-${{ github.event.number }}' (exit=${status})."
+          fi

--- a/.github/workflows/fly-preview.yml
+++ b/.github/workflows/fly-preview.yml
@@ -1,0 +1,248 @@
+name: Preview Environment (Neon + Fly)
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+concurrency:
+  group: preview-pr-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
+    outputs:
+      neon_branch: ${{ steps.meta.outputs.neon_branch }}
+      preview_app: ${{ steps.meta.outputs.preview_app }}
+      preview_url: ${{ steps.meta.outputs.preview_url }}
+    steps:
+      - name: Compute preview metadata
+        id: meta
+        run: |
+          echo "neon_branch=preview/pr-${{ github.event.number }}" >> "$GITHUB_OUTPUT"
+          echo "preview_app=hyre-worker-nestjs-pr-${{ github.event.number }}" >> "$GITHUB_OUTPUT"
+          echo "preview_url=https://pr-${{ github.event.number }}-${{ github.repository_owner }}-${{ github.event.repository.name }}.fly.dev" >> "$GITHUB_OUTPUT"
+
+  create_neon_branch:
+    name: Create Neon Branch
+    needs: setup
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    outputs:
+      db_url: ${{ steps.create_neon_branch.outputs.db_url }}
+      db_url_pooled: ${{ steps.create_neon_branch.outputs.db_url_pooled }}
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Get branch expiration date (2 weeks from now)
+        run: echo "EXPIRES_AT=$(date -u --date '+14 days' +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_ENV"
+
+      - name: Create Neon branch
+        id: create_neon_branch
+        uses: neondatabase/create-branch-action@72ed4f69a12b6be9c16aebfad893f6a21e9aba8b
+        with:
+          project_id: ${{ vars.NEON_PROJECT_ID }}
+          branch_name: ${{ needs.setup.outputs.neon_branch }}
+          api_key: ${{ secrets.NEON_API_KEY }}
+          expires_at: ${{ env.EXPIRES_AT }}
+
+      - name: Post schema diff comment to PR
+        uses: neondatabase/schema-diff-action@80cfa8521628e890015b60f5291a7738926617dc
+        with:
+          project_id: ${{ vars.NEON_PROJECT_ID }}
+          compare_branch: ${{ needs.setup.outputs.neon_branch }}
+          api_key: ${{ secrets.NEON_API_KEY }}
+
+  provision_redis:
+    name: Provision Redis per PR
+    needs: setup
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    outputs:
+      redis_url: ${{ steps.redis.outputs.redis_url }}
+      redis_app: ${{ steps.redis.outputs.redis_app }}
+    env:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+    steps:
+      - name: Setup Fly.io CLI
+        uses: superfly/flyctl-actions/setup-flyctl@v1.4
+
+      - name: Create or reuse PR Redis app
+        id: redis
+        run: |
+          REDIS_APP="hyre-worker-redis-pr-${{ github.event.number }}"
+          REDIS_PASSWORD="$(printf '%s' '${{ github.repository }}-pr-${{ github.event.number }}-redis' | sha256sum | cut -c1-32)"
+
+          if ! flyctl apps show "$REDIS_APP" > /dev/null 2>&1; then
+            flyctl apps create "$REDIS_APP"
+          fi
+
+          # Ensure a machine exists for this Redis app.
+          MACHINE_COUNT="$(flyctl machine list -a "$REDIS_APP" --json | jq 'length')"
+          if [ "$MACHINE_COUNT" = "0" ]; then
+            flyctl machine run flyio/redis:6.2 \
+              --app "$REDIS_APP" \
+              --region lhr \
+              --name redis \
+              --env REDIS_PASSWORD="$REDIS_PASSWORD" \
+              --env PRIMARY_REGION=lhr
+          fi
+
+          echo "redis_app=$REDIS_APP" >> "$GITHUB_OUTPUT"
+          echo "redis_url=redis://default:${REDIS_PASSWORD}@${REDIS_APP}.internal:6379" >> "$GITHUB_OUTPUT"
+
+  preflight:
+    name: Preflight checks (env + migrations)
+    needs: [setup, create_neon_branch, provision_redis]
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    env:
+      NODE_ENV: production
+      DATABASE_URL: ${{ needs.create_neon_branch.outputs.db_url_pooled }}
+      REDIS_URL: ${{ needs.provision_redis.outputs.redis_url }}
+      RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+      RESEND_FROM_EMAIL: ${{ secrets.RESEND_FROM_EMAIL }}
+      APP_NAME: Tripdly API Preview
+      DOMAIN: ${{ needs.setup.outputs.preview_url }}
+      TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
+      TWILIO_AUTH_TOKEN: ${{ secrets.TWILIO_AUTH_TOKEN }}
+      TWILIO_SECRET: ${{ secrets.TWILIO_SECRET }}
+      TWILIO_WHATSAPP_NUMBER: ${{ secrets.TWILIO_WHATSAPP_NUMBER }}
+      TWILIO_WEBHOOK_URL: ${{ needs.setup.outputs.preview_url }}/api/webhook/twilio
+      FLUTTERWAVE_SECRET_KEY: ${{ secrets.FLUTTERWAVE_SECRET_KEY }}
+      FLUTTERWAVE_PUBLIC_KEY: ${{ secrets.FLUTTERWAVE_PUBLIC_KEY }}
+      FLUTTERWAVE_BASE_URL: https://api.flutterwave.com
+      FLUTTERWAVE_WEBHOOK_SECRET: ${{ secrets.FLUTTERWAVE_WEBHOOK_SECRET }}
+      FLUTTERWAVE_WEBHOOK_URL: ${{ needs.setup.outputs.preview_url }}/api/webhook/flutterwave
+      HMAC_KEY: ${{ secrets.HMAC_KEY }}
+      FLIGHTAWARE_API_KEY: ${{ secrets.FLIGHTAWARE_API_KEY }}
+      FLIGHTAWARE_WEBHOOK_SECRET: ${{ secrets.FLIGHTAWARE_WEBHOOK_SECRET }}
+      GOOGLE_DISTANCE_MATRIX_API_KEY: ${{ secrets.GOOGLE_DISTANCE_MATRIX_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
+      AUTH_BASE_URL: ${{ needs.setup.outputs.preview_url }}
+      TRUSTED_ORIGINS: ${{ needs.setup.outputs.preview_url }}
+      SENDER_NAME: Yomide
+      AWS_REGION: eu-west-2
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_BUCKET_NAME: s3-car-rentals-dev-bucket
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      ENABLE_MANUAL_TRIGGERS: "false"
+      API_KEY: ${{ secrets.API_KEY }}
+      BULL_BOARD_USERNAME: ${{ secrets.BULL_BOARD_USERNAME }}
+      BULL_BOARD_PASSWORD: ${{ secrets.BULL_BOARD_PASSWORD }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.20.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Prisma migrations on preview branch
+        run: pnpm exec prisma migrate deploy
+
+      - name: Build app
+        run: pnpm build
+
+      - name: Validate required env keys from canonical schema
+        run: |
+          node -e "const { validateEnvironment } = require('./dist/config/env.config.js'); validateEnvironment(process.env); console.log('Environment schema validation passed.');"
+
+  deploy_preview:
+    name: Deploy Fly preview app
+    needs: [setup, create_neon_branch, provision_redis, preflight]
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Deploy PR app to Fly.io
+        id: deploy
+        uses: superfly/fly-pr-review-apps@1.2.1
+        with:
+          name: ${{ needs.setup.outputs.preview_app }}
+          config: fly.preview.toml
+          secrets: >-
+            NODE_ENV=production
+            DATABASE_URL=${{ needs.create_neon_branch.outputs.db_url_pooled }}
+            REDIS_URL=${{ needs.provision_redis.outputs.redis_url }}
+            RESEND_API_KEY=${{ secrets.RESEND_API_KEY }}
+            RESEND_FROM_EMAIL=${{ secrets.RESEND_FROM_EMAIL }}
+            APP_NAME=Tripdly API Preview
+            DOMAIN=${{ needs.setup.outputs.preview_url }}
+            TWILIO_ACCOUNT_SID=${{ secrets.TWILIO_ACCOUNT_SID }}
+            TWILIO_AUTH_TOKEN=${{ secrets.TWILIO_AUTH_TOKEN }}
+            TWILIO_SECRET=${{ secrets.TWILIO_SECRET }}
+            TWILIO_WHATSAPP_NUMBER=${{ secrets.TWILIO_WHATSAPP_NUMBER }}
+            TWILIO_WEBHOOK_URL=${{ needs.setup.outputs.preview_url }}/api/webhook/twilio
+            FLUTTERWAVE_SECRET_KEY=${{ secrets.FLUTTERWAVE_SECRET_KEY }}
+            FLUTTERWAVE_PUBLIC_KEY=${{ secrets.FLUTTERWAVE_PUBLIC_KEY }}
+            FLUTTERWAVE_BASE_URL=https://api.flutterwave.com
+            FLUTTERWAVE_WEBHOOK_SECRET=${{ secrets.FLUTTERWAVE_WEBHOOK_SECRET }}
+            FLUTTERWAVE_WEBHOOK_URL=${{ needs.setup.outputs.preview_url }}/api/webhook/flutterwave
+            HMAC_KEY=${{ secrets.HMAC_KEY }}
+            FLIGHTAWARE_API_KEY=${{ secrets.FLIGHTAWARE_API_KEY }}
+            FLIGHTAWARE_WEBHOOK_SECRET=${{ secrets.FLIGHTAWARE_WEBHOOK_SECRET }}
+            GOOGLE_DISTANCE_MATRIX_API_KEY=${{ secrets.GOOGLE_DISTANCE_MATRIX_API_KEY }}
+            OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
+            SESSION_SECRET=${{ secrets.SESSION_SECRET }}
+            AUTH_BASE_URL=${{ needs.setup.outputs.preview_url }}
+            TRUSTED_ORIGINS=${{ needs.setup.outputs.preview_url }}
+            SENDER_NAME=Yomide
+            AWS_REGION=eu-west-2
+            AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            AWS_BUCKET_NAME=s3-car-rentals-dev-bucket
+            ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
+            ENABLE_MANUAL_TRIGGERS=false
+            API_KEY=${{ secrets.API_KEY }}
+            BULL_BOARD_USERNAME=${{ secrets.BULL_BOARD_USERNAME }}
+            BULL_BOARD_PASSWORD=${{ secrets.BULL_BOARD_PASSWORD }}
+
+  cleanup:
+    name: Delete preview resources
+    needs: setup
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    env:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+    steps:
+      - name: Delete Neon branch
+        uses: neondatabase/delete-branch-action@c2005bb7d7caeba12ba3ec63857e9c9f9a4d695a
+        with:
+          project_id: ${{ vars.NEON_PROJECT_ID }}
+          branch: ${{ needs.setup.outputs.neon_branch }}
+          api_key: ${{ secrets.NEON_API_KEY }}
+
+      - name: Setup Fly.io CLI
+        uses: superfly/flyctl-actions/setup-flyctl@v1.4
+
+      - name: Destroy Fly preview app
+        run: flyctl apps destroy "${{ needs.setup.outputs.preview_app }}" --yes || true
+
+      - name: Destroy PR Redis app
+        run: flyctl apps destroy "hyre-worker-redis-pr-${{ github.event.number }}" --yes || true

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ lerna-debug.log*
 .env.development
 .env.test
 .env.production
+.env.preview
 
 # temp directory
 .temp
@@ -28,3 +29,6 @@ lerna-debug.log*
 
 *.md
 !README.md
+
+scripts/deploy-secrets.sh
+scripts/set-preview-secrets.sh

--- a/fly.preview.toml
+++ b/fly.preview.toml
@@ -4,6 +4,7 @@
 primary_region = "lhr"
 
 [env]
+  # Intentional: app/business logic uses Lagos local time while Fly region uses nearest suitable region.
   TZ = "Africa/Lagos"
 
 [http_service]

--- a/fly.preview.toml
+++ b/fly.preview.toml
@@ -1,0 +1,20 @@
+# Preview Fly config for PR environments.
+# App name is injected by the review-app GitHub action.
+
+primary_region = "lhr"
+
+[env]
+  TZ = "Africa/Lagos"
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+
+[[vm]]
+  cpu_kind = "shared"
+  cpus = 1
+  memory = "512mb"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.994.0",
+    "@aws-sdk/client-s3": "^3.1014.0",
     "@better-auth/prisma-adapter": "^1.5.3",
     "@bull-board/api": "^6.14.0",
     "@bull-board/express": "^6.14.0",
@@ -37,10 +37,10 @@
     "@langchain/langgraph-checkpoint": "^1.0.0",
     "@langchain/openai": "^1.2.11",
     "@nestjs/bullmq": "^11.0.4",
-    "@nestjs/common": "^11.1.8",
+    "@nestjs/common": "^11.1.17",
     "@nestjs/config": "^4.0.2",
-    "@nestjs/core": "^11.1.8",
-    "@nestjs/platform-express": "^11.1.16",
+    "@nestjs/core": "^11.1.17",
+    "@nestjs/platform-express": "^11.1.17",
     "@nestjs/schedule": "^6.0.1",
     "@nestjs/terminus": "^11.0.0",
     "@nestjs/throttler": "^6.4.0",
@@ -79,7 +79,7 @@
     "@flydotio/dockerfile": "^0.7.10",
     "@nestjs/cli": "^10.4.9",
     "@nestjs/schematics": "^10.2.3",
-    "@nestjs/testing": "^11.1.8",
+    "@nestjs/testing": "^11.1.17",
     "@swc/core": "^1.13.5",
     "@testcontainers/postgresql": "^11.8.0",
     "@testcontainers/redis": "^11.8.0",
@@ -107,7 +107,8 @@
   "pnpm": {
     "overrides": {
       "body-parser": "2.2.1",
-      "flatted": "3.4.0",
+      "fast-xml-parser": "5.5.7",
+      "flatted": "3.4.2",
       "lodash": "4.17.23",
       "minimatch": "10.2.3",
       "multer": "2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,8 @@ settings:
 
 overrides:
   body-parser: 2.2.1
-  flatted: 3.4.0
+  fast-xml-parser: 5.5.7
+  flatted: 3.4.2
   lodash: 4.17.23
   minimatch: 10.2.3
   multer: 2.1.1
@@ -18,8 +19,8 @@ importers:
   .:
     dependencies:
       '@aws-sdk/client-s3':
-        specifier: ^3.994.0
-        version: 3.1009.0
+        specifier: ^3.1014.0
+        version: 3.1014.0
       '@better-auth/prisma-adapter':
         specifier: ^1.5.3
         version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))
@@ -31,7 +32,7 @@ importers:
         version: 6.20.5
       '@bull-board/nestjs':
         specifier: ^6.14.0
-        version: 6.20.5(@bull-board/api@6.20.5(@bull-board/ui@6.20.5))(@nestjs/bull-shared@11.0.4(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.16))(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.16)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+        version: 6.20.5(@bull-board/api@6.20.5(@bull-board/ui@6.20.5))(@nestjs/bull-shared@11.0.4(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.17))(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.17)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       '@date-fns/utc':
         specifier: ^2.1.1
         version: 2.1.1
@@ -52,28 +53,28 @@ importers:
         version: 1.2.13(@langchain/core@1.1.32(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.211.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.29.0(zod@4.3.6)))
       '@nestjs/bullmq':
         specifier: ^11.0.4
-        version: 11.0.4(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.16)(bullmq@5.71.0)
+        version: 11.0.4(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.17)(bullmq@5.71.0)
       '@nestjs/common':
-        specifier: ^11.1.8
-        version: 11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2)
+        specifier: ^11.1.17
+        version: 11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2)
       '@nestjs/config':
         specifier: ^4.0.2
-        version: 4.0.3(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(rxjs@7.8.2)
+        version: 4.0.3(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(rxjs@7.8.2)
       '@nestjs/core':
-        specifier: ^11.1.8
-        version: 11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+        specifier: ^11.1.17
+        version: 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       '@nestjs/platform-express':
-        specifier: ^11.1.16
-        version: 11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.16)
+        specifier: ^11.1.17
+        version: 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.17)
       '@nestjs/schedule':
         specifier: ^6.0.1
-        version: 6.1.1(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.16)
+        version: 6.1.1(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.17)
       '@nestjs/terminus':
         specifier: ^11.0.0
-        version: 11.1.1(@grpc/grpc-js@1.14.3)(@grpc/proto-loader@0.8.0)(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.16)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(reflect-metadata@0.1.14)(rxjs@7.8.2)
+        version: 11.1.1(@grpc/grpc-js@1.14.3)(@grpc/proto-loader@0.8.0)(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.17)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(reflect-metadata@0.1.14)(rxjs@7.8.2)
       '@nestjs/throttler':
         specifier: ^6.4.0
-        version: 6.5.0(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.16)(reflect-metadata@0.1.14)
+        version: 6.5.0(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.17)(reflect-metadata@0.1.14)
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.0
@@ -124,7 +125,7 @@ importers:
         version: 5.10.0
       nestjs-pino:
         specifier: ^4.5.0
-        version: 4.6.1(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(pino-http@11.0.0)(pino@10.3.1)(rxjs@7.8.2)
+        version: 4.6.1(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(pino-http@11.0.0)(pino@10.3.1)(rxjs@7.8.2)
       openai:
         specifier: ^6.22.0
         version: 6.29.0(zod@4.3.6)
@@ -175,8 +176,8 @@ importers:
         specifier: ^10.2.3
         version: 10.2.3(chokidar@3.6.0)(typescript@5.9.3)
       '@nestjs/testing':
-        specifier: ^11.1.8
-        version: 11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.16)(@nestjs/platform-express@11.1.16)
+        specifier: ^11.1.17
+        version: 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.17)(@nestjs/platform-express@11.1.17)
       '@swc/core':
         specifier: ^1.13.5
         version: 1.15.18
@@ -294,48 +295,48 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
-  '@aws-sdk/client-s3@3.1009.0':
-    resolution: {integrity: sha512-luy8CxallkoiGWTqU86ca/BbvkWJjs0oala7uIIRN1JtQxMb5i4Yl/PBZVcQFhbK9kQi0PK0GfD8gIpLkI91fw==}
+  '@aws-sdk/client-s3@3.1014.0':
+    resolution: {integrity: sha512-0XLrOT4Cm3NEhhiME7l/8LbTXS4KdsbR4dSrY207KNKTcHLLTZ9EXt4ZpgnTfLvWQF3pGP2us4Zi1fYLo0N+Ow==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/core@3.973.20':
-    resolution: {integrity: sha512-i3GuX+lowD892F3IuJf8o6AbyDupMTdyTxQrCJGcn71ni5hTZ82L4nQhcdumxZ7XPJRJJVHS/CR3uYOIIs0PVA==}
+  '@aws-sdk/core@3.973.23':
+    resolution: {integrity: sha512-aoJncvD1XvloZ9JLnKqTRL9dBy+Szkryoag9VT+V1TqsuUgIxV9cnBVM/hrDi2vE8bDqLiDR8nirdRcCdtJu0w==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/crc64-nvme@3.972.5':
     resolution: {integrity: sha512-2VbTstbjKdT+yKi8m7b3a9CiVac+pL/IY2PHJwsaGkkHmuuqkJZIErPck1h6P3T9ghQMLSdMPyW6Qp7Di5swFg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-env@3.972.18':
-    resolution: {integrity: sha512-X0B8AlQY507i5DwjLByeU2Af4ARsl9Vr84koDcXCbAkplmU+1xBFWxEPrWRAoh56waBne/yJqEloSwvRf4x6XA==}
+  '@aws-sdk/credential-provider-env@3.972.21':
+    resolution: {integrity: sha512-BkAfKq8Bd4shCtec1usNz//urPJF/SZy14qJyxkSaRJQ/Vv1gVh0VZSTmS7aE6aLMELkFV5wHHrS9ZcdG8Kxsg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-http@3.972.20':
-    resolution: {integrity: sha512-ey9Lelj001+oOfrbKmS6R2CJAiXX7QKY4Vj9VJv6L2eE6/VjD8DocHIoYqztTm70xDLR4E1jYPTKfIui+eRNDA==}
+  '@aws-sdk/credential-provider-http@3.972.23':
+    resolution: {integrity: sha512-4XZ3+Gu5DY8/n8zQFHBgcKTF7hWQl42G6CY9xfXVo2d25FM/lYkpmuzhYopYoPL1ITWkJ2OSBQfYEu5JRfHOhA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-ini@3.972.20':
-    resolution: {integrity: sha512-5flXSnKHMloObNF+9N0cupKegnH1Z37cdVlpETVgx8/rAhCe+VNlkcZH3HDg2SDn9bI765S+rhNPXGDJJPfbtA==}
+  '@aws-sdk/credential-provider-ini@3.972.23':
+    resolution: {integrity: sha512-PZLSmU0JFpNCDFReidBezsgL5ji9jOBry8CnZdw4Jj6d0K2z3Ftnp44NXgADqYx5BLMu/ZHujfeJReaDoV+IwQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-login@3.972.20':
-    resolution: {integrity: sha512-gEWo54nfqp2jABMu6HNsjVC4hDLpg9HC8IKSJnp0kqWtxIJYHTmiLSsIfI4ScQjxEwpB+jOOH8dOLax1+hy/Hw==}
+  '@aws-sdk/credential-provider-login@3.972.23':
+    resolution: {integrity: sha512-OmE/pSkbMM3dCj1HdOnZ5kXnKK+R/Yz+kbBugraBecp0pGAs21eEURfQRz+1N2gzIHLVyGIP1MEjk/uSrFsngg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-node@3.972.21':
-    resolution: {integrity: sha512-hah8if3/B/Q+LBYN5FukyQ1Mym6PLPDsBOBsIgNEYD6wLyZg0UmUF/OKIVC3nX9XH8TfTPuITK+7N/jenVACWA==}
+  '@aws-sdk/credential-provider-node@3.972.24':
+    resolution: {integrity: sha512-9Jwi7aps3AfUicJyF5udYadPypPpCwUZ6BSKr/QjRbVCpRVS1wc+1Q6AEZ/qz8J4JraeRd247pSzyMQSIHVebw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-process@3.972.18':
-    resolution: {integrity: sha512-Tpl7SRaPoOLT32jbTWchPsn52hYYgJ0kpiFgnwk8pxTANQdUymVSZkzFvv1+oOgZm1CrbQUP9MBeoMZ9IzLZjA==}
+  '@aws-sdk/credential-provider-process@3.972.21':
+    resolution: {integrity: sha512-nRxbeOJ1E1gVA0lNQezuMVndx+ZcuyaW/RB05pUsznN5BxykSlH6KkZ/7Ca/ubJf3i5N3p0gwNO5zgPSCzj+ww==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-sso@3.972.20':
-    resolution: {integrity: sha512-p+R+PYR5Z7Gjqf/6pvbCnzEHcqPCpLzR7Yf127HjJ6EAb4hUcD+qsNRnuww1sB/RmSeCLxyay8FMyqREw4p1RA==}
+  '@aws-sdk/credential-provider-sso@3.972.23':
+    resolution: {integrity: sha512-APUccADuYPLL0f2htpM8Z4czabSmHOdo4r41W6lKEZdy++cNJ42Radqy6x4TopENzr3hR6WYMyhiuiqtbf/nAA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-web-identity@3.972.20':
-    resolution: {integrity: sha512-rWCmh8o7QY4CsUj63qopzMzkDq/yPpkrpb+CnjBEFSOg/02T/we7sSTVg4QsDiVS9uwZ8VyONhq98qt+pIh3KA==}
+  '@aws-sdk/credential-provider-web-identity@3.972.23':
+    resolution: {integrity: sha512-H5JNqtIwOu/feInmMMWcK0dL5r897ReEn7n2m16Dd0DPD9gA2Hg8Cq4UDzZ/9OzaLh/uqBM6seixz0U6Fi2Eag==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-bucket-endpoint@3.972.8':
@@ -346,8 +347,8 @@ packages:
     resolution: {integrity: sha512-5DTBTiotEES1e2jOHAq//zyzCjeMB78lEHd35u15qnrid4Nxm7diqIf9fQQ3Ov0ChH1V3Vvt13thOnrACmfGVQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-flexible-checksums@3.973.6':
-    resolution: {integrity: sha512-0nYEgkJH7Yt9k+nZJyllTghnkKaz17TWFcr5Mi0XMVMzYlF4ytDZADQpF2/iJo36cKL5AYSzRsvlykE4M/ErTA==}
+  '@aws-sdk/middleware-flexible-checksums@3.974.3':
+    resolution: {integrity: sha512-fB7FNLH1+VPUs0QL3PLrHW+DD4gKu6daFgWtyq3R0Y0Lx8DLZPvyGAxCZNFBxH+M2xt9KvBJX6USwjuqvitmCQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-host-header@3.972.8':
@@ -366,32 +367,32 @@ packages:
     resolution: {integrity: sha512-BnnvYs2ZEpdlmZ2PNlV2ZyQ8j8AEkMTjN79y/YA475ER1ByFYrkVR85qmhni8oeTaJcDqbx364wDpitDAA/wCA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-sdk-s3@3.972.20':
-    resolution: {integrity: sha512-yhva/xL5H4tWQgsBjwV+RRD0ByCzg0TcByDCLp3GXdn/wlyRNfy8zsswDtCvr1WSKQkSQYlyEzPuWkJG0f5HvQ==}
+  '@aws-sdk/middleware-sdk-s3@3.972.23':
+    resolution: {integrity: sha512-50QgHGPQAb2veqFOmTF1A3GsAklLHZXL47KbY35khIkfbXH5PLvqpEc/gOAEBPj/yFxrlgxz/8mqWcWTNxBkwQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-ssec@3.972.8':
     resolution: {integrity: sha512-wqlK0yO/TxEC2UsY9wIlqeeutF6jjLe0f96Pbm40XscTo57nImUk9lBcw0dPgsm0sppFtAkSlDrfpK+pC30Wqw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-user-agent@3.972.21':
-    resolution: {integrity: sha512-62XRl1GDYPpkt7cx1AX1SPy9wgNE9Iw/NPuurJu4lmhCWS7sGKO+kS53TQ8eRmIxy3skmvNInnk0ZbWrU5Dpyg==}
+  '@aws-sdk/middleware-user-agent@3.972.24':
+    resolution: {integrity: sha512-dLTWy6IfAMhNiSEvMr07g/qZ54be6pLqlxVblbF6AzafmmGAzMMj8qMoY9B4+YgT+gY9IcuxZslNh03L6PyMCQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/nested-clients@3.996.10':
-    resolution: {integrity: sha512-SlDol5Z+C7Ivnc2rKGqiqfSUmUZzY1qHfVs9myt/nxVwswgfpjdKahyTzLTx802Zfq0NFRs7AejwKzzzl5Co2w==}
+  '@aws-sdk/nested-clients@3.996.13':
+    resolution: {integrity: sha512-ptZ1HF4yYHNJX8cgFF+8NdYO69XJKZn7ft0/ynV3c0hCbN+89fAbrLS+fqniU2tW8o9Kfqhj8FUh+IPXb2Qsuw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/region-config-resolver@3.972.8':
-    resolution: {integrity: sha512-1eD4uhTDeambO/PNIDVG19A6+v4NdD7xzwLHDutHsUqz0B+i661MwQB2eYO4/crcCvCiQG4SRm1k81k54FEIvw==}
+  '@aws-sdk/region-config-resolver@3.972.9':
+    resolution: {integrity: sha512-eQ+dFU05ZRC/lC2XpYlYSPlXtX3VT8sn5toxN2Fv7EXlMoA2p9V7vUBKqHunfD4TRLpxUq8Y8Ol/nCqiv327Ng==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/signature-v4-multi-region@3.996.8':
-    resolution: {integrity: sha512-n1qYFD+tbqZuyskVaxUE+t10AUz9g3qzDw3Tp6QZDKmqsjfDmZBd4GIk2EKJJNtcCBtE5YiUjDYA+3djFAFBBg==}
+  '@aws-sdk/signature-v4-multi-region@3.996.11':
+    resolution: {integrity: sha512-SKgZY7x6AloLUXO20FJGnkKJ3a6CXzNDt6PYs2yqoPzgU0xKWcUoGGJGEBTsfM5eihKW42lbwp+sXzACLbSsaA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/token-providers@3.1009.0':
-    resolution: {integrity: sha512-KCPLuTqN9u0Rr38Arln78fRG9KXpzsPWmof+PZzfAHMMQq2QED6YjQrkrfiH7PDefLWEposY1o4/eGwrmKA4JA==}
+  '@aws-sdk/token-providers@3.1014.0':
+    resolution: {integrity: sha512-gHTHNUoaOGNrSWkl32A7wFsU78jlNTlqMccLu0byUk5CysYYXaxNMIonIVr4YcykC7vgtDS5ABuz83giy6fzJA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.6':
@@ -413,8 +414,8 @@ packages:
   '@aws-sdk/util-user-agent-browser@3.972.8':
     resolution: {integrity: sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==}
 
-  '@aws-sdk/util-user-agent-node@3.973.7':
-    resolution: {integrity: sha512-Hz6EZMUAEzqUd7e+vZ9LE7mn+5gMbxltXy18v+YSFY+9LBJz15wkNZvw5JqfX3z0FS9n3bgUtz3L5rAsfh4YlA==}
+  '@aws-sdk/util-user-agent-node@3.973.10':
+    resolution: {integrity: sha512-E99zeTscCc+pTMfsvnfi6foPpKmdD1cZfOC7/P8UUrjsoQdg9VEWPRD+xdFduKnfPXwcvby58AlO9jwwF6U96g==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       aws-crt: '>=1.0.0'
@@ -422,8 +423,8 @@ packages:
       aws-crt:
         optional: true
 
-  '@aws-sdk/xml-builder@3.972.11':
-    resolution: {integrity: sha512-iitV/gZKQMvY9d7ovmyFnFuTHbBAtrmLnvaSb/3X8vOKyevwtpmEtyc8AdhVWZe0pI/1GsHxlEvQeOePFzy7KQ==}
+  '@aws-sdk/xml-builder@3.972.15':
+    resolution: {integrity: sha512-PxMRlCFNiQnke9YR29vjFQwz4jq+6Q04rOVFeTDR2K7Qpv9h9FOWOxG+zJjageimYbWqE3bTuLjmryWHAWbvaA==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.4':
@@ -1169,8 +1170,8 @@ packages:
       '@swc/core':
         optional: true
 
-  '@nestjs/common@11.1.16':
-    resolution: {integrity: sha512-JSIeW+USuMJkkcNbiOdcPkVCeI3TSnXstIVEPpp3HiaKnPRuSbUUKm9TY9o/XpIcPHWUOQItAtC5BiAwFdVITQ==}
+  '@nestjs/common@11.1.17':
+    resolution: {integrity: sha512-hLODw5Abp8OQgA+mUO4tHou4krKgDtUcM9j5Ihxncst9XeyxYBTt2bwZm4e4EQr5E352S4Fyy6V3iFx9ggxKAg==}
     peerDependencies:
       class-transformer: '>=0.4.1'
       class-validator: '>=0.13.2'
@@ -1188,8 +1189,8 @@ packages:
       '@nestjs/common': ^10.0.0 || ^11.0.0
       rxjs: ^7.1.0
 
-  '@nestjs/core@11.1.16':
-    resolution: {integrity: sha512-tXWXyCiqWthelJjrE0KLFjf0O98VEt+WPVx5CrqCf+059kIxJ8y1Vw7Cy7N4fwQafWNrmFL2AfN87DDMbVAY0w==}
+  '@nestjs/core@11.1.17':
+    resolution: {integrity: sha512-lD5mAYekTTurF3vDaa8C2OKPnjiz4tsfxIc5XlcSUzOhkwWf6Ay3HKvt6FmvuWQam6uIIHX52Clg+e6tAvf/cg==}
     engines: {node: '>= 20'}
     peerDependencies:
       '@nestjs/common': ^11.0.0
@@ -1206,8 +1207,8 @@ packages:
       '@nestjs/websockets':
         optional: true
 
-  '@nestjs/platform-express@11.1.16':
-    resolution: {integrity: sha512-IOegr5+ZfUiMKgk+garsSU4MOkPRhm46e6w8Bp1GcO4vCdl9Piz6FlWAzKVfa/U3Hn/DdzSVJOW3TWcQQFdBDw==}
+  '@nestjs/platform-express@11.1.17':
+    resolution: {integrity: sha512-mAf4eOsSBsTOn/VbrUO1gsjW6dVh91qqXPMXun4dN8SnNjf7PTQagM9o8d6ab8ZBpNe6UdZftdrZoDetU+n4Qg==}
     peerDependencies:
       '@nestjs/common': ^11.0.0
       '@nestjs/core': ^11.0.0
@@ -1271,8 +1272,8 @@ packages:
       typeorm:
         optional: true
 
-  '@nestjs/testing@11.1.16':
-    resolution: {integrity: sha512-E7/aUCxzeMSJV80L5GWGIuiMyR/1ncS7uOIetAImfbS4ATE1/h2GBafk0qpk+vjFtPIbtoh9BWDGICzUEU5jDA==}
+  '@nestjs/testing@11.1.17':
+    resolution: {integrity: sha512-lNffw+z+2USewmw4W0tsK+Rq94A2N4PiHbcqoRUu5y8fnqxQeIWGHhjo5BFCqj7eivqJBhT7WdRydxVq4rAHzg==}
     peerDependencies:
       '@nestjs/common': ^11.0.0
       '@nestjs/core': ^11.0.0
@@ -2213,12 +2214,12 @@ packages:
     resolution: {integrity: sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/config-resolver@4.4.11':
-    resolution: {integrity: sha512-YxFiiG4YDAtX7WMN7RuhHZLeTmRRAOyCbr+zB8e3AQzHPnUhS8zXjB1+cniPVQI3xbWsQPM0X2aaIkO/ME0ymw==}
+  '@smithy/config-resolver@4.4.13':
+    resolution: {integrity: sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/core@3.23.11':
-    resolution: {integrity: sha512-952rGf7hBRnhUIaeLp6q4MptKW8sPFe5VvkoZ5qIzFAtx6c/QZ/54FS3yootsyUSf9gJX/NBqEBNdNR7jMIlpQ==}
+  '@smithy/core@3.23.12':
+    resolution: {integrity: sha512-o9VycsYNtgC+Dy3I0yrwCqv9CWicDnke0L7EVOrZtJpjb2t0EjaEofmMrYc0T1Kn3yk32zm6cspxF9u9Bj7e5w==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/credential-provider-imds@4.2.12':
@@ -2281,16 +2282,16 @@ packages:
     resolution: {integrity: sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-endpoint@4.4.25':
-    resolution: {integrity: sha512-dqjLwZs2eBxIUG6Qtw8/YZ4DvzHGIf0DA18wrgtfP6a50UIO7e2nY0FPdcbv5tVJKqWCCU5BmGMOUwT7Puan+A==}
+  '@smithy/middleware-endpoint@4.4.27':
+    resolution: {integrity: sha512-T3TFfUgXQlpcg+UdzcAISdZpj4Z+XECZ/cefgA6wLBd6V4lRi0svN2hBouN/be9dXQ31X4sLWz3fAQDf+nt6BA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-retry@4.4.42':
-    resolution: {integrity: sha512-vbwyqHRIpIZutNXZpLAozakzamcINaRCpEy1MYmK6xBeW3xN+TyPRA123GjXnuxZIjc9848MRRCugVMTXxC4Eg==}
+  '@smithy/middleware-retry@4.4.44':
+    resolution: {integrity: sha512-Y1Rav7m5CFRPQyM4CI0koD/bXjyjJu3EQxZZhtLGD88WIrBrQ7kqXM96ncd6rYnojwOo/u9MXu57JrEvu/nLrA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-serde@4.2.14':
-    resolution: {integrity: sha512-+CcaLoLa5apzSRtloOyG7lQvkUw2ZDml3hRh4QiG9WyEPfW5Ke/3tPOPiPjUneuT59Tpn8+c3RVaUvvkkwqZwg==}
+  '@smithy/middleware-serde@4.2.15':
+    resolution: {integrity: sha512-ExYhcltZSli0pgAKOpQQe1DLFBLryeZ22605y/YS+mQpdNWekum9Ujb/jMKfJKgjtz1AZldtwA/wCYuKJgjjlg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-stack@4.2.12':
@@ -2301,8 +2302,8 @@ packages:
     resolution: {integrity: sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/node-http-handler@4.4.16':
-    resolution: {integrity: sha512-ULC8UCS/HivdCB3jhi+kLFYe4B5gxH2gi9vHBfEIiRrT2jfKiZNiETJSlzRtE6B26XbBHjPtc8iZKSNqMol9bw==}
+  '@smithy/node-http-handler@4.5.0':
+    resolution: {integrity: sha512-Rnq9vQWiR1+/I6NZZMNzJHV6pZYyEHt2ZnuV3MG8z2NNenC4i/8Kzttz7CjZiHSmsN5frhXhg17z3Zqjjhmz1A==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/property-provider@4.2.12':
@@ -2333,8 +2334,8 @@ packages:
     resolution: {integrity: sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/smithy-client@4.12.5':
-    resolution: {integrity: sha512-UqwYawyqSr/aog8mnLnfbPurS0gi4G7IYDcD28cUIBhsvWs1+rQcL2IwkUQ+QZ7dibaoRzhNF99fAQ9AUcO00w==}
+  '@smithy/smithy-client@4.12.7':
+    resolution: {integrity: sha512-q3gqnwml60G44FECaEEsdQMplYhDMZYCtYhMCzadCnRnnHIobZJjegmdoUo6ieLQlPUzvrMdIJUpx6DoPmzANQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.13.1':
@@ -2369,12 +2370,12 @@ packages:
     resolution: {integrity: sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-defaults-mode-browser@4.3.41':
-    resolution: {integrity: sha512-M1w1Ux0rSVvBOxIIiqbxvZvhnjQ+VUjJrugtORE90BbadSTH+jsQL279KRL3Hv0w69rE7EuYkV/4Lepz/NBW9g==}
+  '@smithy/util-defaults-mode-browser@4.3.43':
+    resolution: {integrity: sha512-Qd/0wCKMaXxev/z00TvNzGCH2jlKKKxXP1aDxB6oKwSQthe3Og2dMhSayGCnsma1bK/kQX1+X7SMP99t6FgiiQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-defaults-mode-node@4.2.44':
-    resolution: {integrity: sha512-YPze3/lD1KmWuZsl9JlfhcgGLX7AXhSoaCDtiPntUjNW5/YY0lOHjkcgxyE9x/h5vvS1fzDifMGjzqnNlNiqOQ==}
+  '@smithy/util-defaults-mode-node@4.2.47':
+    resolution: {integrity: sha512-qSRbYp1EQ7th+sPFuVcVO05AE0QH635hycdEXlpzIahqHHf2Fyd/Zl+8v0XYMJ3cgDVPa0lkMefU7oNUjAP+DQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-endpoints@3.3.3':
@@ -2393,8 +2394,8 @@ packages:
     resolution: {integrity: sha512-1zopLDUEOwumjcHdJ1mwBHddubYF8GMQvstVCLC54Y46rqoHwlIU+8ZzUeaBcD+WCJHyDGSeZ2ml9YSe9aqcoQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-stream@4.5.19':
-    resolution: {integrity: sha512-v4sa+3xTweL1CLO2UP0p7tvIMH/Rq1X4KKOxd568mpe6LSLMQCnDHs4uv7m3ukpl3HvcN2JH6jiCS0SNRXKP/w==}
+  '@smithy/util-stream@4.5.20':
+    resolution: {integrity: sha512-4yXLm5n/B5SRBR2p8cZ90Sbv4zL4NKsgxdzCzp/83cXw2KxLEumt5p+GAVyRNZgQOSrzXn9ARpO0lUe8XSlSDw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-uri-escape@4.2.2':
@@ -3638,11 +3639,11 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
-  fast-xml-builder@1.1.3:
-    resolution: {integrity: sha512-1o60KoFw2+LWKQu3IdcfcFlGTW4dpqEWmjhYec6H82AYZU2TVBXep6tMl8Z1Y+wM+ZrzCwe3BZ9Vyd9N2rIvmg==}
+  fast-xml-builder@1.1.4:
+    resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
 
-  fast-xml-parser@5.4.1:
-    resolution: {integrity: sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==}
+  fast-xml-parser@5.5.7:
+    resolution: {integrity: sha512-LteOsISQ2GEiDHZch6L9hB0+MLoYVLToR7xotrzU0opCICBkxOPgHAy1HxAvtxfJNXDJpgAsQN30mkrfpO2Prg==}
     hasBin: true
 
   fdir@6.5.0:
@@ -3661,8 +3662,8 @@ packages:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
     engines: {node: '>=8'}
 
-  file-type@21.3.0:
-    resolution: {integrity: sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA==}
+  file-type@21.3.2:
+    resolution: {integrity: sha512-DLkUvGwep3poOV2wpzbHCOnSKGk1LzyXTv+aHFgN2VFl96wnp8YA9YjO2qPzg5PuL8q/SW9Pdi6WTkYOIh995w==}
     engines: {node: '>=20'}
 
   filelist@1.0.6:
@@ -3676,8 +3677,8 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
-  flatted@3.4.0:
-    resolution: {integrity: sha512-kC6Bb+ooptOIvWj5B63EQWkF0FEnNjV2ZNkLMLZRDDduIiWeFF4iKnslwhiWxjAdbg4NzTNo6h0qLuvFrcx+Sw==}
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   follow-redirects@1.15.11:
     resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
@@ -4510,8 +4511,8 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
-  path-expression-matcher@1.1.3:
-    resolution: {integrity: sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==}
+  path-expression-matcher@1.2.0:
+    resolution: {integrity: sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==}
     engines: {node: '>=14.0.0'}
 
   path-key@3.1.1:
@@ -5574,31 +5575,31 @@ snapshots:
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
-  '@aws-sdk/client-s3@3.1009.0':
+  '@aws-sdk/client-s3@3.1014.0':
     dependencies:
       '@aws-crypto/sha1-browser': 5.2.0
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/credential-provider-node': 3.972.21
+      '@aws-sdk/core': 3.973.23
+      '@aws-sdk/credential-provider-node': 3.972.24
       '@aws-sdk/middleware-bucket-endpoint': 3.972.8
       '@aws-sdk/middleware-expect-continue': 3.972.8
-      '@aws-sdk/middleware-flexible-checksums': 3.973.6
+      '@aws-sdk/middleware-flexible-checksums': 3.974.3
       '@aws-sdk/middleware-host-header': 3.972.8
       '@aws-sdk/middleware-location-constraint': 3.972.8
       '@aws-sdk/middleware-logger': 3.972.8
       '@aws-sdk/middleware-recursion-detection': 3.972.8
-      '@aws-sdk/middleware-sdk-s3': 3.972.20
+      '@aws-sdk/middleware-sdk-s3': 3.972.23
       '@aws-sdk/middleware-ssec': 3.972.8
-      '@aws-sdk/middleware-user-agent': 3.972.21
-      '@aws-sdk/region-config-resolver': 3.972.8
-      '@aws-sdk/signature-v4-multi-region': 3.996.8
+      '@aws-sdk/middleware-user-agent': 3.972.24
+      '@aws-sdk/region-config-resolver': 3.972.9
+      '@aws-sdk/signature-v4-multi-region': 3.996.11
       '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.996.5
       '@aws-sdk/util-user-agent-browser': 3.972.8
-      '@aws-sdk/util-user-agent-node': 3.973.7
-      '@smithy/config-resolver': 4.4.11
-      '@smithy/core': 3.23.11
+      '@aws-sdk/util-user-agent-node': 3.973.10
+      '@smithy/config-resolver': 4.4.13
+      '@smithy/core': 3.23.12
       '@smithy/eventstream-serde-browser': 4.2.12
       '@smithy/eventstream-serde-config-resolver': 4.3.12
       '@smithy/eventstream-serde-node': 4.2.12
@@ -5609,41 +5610,41 @@ snapshots:
       '@smithy/invalid-dependency': 4.2.12
       '@smithy/md5-js': 4.2.12
       '@smithy/middleware-content-length': 4.2.12
-      '@smithy/middleware-endpoint': 4.4.25
-      '@smithy/middleware-retry': 4.4.42
-      '@smithy/middleware-serde': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.27
+      '@smithy/middleware-retry': 4.4.44
+      '@smithy/middleware-serde': 4.2.15
       '@smithy/middleware-stack': 4.2.12
       '@smithy/node-config-provider': 4.3.12
-      '@smithy/node-http-handler': 4.4.16
+      '@smithy/node-http-handler': 4.5.0
       '@smithy/protocol-http': 5.3.12
-      '@smithy/smithy-client': 4.12.5
+      '@smithy/smithy-client': 4.12.7
       '@smithy/types': 4.13.1
       '@smithy/url-parser': 4.2.12
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
       '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.41
-      '@smithy/util-defaults-mode-node': 4.2.44
+      '@smithy/util-defaults-mode-browser': 4.3.43
+      '@smithy/util-defaults-mode-node': 4.2.47
       '@smithy/util-endpoints': 3.3.3
       '@smithy/util-middleware': 4.2.12
       '@smithy/util-retry': 4.2.12
-      '@smithy/util-stream': 4.5.19
+      '@smithy/util-stream': 4.5.20
       '@smithy/util-utf8': 4.2.2
       '@smithy/util-waiter': 4.2.13
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/core@3.973.20':
+  '@aws-sdk/core@3.973.23':
     dependencies:
       '@aws-sdk/types': 3.973.6
-      '@aws-sdk/xml-builder': 3.972.11
-      '@smithy/core': 3.23.11
+      '@aws-sdk/xml-builder': 3.972.15
+      '@smithy/core': 3.23.12
       '@smithy/node-config-provider': 4.3.12
       '@smithy/property-provider': 4.2.12
       '@smithy/protocol-http': 5.3.12
       '@smithy/signature-v4': 5.3.12
-      '@smithy/smithy-client': 4.12.5
+      '@smithy/smithy-client': 4.12.7
       '@smithy/types': 4.13.1
       '@smithy/util-base64': 4.3.2
       '@smithy/util-middleware': 4.2.12
@@ -5655,37 +5656,37 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-env@3.972.18':
+  '@aws-sdk/credential-provider-env@3.972.21':
     dependencies:
-      '@aws-sdk/core': 3.973.20
+      '@aws-sdk/core': 3.973.23
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-http@3.972.20':
+  '@aws-sdk/credential-provider-http@3.972.23':
     dependencies:
-      '@aws-sdk/core': 3.973.20
+      '@aws-sdk/core': 3.973.23
       '@aws-sdk/types': 3.973.6
       '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/node-http-handler': 4.4.16
+      '@smithy/node-http-handler': 4.5.0
       '@smithy/property-provider': 4.2.12
       '@smithy/protocol-http': 5.3.12
-      '@smithy/smithy-client': 4.12.5
+      '@smithy/smithy-client': 4.12.7
       '@smithy/types': 4.13.1
-      '@smithy/util-stream': 4.5.19
+      '@smithy/util-stream': 4.5.20
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-ini@3.972.20':
+  '@aws-sdk/credential-provider-ini@3.972.23':
     dependencies:
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/credential-provider-env': 3.972.18
-      '@aws-sdk/credential-provider-http': 3.972.20
-      '@aws-sdk/credential-provider-login': 3.972.20
-      '@aws-sdk/credential-provider-process': 3.972.18
-      '@aws-sdk/credential-provider-sso': 3.972.20
-      '@aws-sdk/credential-provider-web-identity': 3.972.20
-      '@aws-sdk/nested-clients': 3.996.10
+      '@aws-sdk/core': 3.973.23
+      '@aws-sdk/credential-provider-env': 3.972.21
+      '@aws-sdk/credential-provider-http': 3.972.23
+      '@aws-sdk/credential-provider-login': 3.972.23
+      '@aws-sdk/credential-provider-process': 3.972.21
+      '@aws-sdk/credential-provider-sso': 3.972.23
+      '@aws-sdk/credential-provider-web-identity': 3.972.23
+      '@aws-sdk/nested-clients': 3.996.13
       '@aws-sdk/types': 3.973.6
       '@smithy/credential-provider-imds': 4.2.12
       '@smithy/property-provider': 4.2.12
@@ -5695,10 +5696,10 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-login@3.972.20':
+  '@aws-sdk/credential-provider-login@3.972.23':
     dependencies:
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/nested-clients': 3.996.10
+      '@aws-sdk/core': 3.973.23
+      '@aws-sdk/nested-clients': 3.996.13
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/protocol-http': 5.3.12
@@ -5708,14 +5709,14 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-node@3.972.21':
+  '@aws-sdk/credential-provider-node@3.972.24':
     dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.18
-      '@aws-sdk/credential-provider-http': 3.972.20
-      '@aws-sdk/credential-provider-ini': 3.972.20
-      '@aws-sdk/credential-provider-process': 3.972.18
-      '@aws-sdk/credential-provider-sso': 3.972.20
-      '@aws-sdk/credential-provider-web-identity': 3.972.20
+      '@aws-sdk/credential-provider-env': 3.972.21
+      '@aws-sdk/credential-provider-http': 3.972.23
+      '@aws-sdk/credential-provider-ini': 3.972.23
+      '@aws-sdk/credential-provider-process': 3.972.21
+      '@aws-sdk/credential-provider-sso': 3.972.23
+      '@aws-sdk/credential-provider-web-identity': 3.972.23
       '@aws-sdk/types': 3.973.6
       '@smithy/credential-provider-imds': 4.2.12
       '@smithy/property-provider': 4.2.12
@@ -5725,20 +5726,20 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-process@3.972.18':
+  '@aws-sdk/credential-provider-process@3.972.21':
     dependencies:
-      '@aws-sdk/core': 3.973.20
+      '@aws-sdk/core': 3.973.23
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-sso@3.972.20':
+  '@aws-sdk/credential-provider-sso@3.972.23':
     dependencies:
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/nested-clients': 3.996.10
-      '@aws-sdk/token-providers': 3.1009.0
+      '@aws-sdk/core': 3.973.23
+      '@aws-sdk/nested-clients': 3.996.13
+      '@aws-sdk/token-providers': 3.1014.0
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
@@ -5747,10 +5748,10 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-web-identity@3.972.20':
+  '@aws-sdk/credential-provider-web-identity@3.972.23':
     dependencies:
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/nested-clients': 3.996.10
+      '@aws-sdk/core': 3.973.23
+      '@aws-sdk/nested-clients': 3.996.13
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
@@ -5776,12 +5777,12 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-flexible-checksums@3.973.6':
+  '@aws-sdk/middleware-flexible-checksums@3.974.3':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
       '@aws-crypto/crc32c': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/core': 3.973.20
+      '@aws-sdk/core': 3.973.23
       '@aws-sdk/crc64-nvme': 3.972.5
       '@aws-sdk/types': 3.973.6
       '@smithy/is-array-buffer': 4.2.2
@@ -5789,7 +5790,7 @@ snapshots:
       '@smithy/protocol-http': 5.3.12
       '@smithy/types': 4.13.1
       '@smithy/util-middleware': 4.2.12
-      '@smithy/util-stream': 4.5.19
+      '@smithy/util-stream': 4.5.20
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
@@ -5820,20 +5821,20 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-sdk-s3@3.972.20':
+  '@aws-sdk/middleware-sdk-s3@3.972.23':
     dependencies:
-      '@aws-sdk/core': 3.973.20
+      '@aws-sdk/core': 3.973.23
       '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-arn-parser': 3.972.3
-      '@smithy/core': 3.23.11
+      '@smithy/core': 3.23.12
       '@smithy/node-config-provider': 4.3.12
       '@smithy/protocol-http': 5.3.12
       '@smithy/signature-v4': 5.3.12
-      '@smithy/smithy-client': 4.12.5
+      '@smithy/smithy-client': 4.12.7
       '@smithy/types': 4.13.1
       '@smithy/util-config-provider': 4.2.2
       '@smithy/util-middleware': 4.2.12
-      '@smithy/util-stream': 4.5.19
+      '@smithy/util-stream': 4.5.20
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
@@ -5843,52 +5844,52 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-user-agent@3.972.21':
+  '@aws-sdk/middleware-user-agent@3.972.24':
     dependencies:
-      '@aws-sdk/core': 3.973.20
+      '@aws-sdk/core': 3.973.23
       '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.996.5
-      '@smithy/core': 3.23.11
+      '@smithy/core': 3.23.12
       '@smithy/protocol-http': 5.3.12
       '@smithy/types': 4.13.1
       '@smithy/util-retry': 4.2.12
       tslib: 2.8.1
 
-  '@aws-sdk/nested-clients@3.996.10':
+  '@aws-sdk/nested-clients@3.996.13':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.20
+      '@aws-sdk/core': 3.973.23
       '@aws-sdk/middleware-host-header': 3.972.8
       '@aws-sdk/middleware-logger': 3.972.8
       '@aws-sdk/middleware-recursion-detection': 3.972.8
-      '@aws-sdk/middleware-user-agent': 3.972.21
-      '@aws-sdk/region-config-resolver': 3.972.8
+      '@aws-sdk/middleware-user-agent': 3.972.24
+      '@aws-sdk/region-config-resolver': 3.972.9
       '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.996.5
       '@aws-sdk/util-user-agent-browser': 3.972.8
-      '@aws-sdk/util-user-agent-node': 3.973.7
-      '@smithy/config-resolver': 4.4.11
-      '@smithy/core': 3.23.11
+      '@aws-sdk/util-user-agent-node': 3.973.10
+      '@smithy/config-resolver': 4.4.13
+      '@smithy/core': 3.23.12
       '@smithy/fetch-http-handler': 5.3.15
       '@smithy/hash-node': 4.2.12
       '@smithy/invalid-dependency': 4.2.12
       '@smithy/middleware-content-length': 4.2.12
-      '@smithy/middleware-endpoint': 4.4.25
-      '@smithy/middleware-retry': 4.4.42
-      '@smithy/middleware-serde': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.27
+      '@smithy/middleware-retry': 4.4.44
+      '@smithy/middleware-serde': 4.2.15
       '@smithy/middleware-stack': 4.2.12
       '@smithy/node-config-provider': 4.3.12
-      '@smithy/node-http-handler': 4.4.16
+      '@smithy/node-http-handler': 4.5.0
       '@smithy/protocol-http': 5.3.12
-      '@smithy/smithy-client': 4.12.5
+      '@smithy/smithy-client': 4.12.7
       '@smithy/types': 4.13.1
       '@smithy/url-parser': 4.2.12
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
       '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.41
-      '@smithy/util-defaults-mode-node': 4.2.44
+      '@smithy/util-defaults-mode-browser': 4.3.43
+      '@smithy/util-defaults-mode-node': 4.2.47
       '@smithy/util-endpoints': 3.3.3
       '@smithy/util-middleware': 4.2.12
       '@smithy/util-retry': 4.2.12
@@ -5897,27 +5898,27 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/region-config-resolver@3.972.8':
+  '@aws-sdk/region-config-resolver@3.972.9':
     dependencies:
       '@aws-sdk/types': 3.973.6
-      '@smithy/config-resolver': 4.4.11
+      '@smithy/config-resolver': 4.4.13
       '@smithy/node-config-provider': 4.3.12
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/signature-v4-multi-region@3.996.8':
+  '@aws-sdk/signature-v4-multi-region@3.996.11':
     dependencies:
-      '@aws-sdk/middleware-sdk-s3': 3.972.20
+      '@aws-sdk/middleware-sdk-s3': 3.972.23
       '@aws-sdk/types': 3.973.6
       '@smithy/protocol-http': 5.3.12
       '@smithy/signature-v4': 5.3.12
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/token-providers@3.1009.0':
+  '@aws-sdk/token-providers@3.1014.0':
     dependencies:
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/nested-clients': 3.996.10
+      '@aws-sdk/core': 3.973.23
+      '@aws-sdk/nested-clients': 3.996.13
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
@@ -5954,19 +5955,19 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/util-user-agent-node@3.973.7':
+  '@aws-sdk/util-user-agent-node@3.973.10':
     dependencies:
-      '@aws-sdk/middleware-user-agent': 3.972.21
+      '@aws-sdk/middleware-user-agent': 3.972.24
       '@aws-sdk/types': 3.973.6
       '@smithy/node-config-provider': 4.3.12
       '@smithy/types': 4.13.1
       '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/xml-builder@3.972.11':
+  '@aws-sdk/xml-builder@3.972.15':
     dependencies:
       '@smithy/types': 4.13.1
-      fast-xml-parser: 5.4.1
+      fast-xml-parser: 5.5.7
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.4': {}
@@ -6098,12 +6099,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@bull-board/nestjs@6.20.5(@bull-board/api@6.20.5(@bull-board/ui@6.20.5))(@nestjs/bull-shared@11.0.4(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.16))(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.16)(reflect-metadata@0.1.14)(rxjs@7.8.2)':
+  '@bull-board/nestjs@6.20.5(@bull-board/api@6.20.5(@bull-board/ui@6.20.5))(@nestjs/bull-shared@11.0.4(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.17))(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.17)(reflect-metadata@0.1.14)(rxjs@7.8.2)':
     dependencies:
       '@bull-board/api': 6.20.5(@bull-board/ui@6.20.5)
-      '@nestjs/bull-shared': 11.0.4(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.16)
-      '@nestjs/common': 11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/bull-shared': 11.0.4(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.17)
+      '@nestjs/common': 11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       reflect-metadata: 0.1.14
       rxjs: 7.8.2
 
@@ -6614,17 +6615,17 @@ snapshots:
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
     optional: true
 
-  '@nestjs/bull-shared@11.0.4(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.16)':
+  '@nestjs/bull-shared@11.0.4(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.17)':
     dependencies:
-      '@nestjs/common': 11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       tslib: 2.8.1
 
-  '@nestjs/bullmq@11.0.4(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.16)(bullmq@5.71.0)':
+  '@nestjs/bullmq@11.0.4(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.17)(bullmq@5.71.0)':
     dependencies:
-      '@nestjs/bull-shared': 11.0.4(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.16)
-      '@nestjs/common': 11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/bull-shared': 11.0.4(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.17)
+      '@nestjs/common': 11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       bullmq: 5.71.0
       tslib: 2.8.1
 
@@ -6656,9 +6657,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2)':
+  '@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2)':
     dependencies:
-      file-type: 21.3.0
+      file-type: 21.3.2
       iterare: 1.2.1
       load-esm: 1.0.3
       reflect-metadata: 0.1.14
@@ -6668,17 +6669,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@nestjs/config@4.0.3(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(rxjs@7.8.2)':
+  '@nestjs/config@4.0.3(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(rxjs@7.8.2)':
     dependencies:
-      '@nestjs/common': 11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2)
       dotenv: 17.2.3
       dotenv-expand: 12.0.3
       lodash: 4.17.23
       rxjs: 7.8.2
 
-  '@nestjs/core@11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.1.14)(rxjs@7.8.2)':
+  '@nestjs/core@11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.1.14)(rxjs@7.8.2)':
     dependencies:
-      '@nestjs/common': 11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2)
       '@nuxt/opencollective': 0.4.1
       fast-safe-stringify: 2.1.1
       iterare: 1.2.1
@@ -6688,12 +6689,12 @@ snapshots:
       tslib: 2.8.1
       uid: 2.0.2
     optionalDependencies:
-      '@nestjs/platform-express': 11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.16)
+      '@nestjs/platform-express': 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.17)
 
-  '@nestjs/platform-express@11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.16)':
+  '@nestjs/platform-express@11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.17)':
     dependencies:
-      '@nestjs/common': 11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       cors: 2.8.6
       express: 5.2.1
       multer: 2.1.1
@@ -6702,10 +6703,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@nestjs/schedule@6.1.1(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.16)':
+  '@nestjs/schedule@6.1.1(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.17)':
     dependencies:
-      '@nestjs/common': 11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       cron: 4.4.0
 
   '@nestjs/schematics@10.2.3(chokidar@3.6.0)(typescript@5.7.2)':
@@ -6730,10 +6731,10 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@nestjs/terminus@11.1.1(@grpc/grpc-js@1.14.3)(@grpc/proto-loader@0.8.0)(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.16)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(reflect-metadata@0.1.14)(rxjs@7.8.2)':
+  '@nestjs/terminus@11.1.1(@grpc/grpc-js@1.14.3)(@grpc/proto-loader@0.8.0)(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.17)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(reflect-metadata@0.1.14)(rxjs@7.8.2)':
     dependencies:
-      '@nestjs/common': 11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       boxen: 5.1.2
       check-disk-space: 3.4.0
       reflect-metadata: 0.1.14
@@ -6743,18 +6744,18 @@ snapshots:
       '@grpc/proto-loader': 0.8.0
       '@prisma/client': 6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3)
 
-  '@nestjs/testing@11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.16)(@nestjs/platform-express@11.1.16)':
+  '@nestjs/testing@11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.17)(@nestjs/platform-express@11.1.17)':
     dependencies:
-      '@nestjs/common': 11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       tslib: 2.8.1
     optionalDependencies:
-      '@nestjs/platform-express': 11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.16)
+      '@nestjs/platform-express': 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.17)
 
-  '@nestjs/throttler@6.5.0(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.16)(reflect-metadata@0.1.14)':
+  '@nestjs/throttler@6.5.0(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.17)(reflect-metadata@0.1.14)':
     dependencies:
-      '@nestjs/common': 11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       reflect-metadata: 0.1.14
 
   '@noble/ciphers@2.1.1': {}
@@ -7849,7 +7850,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/config-resolver@4.4.11':
+  '@smithy/config-resolver@4.4.13':
     dependencies:
       '@smithy/node-config-provider': 4.3.12
       '@smithy/types': 4.13.1
@@ -7858,7 +7859,7 @@ snapshots:
       '@smithy/util-middleware': 4.2.12
       tslib: 2.8.1
 
-  '@smithy/core@3.23.11':
+  '@smithy/core@3.23.12':
     dependencies:
       '@smithy/protocol-http': 5.3.12
       '@smithy/types': 4.13.1
@@ -7866,7 +7867,7 @@ snapshots:
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
       '@smithy/util-middleware': 4.2.12
-      '@smithy/util-stream': 4.5.19
+      '@smithy/util-stream': 4.5.20
       '@smithy/util-utf8': 4.2.2
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
@@ -7962,10 +7963,10 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/middleware-endpoint@4.4.25':
+  '@smithy/middleware-endpoint@4.4.27':
     dependencies:
-      '@smithy/core': 3.23.11
-      '@smithy/middleware-serde': 4.2.14
+      '@smithy/core': 3.23.12
+      '@smithy/middleware-serde': 4.2.15
       '@smithy/node-config-provider': 4.3.12
       '@smithy/shared-ini-file-loader': 4.4.7
       '@smithy/types': 4.13.1
@@ -7973,21 +7974,21 @@ snapshots:
       '@smithy/util-middleware': 4.2.12
       tslib: 2.8.1
 
-  '@smithy/middleware-retry@4.4.42':
+  '@smithy/middleware-retry@4.4.44':
     dependencies:
       '@smithy/node-config-provider': 4.3.12
       '@smithy/protocol-http': 5.3.12
       '@smithy/service-error-classification': 4.2.12
-      '@smithy/smithy-client': 4.12.5
+      '@smithy/smithy-client': 4.12.7
       '@smithy/types': 4.13.1
       '@smithy/util-middleware': 4.2.12
       '@smithy/util-retry': 4.2.12
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
-  '@smithy/middleware-serde@4.2.14':
+  '@smithy/middleware-serde@4.2.15':
     dependencies:
-      '@smithy/core': 3.23.11
+      '@smithy/core': 3.23.12
       '@smithy/protocol-http': 5.3.12
       '@smithy/types': 4.13.1
       tslib: 2.8.1
@@ -8004,7 +8005,7 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/node-http-handler@4.4.16':
+  '@smithy/node-http-handler@4.5.0':
     dependencies:
       '@smithy/abort-controller': 4.2.12
       '@smithy/protocol-http': 5.3.12
@@ -8053,14 +8054,14 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/smithy-client@4.12.5':
+  '@smithy/smithy-client@4.12.7':
     dependencies:
-      '@smithy/core': 3.23.11
-      '@smithy/middleware-endpoint': 4.4.25
+      '@smithy/core': 3.23.12
+      '@smithy/middleware-endpoint': 4.4.27
       '@smithy/middleware-stack': 4.2.12
       '@smithy/protocol-http': 5.3.12
       '@smithy/types': 4.13.1
-      '@smithy/util-stream': 4.5.19
+      '@smithy/util-stream': 4.5.20
       tslib: 2.8.1
 
   '@smithy/types@4.13.1':
@@ -8101,20 +8102,20 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/util-defaults-mode-browser@4.3.41':
+  '@smithy/util-defaults-mode-browser@4.3.43':
     dependencies:
       '@smithy/property-provider': 4.2.12
-      '@smithy/smithy-client': 4.12.5
+      '@smithy/smithy-client': 4.12.7
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/util-defaults-mode-node@4.2.44':
+  '@smithy/util-defaults-mode-node@4.2.47':
     dependencies:
-      '@smithy/config-resolver': 4.4.11
+      '@smithy/config-resolver': 4.4.13
       '@smithy/credential-provider-imds': 4.2.12
       '@smithy/node-config-provider': 4.3.12
       '@smithy/property-provider': 4.2.12
-      '@smithy/smithy-client': 4.12.5
+      '@smithy/smithy-client': 4.12.7
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
@@ -8139,10 +8140,10 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/util-stream@4.5.19':
+  '@smithy/util-stream@4.5.20':
     dependencies:
       '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/node-http-handler': 4.4.16
+      '@smithy/node-http-handler': 4.5.0
       '@smithy/types': 4.13.1
       '@smithy/util-base64': 4.3.2
       '@smithy/util-buffer-from': 4.2.2
@@ -8475,7 +8476,7 @@ snapshots:
     dependencies:
       '@vitest/utils': 3.2.4
       fflate: 0.8.2
-      flatted: 3.4.0
+      flatted: 3.4.2
       pathe: 2.0.3
       sirv: 3.0.2
       tinyglobby: 0.2.15
@@ -9471,13 +9472,14 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
-  fast-xml-builder@1.1.3:
+  fast-xml-builder@1.1.4:
     dependencies:
-      path-expression-matcher: 1.1.3
+      path-expression-matcher: 1.2.0
 
-  fast-xml-parser@5.4.1:
+  fast-xml-parser@5.5.7:
     dependencies:
-      fast-xml-builder: 1.1.3
+      fast-xml-builder: 1.1.4
+      path-expression-matcher: 1.2.0
       strnum: 2.2.0
 
   fdir@6.5.0(picomatch@4.0.3):
@@ -9490,7 +9492,7 @@ snapshots:
     dependencies:
       escape-string-regexp: 1.0.5
 
-  file-type@21.3.0:
+  file-type@21.3.2:
     dependencies:
       '@tokenizer/inflate': 0.4.1
       strtok3: 10.3.4
@@ -9518,7 +9520,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  flatted@3.4.0: {}
+  flatted@3.4.2: {}
 
   follow-redirects@1.15.11: {}
 
@@ -10200,9 +10202,9 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  nestjs-pino@4.6.1(@nestjs/common@11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2))(pino-http@11.0.0)(pino@10.3.1)(rxjs@7.8.2):
+  nestjs-pino@4.6.1(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(pino-http@11.0.0)(pino@10.3.1)(rxjs@7.8.2):
     dependencies:
-      '@nestjs/common': 11.1.16(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2)
       pino: 10.3.1
       pino-http: 11.0.0
       rxjs: 7.8.2
@@ -10325,7 +10327,7 @@ snapshots:
 
   parseurl@1.3.3: {}
 
-  path-expression-matcher@1.1.3: {}
+  path-expression-matcher@1.2.0: {}
 
   path-key@3.1.1: {}
 


### PR DESCRIPTION
Add a pull-request preview workflow that creates and cleans up isolated preview infrastructure for each PR.

- Add `fly-preview.yml` workflow to:
  - create/delete Neon branches per PR
  - provision/destroy a dedicated Fly Redis app per PR
  - run preflight checks (deps install, Prisma migrate deploy, build, env validation)
  - deploy/destroy Fly preview apps on PR lifecycle events
- Add preview Fly config (`fly.preview.toml`) with lower-cost autoscaling defaults.
- Add `scripts/set-preview-secrets.sh` to load `.env.preview` and push required/optional GitHub secrets for preview runs.
- Document preview env requirements and align workflow values for preview runtime parity (`NODE_ENV=production`).