### PR TITLE
feat(booking-agent): normalize booking windows and linked guest notifications

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/docs/preview-env.txt
+++ b/docs/preview-env.txt
@@ -1,0 +1,55 @@
+Preview Environment Requirements
+===============================
+
+This repository's PR preview workflow is defined in `.github/workflows/neon-preview.yml`.
+
+What it does
+------------
+
+- Creates a Neon branch per PR (`preview/pr-<number>`)
+- Runs Prisma migrations on that branch
+- Validates runtime env using `src/config/env.config.ts` (canonical schema)
+- Deploys a Fly preview app (`hyre-worker-nestjs-pr-<number>`)
+- Deletes Neon branch and Fly app when the PR is closed
+
+Required GitHub repository variables
+------------------------------------
+
+- `NEON_PROJECT_ID`
+
+Required GitHub repository secrets
+----------------------------------
+
+- `NEON_API_KEY`
+- `FLY_API_TOKEN`
+- `RESEND_API_KEY`
+- `RESEND_FROM_EMAIL`
+- `TWILIO_ACCOUNT_SID`
+- `TWILIO_AUTH_TOKEN`
+- `TWILIO_SECRET`
+- `TWILIO_WHATSAPP_NUMBER`
+- `FLUTTERWAVE_SECRET_KEY`
+- `FLUTTERWAVE_PUBLIC_KEY`
+- `FLUTTERWAVE_WEBHOOK_SECRET`
+- `HMAC_KEY`
+- `FLIGHTAWARE_API_KEY`
+- `FLIGHTAWARE_WEBHOOK_SECRET`
+- `GOOGLE_DISTANCE_MATRIX_API_KEY`
+- `OPENAI_API_KEY`
+- `SESSION_SECRET`
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `ANTHROPIC_API_KEY`
+
+Optional GitHub repository secrets
+----------------------------------
+
+- `API_KEY`
+- `BULL_BOARD_USERNAME`
+- `BULL_BOARD_PASSWORD`
+
+Redis note
+----------
+
+Redis is provisioned per PR as a dedicated Fly app (`hyre-worker-redis-pr-<number>`), and the workflow computes a per-PR `REDIS_URL` automatically.
+No `PREVIEW_REDIS_URL` secret is required.

--- a/prisma/migrations/20260402160000_add_whatsapp_conversation_link_state/migration.sql
+++ b/prisma/migrations/20260402160000_add_whatsapp_conversation_link_state/migration.sql
@@ -1,0 +1,25 @@
+-- Add explicit link state for secure WhatsApp-to-user association.
+CREATE TYPE "WhatsAppLinkStatus" AS ENUM (
+  'UNLINKED',
+  'PENDING_VERIFICATION',
+  'LINKED',
+  'REVOKED'
+);
+
+ALTER TABLE "WhatsAppConversation"
+ADD COLUMN "linkedUserId" TEXT,
+ADD COLUMN "linkStatus" "WhatsAppLinkStatus" NOT NULL DEFAULT 'UNLINKED',
+ADD COLUMN "linkRequestedAt" TIMESTAMP(3),
+ADD COLUMN "linkVerifiedAt" TIMESTAMP(3);
+
+ALTER TABLE "WhatsAppConversation"
+ADD CONSTRAINT "WhatsAppConversation_linkedUserId_fkey"
+FOREIGN KEY ("linkedUserId") REFERENCES "User"("id")
+ON DELETE SET NULL
+ON UPDATE CASCADE;
+
+CREATE INDEX "WhatsAppConversation_linkedUserId_idx"
+ON "WhatsAppConversation"("linkedUserId");
+
+CREATE INDEX "WhatsAppConversation_linkStatus_idx"
+ON "WhatsAppConversation"("linkStatus");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -93,6 +93,7 @@ model User {
   approvedVehicleImages     VehicleImage[]             @relation("ApprovedVehicleImages")
   sessions                  Session[]
   roles                     Role[]                     @relation("RoleToUser")
+  whatsAppConversations     WhatsAppConversation[]     @relation("WhatsAppConversationLinkedUser")
 
   @@index([fleetOwnerId])
   @@index([fleetOwnerStatus, hasOnboarded])
@@ -621,6 +622,10 @@ model WhatsAppConversation {
   waId                    String?                    @unique
   profileName             String?
   status                  WhatsAppConversationStatus @default(ACTIVE)
+  linkedUserId            String?
+  linkStatus              WhatsAppLinkStatus         @default(UNLINKED)
+  linkRequestedAt         DateTime?
+  linkVerifiedAt          DateTime?
   lastInboundAt           DateTime?
   lastOutboundAt          DateTime?
   windowExpiresAt         DateTime?
@@ -628,6 +633,7 @@ model WhatsAppConversation {
   handoffAt               DateTime?
   activeBookingDraftId    String?
   activeBookingDraft      BookingDraft?              @relation("ActiveConversationDraft", fields: [activeBookingDraftId], references: [id], onDelete: SetNull)
+  linkedUser              User?                      @relation("WhatsAppConversationLinkedUser", fields: [linkedUserId], references: [id], onDelete: SetNull)
   processingLockToken     String?
   processingLockExpiresAt DateTime?
   messages                WhatsAppMessage[]
@@ -637,6 +643,8 @@ model WhatsAppConversation {
   updatedAt               DateTime                   @updatedAt
 
   @@index([status])
+  @@index([linkedUserId])
+  @@index([linkStatus])
   @@index([windowExpiresAt])
   @@index([processingLockExpiresAt])
 }
@@ -867,6 +875,13 @@ enum WhatsAppConversationStatus {
   ACTIVE
   HANDOFF
   CLOSED
+}
+
+enum WhatsAppLinkStatus {
+  UNLINKED
+  PENDING_VERIFICATION
+  LINKED
+  REVOKED
 }
 
 enum WhatsAppDeliveryMode {

--- a/src/modules/booking-agent/booking-agent-orchestrator.service.spec.ts
+++ b/src/modules/booking-agent/booking-agent-orchestrator.service.spec.ts
@@ -107,6 +107,29 @@ describe("BookingAgentOrchestratorService", () => {
     expect(result.enqueueOutbox[0]?.dedupeKey).toBe("langgraph:outbox:1");
   });
 
+  it("passes linked customerId through to LangGraph invocation", async () => {
+    langGraphService.invoke.mockResolvedValue({
+      outboxItems: [],
+      response: { text: "ok" },
+      stage: "collecting",
+      draft: {},
+      error: null,
+    });
+
+    await service.decide(
+      buildContext({
+        body: "Need an SUV tomorrow",
+        customerId: "user_linked_123",
+      }),
+    );
+
+    expect(langGraphService.invoke).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customerId: "user_linked_123",
+      }),
+    );
+  });
+
   it("marks conversation as handoff when LangGraph returns handoff outbox", async () => {
     langGraphService.invoke.mockResolvedValue({
       outboxItems: [

--- a/src/modules/booking-agent/booking-agent-orchestrator.service.ts
+++ b/src/modules/booking-agent/booking-agent-orchestrator.service.ts
@@ -111,6 +111,7 @@ export class BookingAgentOrchestratorService {
           this.buildSingleOutboxReply(context, {
             dedupeKey: `langgraph-error-fallback:${context.messageId}`,
             textBody: LANGGRAPH_ERROR_FALLBACK_TEXT,
+            templateName: "booking-reopen",
           }),
         );
       }

--- a/src/modules/booking-agent/booking-agent-orchestrator.service.ts
+++ b/src/modules/booking-agent/booking-agent-orchestrator.service.ts
@@ -5,6 +5,9 @@ import { BookingAgentWindowPolicyService } from "./booking-agent-window-policy.s
 import { LangGraphGraphService } from "./langgraph/langgraph-graph.service";
 import { LangGraphStateService } from "./langgraph/langgraph-state.service";
 
+const LANGGRAPH_ERROR_FALLBACK_TEXT =
+  "I'm having trouble processing your request. Please try again or type AGENT to speak with someone.";
+
 @Injectable()
 export class BookingAgentOrchestratorService {
   private readonly logger = new Logger(BookingAgentOrchestratorService.name);
@@ -30,14 +33,12 @@ export class BookingAgentOrchestratorService {
     if (body === "AGENT") {
       return {
         enqueueOutbox: [
-          {
-            conversationId: context.conversationId,
+          this.buildSingleOutboxReply(context, {
             dedupeKey: `handoff-ack:${context.messageId}`,
-            mode: this.windowPolicyService.resolveOutboundMode(context.windowExpiresAt),
             textBody:
               "A Tripdly agent will join this chat shortly. Please share your booking reference if available.",
             templateName: "handoff-reopen",
-          },
+          }),
         ],
         markAsHandoff: { reason: "USER_REQUESTED_AGENT" },
       };
@@ -47,14 +48,12 @@ export class BookingAgentOrchestratorService {
       await this.langGraphStateService.clearState(context.conversationId);
       return {
         enqueueOutbox: [
-          {
-            conversationId: context.conversationId,
+          this.buildSingleOutboxReply(context, {
             dedupeKey: `reset-ack:${context.messageId}`,
-            mode: this.windowPolicyService.resolveOutboundMode(context.windowExpiresAt),
             textBody:
               "Done - I have reset your current booking details. Please share your new request.",
             templateName: "booking-reopen",
-          },
+          }),
         ],
       };
     }
@@ -67,14 +66,12 @@ export class BookingAgentOrchestratorService {
     ) {
       return {
         enqueueOutbox: [
-          {
-            conversationId: context.conversationId,
+          this.buildSingleOutboxReply(context, {
             dedupeKey: `media-fallback:${context.messageId}`,
-            mode: this.windowPolicyService.resolveOutboundMode(context.windowExpiresAt),
             textBody:
               "Thanks. For now, please send your pickup location, date/time, and booking type (DAY, NIGHT, or FULL_DAY) as text.",
             templateName: "booking-reopen",
-          },
+          }),
         ],
       };
     }
@@ -88,13 +85,14 @@ export class BookingAgentOrchestratorService {
   private async decideLangGraph(
     context: InboundMessageContext & { windowExpiresAt?: Date | null },
   ): Promise<OrchestratorResult> {
+    const { conversationId, messageId, body = "", customerId = null, interactive } = context;
     try {
       const result = await this.langGraphService.invoke({
-        conversationId: context.conversationId,
-        messageId: context.messageId,
-        message: context.body ?? "",
-        customerId: null,
-        interactive: context.interactive,
+        conversationId,
+        messageId,
+        message: body ?? "",
+        customerId,
+        interactive,
       });
 
       if (result.error) {
@@ -104,26 +102,17 @@ export class BookingAgentOrchestratorService {
         });
       }
 
-      const outboxItems: OrchestratorResult["enqueueOutbox"] = result.outboxItems.map((item) => ({
-        conversationId: item.conversationId,
-        dedupeKey: item.dedupeKey,
-        mode: item.mode,
-        textBody: item.textBody,
-        mediaUrl: item.mediaUrl,
-        templateName: item.templateName,
-        templateVariables: item.templateVariables,
-      }));
+      const outboxItems: OrchestratorResult["enqueueOutbox"] = result.outboxItems.map(
+        ({ interactive, ...outboxItem }) => outboxItem,
+      );
 
       if (result.error && outboxItems.length === 0) {
-        outboxItems.push({
-          conversationId: context.conversationId,
-          dedupeKey: `langgraph-error-fallback:${context.messageId}`,
-          mode: this.windowPolicyService.resolveOutboundMode(context.windowExpiresAt),
-          textBody:
-            "I'm having trouble processing your request. Please try again or type AGENT to speak with someone.",
-          templateName: undefined,
-          templateVariables: undefined,
-        });
+        outboxItems.push(
+          this.buildSingleOutboxReply(context, {
+            dedupeKey: `langgraph-error-fallback:${context.messageId}`,
+            textBody: LANGGRAPH_ERROR_FALLBACK_TEXT,
+          }),
+        );
       }
 
       const hasHandoffOutbox = outboxItems.some((item) =>
@@ -141,19 +130,33 @@ export class BookingAgentOrchestratorService {
         error: error instanceof Error ? error.message : String(error),
       });
 
-      const mode = this.windowPolicyService.resolveOutboundMode(context.windowExpiresAt);
       return {
         enqueueOutbox: [
-          {
-            conversationId: context.conversationId,
+          this.buildSingleOutboxReply(context, {
             dedupeKey: `langgraph-error:${context.messageId}`,
-            mode,
-            textBody:
-              "I'm having trouble processing your request. Please try again or type AGENT to speak with someone.",
+            textBody: LANGGRAPH_ERROR_FALLBACK_TEXT,
             templateName: "booking-reopen",
-          },
+          }),
         ],
       };
     }
+  }
+
+  private buildSingleOutboxReply(
+    context: InboundMessageContext & { windowExpiresAt?: Date | null },
+    input: {
+      dedupeKey: string;
+      textBody: string;
+      templateName?: string;
+    },
+  ): OrchestratorResult["enqueueOutbox"][number] {
+    return {
+      conversationId: context.conversationId,
+      dedupeKey: input.dedupeKey,
+      mode: this.windowPolicyService.resolveOutboundMode(context.windowExpiresAt),
+      textBody: input.textBody,
+      templateName: input.templateName,
+      templateVariables: undefined,
+    };
   }
 }

--- a/src/modules/booking-agent/booking-agent.interface.ts
+++ b/src/modules/booking-agent/booking-agent.interface.ts
@@ -71,6 +71,7 @@ export interface InteractiveReply {
 export interface InboundMessageContext {
   messageId: string;
   conversationId: string;
+  customerId?: string | null;
   body?: string;
   kind: WhatsAppMessageKind;
   interactive?: InteractiveReply;

--- a/src/modules/booking-agent/langgraph/create-booking.node.spec.ts
+++ b/src/modules/booking-agent/langgraph/create-booking.node.spec.ts
@@ -4,6 +4,7 @@ import { CarNotAvailableException, CarNotFoundException } from "../../booking/bo
 import { BookingCreationService } from "../../booking/booking-creation.service";
 import { DatabaseService } from "../../database/database.service";
 import { BookingAgentSearchService } from "../booking-agent-search.service";
+import { WhatsAppPersistenceService } from "../whatsapp/whatsapp-persistence.service";
 import { CreateBookingNode } from "./create-booking.node";
 import { LANGGRAPH_SERVICE_UNAVAILABLE_MESSAGE } from "./langgraph.const";
 import { buildVehicleOption } from "./langgraph.factory";
@@ -54,14 +55,31 @@ describe("CreateBookingNode", () => {
   const bookingAgentSearchServiceMock = {
     searchVehiclesFromExtracted: vi.fn(),
   };
+  const whatsAppPersistenceServiceMock = {
+    getConversationLinkState: vi
+      .fn()
+      .mockResolvedValue({ linkedUserId: null, linkStatus: "UNLINKED" }),
+  };
 
   beforeEach(async () => {
+    databaseServiceMock.whatsAppConversation.findUnique.mockImplementation(() => {
+      return Promise.resolve({
+        phoneE164: "+2348012345678",
+        profileName: "Test User",
+      });
+    });
+    whatsAppPersistenceServiceMock.getConversationLinkState.mockResolvedValue({
+      linkedUserId: null,
+      linkStatus: "UNLINKED",
+    });
+
     moduleRef = await Test.createTestingModule({
       providers: [
         CreateBookingNode,
         { provide: BookingCreationService, useValue: bookingCreationServiceMock },
         { provide: DatabaseService, useValue: databaseServiceMock },
         { provide: BookingAgentSearchService, useValue: bookingAgentSearchServiceMock },
+        { provide: WhatsAppPersistenceService, useValue: whatsAppPersistenceServiceMock },
       ],
     }).compile();
 
@@ -107,6 +125,57 @@ describe("CreateBookingNode", () => {
     expect(result.stage).toBe("awaiting_payment");
     expect(result.bookingId).toBe("booking_123");
     expect(result.paymentLink).toBe("https://pay.example.com/booking_123");
+    expect(bookingCreationServiceMock.createBooking).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({
+          guestEmail: "whatsapp.2348012345678@tripdly.com",
+        }),
+        sessionUser: null,
+        context: { guestContactSource: "WHATSAPP_AGENT" },
+      }),
+    );
+  });
+
+  it("creates booking as linked user when conversation is verified-linked", async () => {
+    databaseServiceMock.whatsAppConversation.findUnique.mockResolvedValueOnce({
+      phoneE164: "+2348012345678",
+      profileName: "Test User",
+    });
+    whatsAppPersistenceServiceMock.getConversationLinkState.mockResolvedValueOnce({
+      linkedUserId: "user_linked_123",
+      linkStatus: "LINKED",
+    });
+    bookingCreationServiceMock.createBooking.mockResolvedValue({
+      bookingId: "booking_456",
+      checkoutUrl: "https://pay.example.com/booking_456",
+    });
+
+    const result = await createBookingNode.run(
+      buildTestState({
+        customerId: "user_linked_123",
+        draft: {
+          bookingType: "DAY",
+          pickupDate: "2026-03-01",
+          pickupTime: "09:00",
+          dropoffDate: "2026-03-01",
+          pickupLocation: "Victoria Island",
+          dropoffLocation: "Lekki",
+        },
+        selectedOption: buildVehicleOption(),
+      }),
+    );
+
+    expect(result.stage).toBe("awaiting_payment");
+    expect(result.bookingId).toBe("booking_456");
+    expect(bookingCreationServiceMock.createBooking).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.any(Object),
+        sessionUser: expect.objectContaining({ id: "user_linked_123" }),
+      }),
+    );
+    expect(bookingCreationServiceMock.createBooking.mock.calls[0]?.[0]?.input).not.toHaveProperty(
+      "guestEmail",
+    );
   });
 
   it("returns alternatives when selected car is unavailable", async () => {

--- a/src/modules/booking-agent/langgraph/create-booking.node.ts
+++ b/src/modules/booking-agent/langgraph/create-booking.node.ts
@@ -1,9 +1,12 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { maskEmail } from "../../../shared/helper";
+import type { AuthSession } from "../../auth/guards/session.guard";
 import { CarNotAvailableException, CarNotFoundException } from "../../booking/booking.error";
 import { BookingCreationService } from "../../booking/booking-creation.service";
+import type { CreateBookingInput } from "../../booking/dto/create-booking.dto";
 import { DatabaseService } from "../../database/database.service";
 import { BookingAgentSearchService } from "../booking-agent-search.service";
+import { WhatsAppPersistenceService } from "../whatsapp/whatsapp-persistence.service";
 import { LANGGRAPH_SERVICE_UNAVAILABLE_MESSAGE } from "./langgraph.const";
 import {
   type BookingDraft,
@@ -23,6 +26,7 @@ export class CreateBookingNode {
     private readonly bookingCreationService: BookingCreationService,
     private readonly databaseService: DatabaseService,
     private readonly bookingAgentSearchService: BookingAgentSearchService,
+    private readonly whatsAppPersistenceService: WhatsAppPersistenceService,
   ) {}
 
   async run(state: LangGraphNodeState): Promise<LangGraphNodeResult> {
@@ -71,7 +75,25 @@ export class CreateBookingNode {
 
       this.logBookingCreationInput(bookingInput, normalizedStartDate, normalizedEndDate);
 
-      const result = await this.bookingCreationService.createBooking(bookingInput, null);
+      const conversationLinkState = await this.whatsAppPersistenceService.getConversationLinkState(
+        state.conversationId,
+      );
+      const linkedCustomerId = this.resolveLinkedCustomerId(
+        state.customerId,
+        conversationLinkState,
+      );
+      const result = linkedCustomerId
+        ? await this.bookingCreationService.createBooking({
+            input: this.buildAuthenticatedBookingInput(bookingInput),
+            sessionUser: { id: linkedCustomerId } as AuthSession["user"],
+          })
+        : await this.bookingCreationService.createBooking({
+            input: bookingInput,
+            sessionUser: null,
+            context: {
+              guestContactSource: "WHATSAPP_AGENT",
+            },
+          });
 
       this.logger.log("Booking created successfully", {
         bookingId: result.bookingId,
@@ -134,6 +156,42 @@ export class CreateBookingNode {
     }
 
     return conversation;
+  }
+
+  private resolveLinkedCustomerId(
+    stateCustomerId: string | null,
+    conversation: {
+      linkedUserId: string | null;
+      linkStatus: string | null;
+    },
+  ): string | null {
+    if (conversation.linkStatus !== "LINKED" || !conversation.linkedUserId) {
+      return null;
+    }
+
+    if (stateCustomerId && stateCustomerId !== conversation.linkedUserId) {
+      this.logger.warn("State customerId does not match linked conversation userId", {
+        stateCustomerId,
+        linkedUserId: conversation.linkedUserId,
+      });
+    }
+
+    return conversation.linkedUserId;
+  }
+
+  private buildAuthenticatedBookingInput(input: CreateBookingInput): CreateBookingInput {
+    const {
+      guestEmail: _guestEmail,
+      guestName: _guestName,
+      guestPhone: _guestPhone,
+      ...rest
+    } = input as CreateBookingInput & {
+      guestEmail?: string;
+      guestName?: string;
+      guestPhone?: string;
+    };
+
+    return rest as CreateBookingInput;
   }
 
   private validateDraftBeforeBookingCreation(draft: BookingDraft): LangGraphNodeResult | null {

--- a/src/modules/booking-agent/langgraph/langgraph-booking-rules.spec.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-booking-rules.spec.ts
@@ -33,6 +33,64 @@ describe("langgraph-booking-rules", () => {
     expect(result.dropoffDate).toBe("2026-03-07");
   });
 
+  it("auto-derives DAY dropoffDate using durationDays as leg count", () => {
+    const draft = {
+      bookingType: "DAY" as const,
+      pickupDate: "2026-03-05",
+      durationDays: 5,
+      pickupLocation: "Lekki Phase 1",
+      dropoffLocation: "Lekki Phase 1",
+      pickupTime: "09:00",
+    };
+
+    const result = applyDerivedDraftFields(draft, "");
+    expect(result.dropoffDate).toBe("2026-03-09");
+  });
+
+  it("auto-derives FULL_DAY dropoffDate using durationDays as leg count", () => {
+    const draft = {
+      bookingType: "FULL_DAY" as const,
+      pickupDate: "2026-03-05",
+      durationDays: 5,
+      pickupLocation: "Lekki Phase 1",
+      dropoffLocation: "Lekki Phase 1",
+      pickupTime: "09:00",
+    };
+
+    const result = applyDerivedDraftFields(draft, "");
+    expect(result.dropoffDate).toBe("2026-03-10");
+  });
+
+  it("normalizes conflicting dropoffDate from durationDays for non-NIGHT bookings", () => {
+    const draft = {
+      bookingType: "DAY" as const,
+      pickupDate: "2026-04-05",
+      durationDays: 5,
+      dropoffDate: "2026-04-10",
+      pickupLocation: "Lekki Phase 1",
+      dropoffLocation: "Lekki Phase 1",
+      pickupTime: "09:00",
+    };
+
+    const result = applyDerivedDraftFields(draft, "");
+    expect(result.dropoffDate).toBe("2026-04-09");
+  });
+
+  it("normalizes conflicting dropoffDate from durationDays for FULL_DAY bookings", () => {
+    const draft = {
+      bookingType: "FULL_DAY" as const,
+      pickupDate: "2026-04-05",
+      durationDays: 5,
+      dropoffDate: "2026-04-09",
+      pickupLocation: "Lekki Phase 1",
+      dropoffLocation: "Lekki Phase 1",
+      pickupTime: "09:00",
+    };
+
+    const result = applyDerivedDraftFields(draft, "");
+    expect(result.dropoffDate).toBe("2026-04-10");
+  });
+
   it("detects draft changes across key fields", () => {
     const oldDraft = { pickupDate: "2026-03-01", bookingType: "DAY" as const };
     const newDraft = { pickupDate: "2026-03-02", bookingType: "DAY" as const };

--- a/src/modules/booking-agent/langgraph/langgraph-booking-rules.spec.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-booking-rules.spec.ts
@@ -91,6 +91,20 @@ describe("langgraph-booking-rules", () => {
     expect(result.dropoffDate).toBe("2026-04-10");
   });
 
+  it("preserves explicit NIGHT dropoffDate when durationDays is missing", () => {
+    const draft = {
+      bookingType: "NIGHT" as const,
+      pickupDate: "2026-04-05",
+      dropoffDate: "2026-04-08",
+      pickupLocation: "Lekki Phase 1",
+      dropoffLocation: "Lekki Phase 1",
+    };
+
+    const result = applyDerivedDraftFields(draft, "");
+    expect(result.pickupTime).toBe("23:00");
+    expect(result.dropoffDate).toBe("2026-04-08");
+  });
+
   it("detects draft changes across key fields", () => {
     const oldDraft = { pickupDate: "2026-03-01", bookingType: "DAY" as const };
     const newDraft = { pickupDate: "2026-03-02", bookingType: "DAY" as const };

--- a/src/modules/booking-agent/langgraph/langgraph-booking-rules.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-booking-rules.ts
@@ -34,19 +34,20 @@ export function applyDerivedDraftFields(draft: BookingDraft, inboundMessage: str
     updatedDraft.dropoffLocation = updatedDraft.pickupLocation;
   }
 
-  if (!updatedDraft.dropoffDate && updatedDraft.pickupDate && updatedDraft.durationDays) {
-    updatedDraft.dropoffDate = calculateDropoffDate(
-      updatedDraft.pickupDate,
-      updatedDraft.durationDays,
-    );
-  }
-
   if (updatedDraft.bookingType === "NIGHT") {
     updatedDraft.pickupTime = "23:00";
-    if (!updatedDraft.dropoffDate && updatedDraft.pickupDate) {
-      const daysToAdd = updatedDraft.durationDays ?? 1;
-      updatedDraft.dropoffDate = calculateDropoffDate(updatedDraft.pickupDate, daysToAdd);
-    }
+  }
+
+  if (
+    updatedDraft.pickupDate &&
+    (updatedDraft.durationDays || updatedDraft.bookingType === "NIGHT")
+  ) {
+    const normalizedDurationDays = Math.max(updatedDraft.durationDays ?? 1, 1);
+    const daysToAdd =
+      updatedDraft.bookingType === "DAY"
+        ? Math.max(normalizedDurationDays - 1, 0)
+        : normalizedDurationDays;
+    updatedDraft.dropoffDate = calculateDropoffDate(updatedDraft.pickupDate, daysToAdd);
   }
 
   return updatedDraft;

--- a/src/modules/booking-agent/langgraph/langgraph-booking-rules.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-booking-rules.ts
@@ -38,10 +38,12 @@ export function applyDerivedDraftFields(draft: BookingDraft, inboundMessage: str
     updatedDraft.pickupTime = "23:00";
   }
 
-  if (
-    updatedDraft.pickupDate &&
-    (updatedDraft.durationDays || updatedDraft.bookingType === "NIGHT")
-  ) {
+  const hasDurationDays =
+    typeof updatedDraft.durationDays === "number" && updatedDraft.durationDays > 0;
+  const shouldDefaultNightToOne =
+    updatedDraft.bookingType === "NIGHT" && !hasDurationDays && !updatedDraft.dropoffDate;
+
+  if (updatedDraft.pickupDate && (hasDurationDays || shouldDefaultNightToOne)) {
     const normalizedDurationDays = Math.max(updatedDraft.durationDays ?? 1, 1);
     const daysToAdd =
       updatedDraft.bookingType === "DAY"

--- a/src/modules/booking-agent/langgraph/langgraph-extractor.service.spec.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-extractor.service.spec.ts
@@ -427,6 +427,79 @@ describe("LangGraphExtractorService", () => {
       expect(result.draftPatch.pickupLocation).toBe("Victoria Island");
     });
 
+    it("uses make when extractor returns explicit brand from message", async () => {
+      openaiMock.invoke.mockResolvedValue({
+        content: JSON.stringify({
+          intent: "provide_info",
+          draftPatch: {
+            vehicleType: "SUV",
+            make: "Toyota",
+          },
+          confidence: 0.9,
+        }),
+      });
+
+      const state = buildState({
+        inboundMessage: "I need a Toyota SUV for today",
+      });
+
+      const result = await service.extract(state);
+
+      expect(result.intent).toBe("provide_info");
+      expect(result.draftPatch.vehicleType).toBe("SUV");
+      expect(result.draftPatch.make).toBe("Toyota");
+      expect(result.draftPatch.model).toBeUndefined();
+      expect(openaiMock.invoke).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not force make or model when none is explicitly mentioned", async () => {
+      openaiMock.invoke.mockResolvedValue({
+        content: JSON.stringify({
+          intent: "provide_info",
+          draftPatch: {
+            vehicleType: "SUV",
+          },
+          confidence: 0.9,
+        }),
+      });
+
+      const state = buildState({
+        inboundMessage: "I need an SUV for today",
+      });
+
+      const result = await service.extract(state);
+
+      expect(result.intent).toBe("provide_info");
+      expect(result.draftPatch.vehicleType).toBe("SUV");
+      expect(result.draftPatch.make).toBeUndefined();
+      expect(result.draftPatch.model).toBeUndefined();
+    });
+
+    it("uses make and model when extractor returns both explicitly", async () => {
+      openaiMock.invoke.mockResolvedValue({
+        content: JSON.stringify({
+          intent: "provide_info",
+          draftPatch: {
+            vehicleType: "SUV",
+            make: "Toyota",
+            model: "Highlander",
+          },
+          confidence: 0.9,
+        }),
+      });
+
+      const state = buildState({
+        inboundMessage: "Please find a Toyota Highlander SUV",
+      });
+
+      const result = await service.extract(state);
+
+      expect(result.draftPatch.make).toBe("Toyota");
+      expect(result.draftPatch.model).toBe("Highlander");
+      expect(result.draftPatch.vehicleType).toBe("SUV");
+      expect(openaiMock.invoke).toHaveBeenCalledTimes(1);
+    });
+
     it("extracts selection hint when selecting option", async () => {
       openaiMock.invoke.mockResolvedValue({
         content: JSON.stringify({

--- a/src/modules/booking-agent/langgraph/langgraph-extractor.service.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-extractor.service.ts
@@ -91,17 +91,7 @@ export class LangGraphExtractorService {
       ]);
       this.logger.debug("Extraction response received", { conversationId });
 
-      let content = "";
-      if (typeof response.content === "string") {
-        content = response.content;
-      } else if (
-        Array.isArray(response.content) &&
-        response.content.length > 0 &&
-        response.content[0]?.type === "text"
-      ) {
-        content = String(response.content[0].text ?? "");
-      }
-
+      const content = this.getTextContent(response.content);
       const parsed = JSON.parse(content);
       const validated = extractionSchema.parse(parsed);
 
@@ -280,5 +270,15 @@ export class LangGraphExtractorService {
     }
 
     return null;
+  }
+
+  private getTextContent(content: unknown): string {
+    if (typeof content === "string") {
+      return content;
+    }
+    if (Array.isArray(content) && content.length > 0 && content[0]?.type === "text") {
+      return String(content[0].text ?? "");
+    }
+    return "";
   }
 }

--- a/src/modules/booking-agent/langgraph/langgraph-graph.service.spec.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-graph.service.spec.ts
@@ -6,6 +6,7 @@ import { DatabaseService } from "../../database/database.service";
 import { GooglePlacesService } from "../../maps/google-places.service";
 import { BookingAgentSearchService } from "../booking-agent-search.service";
 import { BookingAgentWindowPolicyService } from "../booking-agent-window-policy.service";
+import { WhatsAppPersistenceService } from "../whatsapp/whatsapp-persistence.service";
 import { CreateBookingNode } from "./create-booking.node";
 import { ExtractNode } from "./extract.node";
 import { HandoffNode } from "./handoff.node";
@@ -54,6 +55,9 @@ describe("LangGraphGraphService", () => {
   };
   let googlePlacesServiceMock: {
     validateAddress: ReturnType<typeof vi.fn>;
+  };
+  let whatsAppPersistenceServiceMock: {
+    getConversationLinkState: ReturnType<typeof vi.fn>;
   };
 
   const conversationId = "conv_test";
@@ -128,11 +132,19 @@ describe("LangGraphGraphService", () => {
 
     databaseServiceMock = {
       whatsAppConversation: {
-        findUnique: vi.fn().mockResolvedValue({
-          phoneE164: "+2348012345678",
-          profileName: "Test Customer",
+        findUnique: vi.fn().mockImplementation(() => {
+          return Promise.resolve({
+            phoneE164: "+2348012345678",
+            profileName: "Test Customer",
+          });
         }),
       },
+    };
+
+    whatsAppPersistenceServiceMock = {
+      getConversationLinkState: vi
+        .fn()
+        .mockResolvedValue({ linkedUserId: null, linkStatus: "UNLINKED" }),
     };
 
     googlePlacesServiceMock = {
@@ -152,6 +164,7 @@ describe("LangGraphGraphService", () => {
         { provide: BookingAgentWindowPolicyService, useValue: windowPolicyServiceMock },
         { provide: BookingCreationService, useValue: bookingCreationServiceMock },
         { provide: DatabaseService, useValue: databaseServiceMock },
+        { provide: WhatsAppPersistenceService, useValue: whatsAppPersistenceServiceMock },
         { provide: GooglePlacesService, useValue: googlePlacesServiceMock },
         ExtractNode,
         MergeNode,
@@ -2377,7 +2390,7 @@ describe("LangGraphGraphService", () => {
       });
 
       expect(result.stage).toBe("presenting_options");
-      expect(result.draft.dropoffDate).toBe("2026-03-07");
+      expect(result.draft.dropoffDate).toBe("2026-03-06");
     });
   });
 });

--- a/src/modules/booking-agent/langgraph/langgraph-responder.service.spec.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-responder.service.spec.ts
@@ -198,7 +198,14 @@ describe("LangGraphResponderService", () => {
       // confirming stage now returns fixed booking summary with interactive buttons
       expect(response.text).toContain("Booking Summary");
       expect(response.text).toContain("Toyota Prado");
-      expect(response.text).toContain("Duration:* 2 days");
+      expect(response.text).toContain("*🕐 Start:*");
+      expect(response.text).toContain("*🏁 End:*");
+      expect(response.text).toContain("1st Mar 2026");
+      expect(response.text).toContain("2nd Mar 2026");
+      expect(response.text).toContain("9:00 am");
+      expect(response.text).toContain("9:00 pm");
+      expect(response.text).toContain("Booked for:* 2 days");
+      expect(response.text).toContain("2 billed legs");
       expect(response.interactive).toBeDefined();
       expect(response.interactive?.type).toBe("buttons");
       expect(response.interactive?.buttons).toHaveLength(3);
@@ -223,7 +230,31 @@ describe("LangGraphResponderService", () => {
 
       const response = await service.generateResponse(state);
 
-      expect(response.text).toContain("Duration:* 6 days");
+      expect(response.text).toContain("*🕐 Start:*");
+      expect(response.text).toContain("*🏁 End:*");
+      expect(response.text).toContain("6:30 am");
+      expect(response.text).toContain("Booked for:* 6 days");
+      expect(response.text).toContain("6 billed legs");
+    });
+
+    it("uses nights wording for NIGHT booking type", async () => {
+      const state = buildState({
+        stage: "confirming",
+        selectedOption: buildVehicleOption(),
+        draft: {
+          bookingType: "NIGHT",
+          pickupDate: "2026-04-05",
+          durationDays: 1,
+          pickupTime: "23:00",
+          pickupLocation: "Victoria Island",
+          dropoffLocation: "Lekki",
+        },
+      });
+
+      const response = await service.generateResponse(state);
+
+      expect(response.text).toContain("Booked for:* 1 night");
+      expect(response.text).toContain("1 billed leg");
     });
 
     it("returns retry and agent buttons when confirming has booking error", async () => {

--- a/src/modules/booking-agent/langgraph/langgraph-responder.service.spec.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-responder.service.spec.ts
@@ -205,7 +205,6 @@ describe("LangGraphResponderService", () => {
       expect(response.text).toContain("9:00 am");
       expect(response.text).toContain("9:00 pm");
       expect(response.text).toContain("Booked for:* 2 days");
-      expect(response.text).toContain("2 billed legs");
       expect(response.interactive).toBeDefined();
       expect(response.interactive?.type).toBe("buttons");
       expect(response.interactive?.buttons).toHaveLength(3);
@@ -233,11 +232,11 @@ describe("LangGraphResponderService", () => {
       expect(response.text).toContain("*🕐 Start:*");
       expect(response.text).toContain("*🏁 End:*");
       expect(response.text).toContain("6:30 am");
+      expect(response.text).toContain("10th Apr 2026");
       expect(response.text).toContain("Booked for:* 6 days");
-      expect(response.text).toContain("6 billed legs");
     });
 
-    it("keeps billed legs aligned with durationDays for DAY bookings when dropoffDate is present", async () => {
+    it("shows durationDays for DAY bookings when dropoffDate is present", async () => {
       const state = buildState({
         stage: "confirming",
         selectedOption: buildVehicleOption(),
@@ -255,7 +254,6 @@ describe("LangGraphResponderService", () => {
       const response = await service.generateResponse(state);
 
       expect(response.text).toContain("Booked for:* 5 days");
-      expect(response.text).toContain("5 billed legs");
     });
 
     it("uses nights wording for NIGHT booking type", async () => {
@@ -275,7 +273,6 @@ describe("LangGraphResponderService", () => {
       const response = await service.generateResponse(state);
 
       expect(response.text).toContain("Booked for:* 1 night");
-      expect(response.text).toContain("1 billed leg");
     });
 
     it("returns retry and agent buttons when confirming has booking error", async () => {

--- a/src/modules/booking-agent/langgraph/langgraph-responder.service.spec.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-responder.service.spec.ts
@@ -237,6 +237,27 @@ describe("LangGraphResponderService", () => {
       expect(response.text).toContain("6 billed legs");
     });
 
+    it("keeps billed legs aligned with durationDays for DAY bookings when dropoffDate is present", async () => {
+      const state = buildState({
+        stage: "confirming",
+        selectedOption: buildVehicleOption(),
+        draft: {
+          bookingType: "DAY",
+          pickupDate: "2026-03-05",
+          dropoffDate: "2026-03-09",
+          durationDays: 5,
+          pickupTime: "09:00",
+          pickupLocation: "Lekki",
+          dropoffLocation: "Lekki",
+        },
+      });
+
+      const response = await service.generateResponse(state);
+
+      expect(response.text).toContain("Booked for:* 5 days");
+      expect(response.text).toContain("5 billed legs");
+    });
+
     it("uses nights wording for NIGHT booking type", async () => {
       const state = buildState({
         stage: "confirming",

--- a/src/modules/booking-agent/langgraph/langgraph-responder.service.spec.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-responder.service.spec.ts
@@ -236,6 +236,25 @@ describe("LangGraphResponderService", () => {
       expect(response.text).toContain("Booked for:* 6 days");
     });
 
+    it("derives DAY duration from canonical leg count when durationDays is not present", async () => {
+      const state = buildState({
+        stage: "confirming",
+        selectedOption: buildVehicleOption(),
+        draft: {
+          bookingType: "DAY",
+          pickupDate: "2026-04-04",
+          dropoffDate: "2026-04-10",
+          pickupTime: "09:00",
+          pickupLocation: "Victoria Island",
+          dropoffLocation: "Lekki",
+        },
+      });
+
+      const response = await service.generateResponse(state);
+
+      expect(response.text).toContain("Booked for:* 7 days");
+    });
+
     it("shows durationDays for DAY bookings when dropoffDate is present", async () => {
       const state = buildState({
         stage: "confirming",

--- a/src/modules/booking-agent/langgraph/langgraph-responder.service.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-responder.service.ts
@@ -1,6 +1,11 @@
 import { Inject, Injectable, Logger } from "@nestjs/common";
 import { BookingType } from "@prisma/client";
 import { addHours, format } from "date-fns";
+import {
+  getDefaultPickupTime,
+  normalizeBookingTimeWindow,
+} from "../../../shared/booking-time-window.helper";
+import { calculateLegCount } from "../../booking/booking.helper";
 import { parseSearchDate } from "../vehicle-search-precondition.policy";
 import { LANGGRAPH_BUTTON_ID, LANGGRAPH_SERVICE_UNAVAILABLE_MESSAGE } from "./langgraph.const";
 import { LangGraphResponseFailedException } from "./langgraph.error";
@@ -349,6 +354,11 @@ export class LangGraphResponderService {
       return draft.durationDays;
     }
 
+    const derivedDuration = this.resolveDurationFromCanonicalLegCount(draft);
+    if (derivedDuration !== null) {
+      return derivedDuration;
+    }
+
     if (!draft.pickupDate || !draft.dropoffDate) {
       return null;
     }
@@ -367,6 +377,28 @@ export class LangGraphResponderService {
     }
 
     return dayDifference;
+  }
+
+  private resolveDurationFromCanonicalLegCount(draft: BookingDraft): number | null {
+    if (!draft.bookingType || !draft.pickupDate || !draft.dropoffDate) {
+      return null;
+    }
+
+    const pickupDate = parseSearchDate(draft.pickupDate);
+    const dropoffDate = parseSearchDate(draft.dropoffDate);
+    if (!pickupDate || !dropoffDate) {
+      return null;
+    }
+
+    const pickupTime = draft.pickupTime ?? getDefaultPickupTime(draft.bookingType);
+    const { startDate, endDate } = normalizeBookingTimeWindow({
+      bookingType: draft.bookingType,
+      startDate: pickupDate,
+      endDate: dropoffDate,
+      pickupTime,
+    });
+
+    return calculateLegCount(draft.bookingType, startDate, endDate);
   }
 
   private resolveBookedForUnit(bookingType: BookingType | undefined): {

--- a/src/modules/booking-agent/langgraph/langgraph-responder.service.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-responder.service.ts
@@ -431,9 +431,6 @@ export class LangGraphResponderService {
         return addHours(this.withTime(date, pickupTime), 12);
       case "NIGHT":
         return this.withTime(date, "05:00");
-      case "FULL_DAY":
-        return this.withTime(date, pickupTime);
-      case "AIRPORT_PICKUP":
       default:
         return this.withTime(date, pickupTime);
     }
@@ -497,15 +494,9 @@ export class LangGraphResponderService {
   }
 
   private formatDateWithAmPm(date: Date): string {
-    const datePart = format(date, "do MMM yyyy");
-    const timePart = date
-      .toLocaleTimeString("en-GB", {
-        hour: "numeric",
-        minute: "2-digit",
-        hour12: true,
-      })
-      .toLowerCase();
-    return `${datePart}, ${timePart}`;
+    return format(date, "do MMM yyyy, h:mm a").replace(/\s(AM|PM)$/u, (match) =>
+      match.toLowerCase(),
+    );
   }
 
   private formatRequiredPrice(estimatedTotalInclVat: number): string {

--- a/src/modules/booking-agent/langgraph/langgraph-responder.service.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-responder.service.ts
@@ -1,5 +1,8 @@
 import { Inject, Injectable, Logger } from "@nestjs/common";
 import { BookingType } from "@prisma/client";
+import { addHours, format } from "date-fns";
+import { calculateLegCount } from "../../booking/booking.helper";
+import { parseSearchDate } from "../vehicle-search-precondition.policy";
 import { LANGGRAPH_BUTTON_ID, LANGGRAPH_SERVICE_UNAVAILABLE_MESSAGE } from "./langgraph.const";
 import { LangGraphResponseFailedException } from "./langgraph.error";
 import type {
@@ -313,10 +316,17 @@ export class LangGraphResponderService {
   private buildBookingSummary(draft: BookingDraft, selectedOption: VehicleSearchOption): string {
     const priceFormatted = this.formatRequiredPrice(selectedOption.estimatedTotalInclVat);
     const durationDays = this.resolveDurationDays(draft);
+    const billedLegs = this.resolveBilledLegs(draft);
+    const billedLegUnit = billedLegs === 1 ? "leg" : "legs";
+    const bookingWindowLines = this.buildBookingWindowLines(draft);
+    const billedLegsSuffix = billedLegs === null ? "" : ` (${billedLegs} billed ${billedLegUnit})`;
+    const bookedForUnit = this.resolveBookedForUnit(draft.bookingType);
     const durationLine =
       durationDays === null
         ? []
-        : [`*🗓️ Duration:* ${durationDays} ${durationDays === 1 ? "day" : "days"}`];
+        : [
+            `*🗓️ Booked for:* ${durationDays} ${durationDays === 1 ? bookedForUnit.singular : bookedForUnit.plural}${billedLegsSuffix}`,
+          ];
 
     return [
       "*📋 Booking Summary*",
@@ -327,9 +337,8 @@ export class LangGraphResponderService {
       ...(draft.bookingType
         ? [`*📅 Service:* ${this.getBookingTypeLabel(draft.bookingType)}`]
         : []),
-      ...(draft.pickupDate ? [`*📆 Date:* ${draft.pickupDate}`] : []),
+      ...bookingWindowLines,
       ...durationLine,
-      ...(draft.pickupTime ? [`*⏰ Pickup Time:* ${draft.pickupTime}`] : []),
       ...(draft.pickupLocation ? [`*📍 Pickup:* ${draft.pickupLocation}`] : []),
       ...(draft.dropoffLocation ? [`*📍 Drop-off:* ${draft.dropoffLocation}`] : []),
       "",
@@ -362,6 +371,141 @@ export class LangGraphResponderService {
     }
 
     return dayDifference;
+  }
+
+  private resolveBilledLegs(draft: BookingDraft): number | null {
+    if (draft.bookingType && draft.pickupDate && draft.dropoffDate) {
+      const pickupDate = parseSearchDate(draft.pickupDate);
+      const dropoffDate = parseSearchDate(draft.dropoffDate);
+      if (pickupDate && dropoffDate) {
+        return calculateLegCount(draft.bookingType, pickupDate, dropoffDate);
+      }
+    }
+
+    if (typeof draft.durationDays === "number" && draft.durationDays > 0) {
+      return draft.durationDays;
+    }
+
+    return null;
+  }
+
+  private resolveBookedForUnit(bookingType: BookingType | undefined): {
+    singular: string;
+    plural: string;
+  } {
+    if (bookingType === "NIGHT") {
+      return { singular: "night", plural: "nights" };
+    }
+    return { singular: "day", plural: "days" };
+  }
+
+  private buildBookingWindowLines(draft: BookingDraft): string[] {
+    if (!draft.pickupDate || !draft.pickupTime) {
+      return draft.pickupDate ? [`*📆 Date:* ${draft.pickupDate}`] : [];
+    }
+
+    const startDate = parseSearchDate(draft.pickupDate);
+    if (!startDate) {
+      return [`*📆 Date:* ${draft.pickupDate}`, `*⏰ Pickup Time:* ${draft.pickupTime}`];
+    }
+
+    const startDateTime = this.withTime(startDate, draft.pickupTime);
+    const startLabel = this.formatDateWithAmPm(startDateTime);
+
+    if (!draft.bookingType) {
+      return [`*🕐 Start:* ${startLabel}`];
+    }
+
+    const dropoffDate = this.resolveDisplayDropoffDate(draft, startDate);
+    if (!dropoffDate) {
+      return [`*🕐 Start:* ${startLabel}`];
+    }
+
+    const endDateTime = this.resolveEndDateTime(dropoffDate, draft.bookingType, draft.pickupTime);
+    return [`*🕐 Start:* ${startLabel}`, `*🏁 End:* ${this.formatDateWithAmPm(endDateTime)}`];
+  }
+
+  private resolveEndDateTime(date: Date, bookingType: BookingType, pickupTime: string): Date {
+    switch (bookingType) {
+      case "DAY":
+        return addHours(this.withTime(date, pickupTime), 12);
+      case "NIGHT":
+        return this.withTime(date, "05:00");
+      case "FULL_DAY":
+        return this.withTime(date, pickupTime);
+      case "AIRPORT_PICKUP":
+      default:
+        return this.withTime(date, pickupTime);
+    }
+  }
+
+  private resolveDisplayDropoffDate(draft: BookingDraft, pickupDate: Date): Date | null {
+    if (draft.dropoffDate) {
+      return parseSearchDate(draft.dropoffDate);
+    }
+
+    if (typeof draft.durationDays !== "number" || draft.durationDays <= 0 || !draft.bookingType) {
+      return null;
+    }
+
+    const daysToAdd =
+      draft.bookingType === "DAY" ? Math.max(draft.durationDays - 1, 0) : draft.durationDays;
+    return addHours(pickupDate, daysToAdd * 24);
+  }
+
+  private withTime(date: Date, time: string): Date {
+    const parsed = this.parseTimeTo24Hour(time);
+    if (!parsed) {
+      return date;
+    }
+    return new Date(
+      date.getFullYear(),
+      date.getMonth(),
+      date.getDate(),
+      parsed.hours24,
+      parsed.minutes,
+      0,
+      0,
+    );
+  }
+
+  private parseTimeTo24Hour(time: string): { hours24: number; minutes: number } | null {
+    const normalized = time.trim();
+    const twelveHourMatch = /^(\d{1,2})(?::(\d{2}))?\s*(AM|PM)$/i.exec(normalized);
+    if (twelveHourMatch) {
+      const hour = Number.parseInt(twelveHourMatch[1], 10);
+      const minutes = twelveHourMatch[2] ? Number.parseInt(twelveHourMatch[2], 10) : 0;
+      if (hour < 1 || hour > 12 || minutes < 0 || minutes > 59) {
+        return null;
+      }
+      let hours24 = hour % 12;
+      if (twelveHourMatch[3].toUpperCase() === "PM") {
+        hours24 += 12;
+      }
+      return { hours24, minutes };
+    }
+
+    const twentyFourHourMatch = /^([01]?\d|2[0-3]):([0-5]\d)$/.exec(normalized);
+    if (twentyFourHourMatch) {
+      return {
+        hours24: Number.parseInt(twentyFourHourMatch[1], 10),
+        minutes: Number.parseInt(twentyFourHourMatch[2], 10),
+      };
+    }
+
+    return null;
+  }
+
+  private formatDateWithAmPm(date: Date): string {
+    const datePart = format(date, "do MMM yyyy");
+    const timePart = date
+      .toLocaleTimeString("en-GB", {
+        hour: "numeric",
+        minute: "2-digit",
+        hour12: true,
+      })
+      .toLowerCase();
+    return `${datePart}, ${timePart}`;
   }
 
   private formatRequiredPrice(estimatedTotalInclVat: number): string {

--- a/src/modules/booking-agent/langgraph/langgraph-responder.service.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-responder.service.ts
@@ -494,9 +494,7 @@ export class LangGraphResponderService {
   }
 
   private formatDateWithAmPm(date: Date): string {
-    return format(date, "do MMM yyyy, h:mm a").replace(/\s(AM|PM)$/u, (match) =>
-      match.toLowerCase(),
-    );
+    return format(date, "do MMM yyyy, h:mm aaa");
   }
 
   private formatRequiredPrice(estimatedTotalInclVat: number): string {

--- a/src/modules/booking-agent/langgraph/langgraph-responder.service.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-responder.service.ts
@@ -1,7 +1,6 @@
 import { Inject, Injectable, Logger } from "@nestjs/common";
 import { BookingType } from "@prisma/client";
-import { addHours, format } from "date-fns";
-import { calculateLegCount } from "../../booking/booking.helper";
+import { addHours, format, isMatch, isValid, parse } from "date-fns";
 import { parseSearchDate } from "../vehicle-search-precondition.policy";
 import { LANGGRAPH_BUTTON_ID, LANGGRAPH_SERVICE_UNAVAILABLE_MESSAGE } from "./langgraph.const";
 import { LangGraphResponseFailedException } from "./langgraph.error";
@@ -374,19 +373,67 @@ export class LangGraphResponderService {
   }
 
   private resolveBilledLegs(draft: BookingDraft): number | null {
-    if (draft.bookingType && draft.pickupDate && draft.dropoffDate) {
-      const pickupDate = parseSearchDate(draft.pickupDate);
-      const dropoffDate = parseSearchDate(draft.dropoffDate);
-      if (pickupDate && dropoffDate) {
-        return calculateLegCount(draft.bookingType, pickupDate, dropoffDate);
-      }
-    }
-
     if (typeof draft.durationDays === "number" && draft.durationDays > 0) {
       return draft.durationDays;
     }
 
+    if (draft.bookingType && draft.pickupDate && draft.dropoffDate) {
+      const daySpan = this.calculateDateOnlyDaySpan(draft.pickupDate, draft.dropoffDate);
+      if (daySpan !== null) {
+        switch (draft.bookingType) {
+          case "DAY":
+            return Math.max(1, daySpan + 1);
+          case "NIGHT":
+          case "FULL_DAY":
+            return Math.max(1, daySpan);
+          case "AIRPORT_PICKUP":
+            return 1;
+          default:
+            return null;
+        }
+      }
+    }
+
     return null;
+  }
+
+  private calculateDateOnlyDaySpan(startIsoDate: string, endIsoDate: string): number | null {
+    const startUtc = this.parseIsoDateOnlyToUtc(startIsoDate);
+    const endUtc = this.parseIsoDateOnlyToUtc(endIsoDate);
+    if (startUtc === null || endUtc === null) {
+      return null;
+    }
+
+    const daySpan = Math.round((endUtc - startUtc) / (24 * 60 * 60 * 1000));
+    return Number.isNaN(daySpan) ? null : daySpan;
+  }
+
+  private parseIsoDateOnlyToUtc(value: string): number | null {
+    const normalized = value.trim();
+    if (!isMatch(normalized, "yyyy-MM-dd")) {
+      return null;
+    }
+
+    const parsedDate = parse(normalized, "yyyy-MM-dd", new Date());
+    if (!isValid(parsedDate)) {
+      return null;
+    }
+
+    const year = parsedDate.getFullYear();
+    const month = parsedDate.getMonth() + 1;
+    const day = parsedDate.getDate();
+    const utcTimestamp = Date.UTC(year, month - 1, day, 0, 0, 0, 0);
+    const strictDate = new Date(utcTimestamp);
+    if (
+      Number.isNaN(strictDate.getTime()) ||
+      strictDate.getUTCFullYear() !== year ||
+      strictDate.getUTCMonth() !== month - 1 ||
+      strictDate.getUTCDate() !== day
+    ) {
+      return null;
+    }
+
+    return utcTimestamp;
   }
 
   private resolveBookedForUnit(bookingType: BookingType | undefined): {

--- a/src/modules/booking-agent/langgraph/langgraph-responder.service.ts
+++ b/src/modules/booking-agent/langgraph/langgraph-responder.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Logger } from "@nestjs/common";
 import { BookingType } from "@prisma/client";
-import { addHours, format, isMatch, isValid, parse } from "date-fns";
+import { addHours, format } from "date-fns";
 import { parseSearchDate } from "../vehicle-search-precondition.policy";
 import { LANGGRAPH_BUTTON_ID, LANGGRAPH_SERVICE_UNAVAILABLE_MESSAGE } from "./langgraph.const";
 import { LangGraphResponseFailedException } from "./langgraph.error";
@@ -315,16 +315,13 @@ export class LangGraphResponderService {
   private buildBookingSummary(draft: BookingDraft, selectedOption: VehicleSearchOption): string {
     const priceFormatted = this.formatRequiredPrice(selectedOption.estimatedTotalInclVat);
     const durationDays = this.resolveDurationDays(draft);
-    const billedLegs = this.resolveBilledLegs(draft);
-    const billedLegUnit = billedLegs === 1 ? "leg" : "legs";
     const bookingWindowLines = this.buildBookingWindowLines(draft);
-    const billedLegsSuffix = billedLegs === null ? "" : ` (${billedLegs} billed ${billedLegUnit})`;
     const bookedForUnit = this.resolveBookedForUnit(draft.bookingType);
     const durationLine =
       durationDays === null
         ? []
         : [
-            `*🗓️ Booked for:* ${durationDays} ${durationDays === 1 ? bookedForUnit.singular : bookedForUnit.plural}${billedLegsSuffix}`,
+            `*🗓️ Booked for:* ${durationDays} ${durationDays === 1 ? bookedForUnit.singular : bookedForUnit.plural}`,
           ];
 
     return [
@@ -370,70 +367,6 @@ export class LangGraphResponderService {
     }
 
     return dayDifference;
-  }
-
-  private resolveBilledLegs(draft: BookingDraft): number | null {
-    if (typeof draft.durationDays === "number" && draft.durationDays > 0) {
-      return draft.durationDays;
-    }
-
-    if (draft.bookingType && draft.pickupDate && draft.dropoffDate) {
-      const daySpan = this.calculateDateOnlyDaySpan(draft.pickupDate, draft.dropoffDate);
-      if (daySpan !== null) {
-        switch (draft.bookingType) {
-          case "DAY":
-            return Math.max(1, daySpan + 1);
-          case "NIGHT":
-          case "FULL_DAY":
-            return Math.max(1, daySpan);
-          case "AIRPORT_PICKUP":
-            return 1;
-          default:
-            return null;
-        }
-      }
-    }
-
-    return null;
-  }
-
-  private calculateDateOnlyDaySpan(startIsoDate: string, endIsoDate: string): number | null {
-    const startUtc = this.parseIsoDateOnlyToUtc(startIsoDate);
-    const endUtc = this.parseIsoDateOnlyToUtc(endIsoDate);
-    if (startUtc === null || endUtc === null) {
-      return null;
-    }
-
-    const daySpan = Math.round((endUtc - startUtc) / (24 * 60 * 60 * 1000));
-    return Number.isNaN(daySpan) ? null : daySpan;
-  }
-
-  private parseIsoDateOnlyToUtc(value: string): number | null {
-    const normalized = value.trim();
-    if (!isMatch(normalized, "yyyy-MM-dd")) {
-      return null;
-    }
-
-    const parsedDate = parse(normalized, "yyyy-MM-dd", new Date());
-    if (!isValid(parsedDate)) {
-      return null;
-    }
-
-    const year = parsedDate.getFullYear();
-    const month = parsedDate.getMonth() + 1;
-    const day = parsedDate.getDate();
-    const utcTimestamp = Date.UTC(year, month - 1, day, 0, 0, 0, 0);
-    const strictDate = new Date(utcTimestamp);
-    if (
-      Number.isNaN(strictDate.getTime()) ||
-      strictDate.getUTCFullYear() !== year ||
-      strictDate.getUTCMonth() !== month - 1 ||
-      strictDate.getUTCDate() !== day
-    ) {
-      return null;
-    }
-
-    return utcTimestamp;
   }
 
   private resolveBookedForUnit(bookingType: BookingType | undefined): {

--- a/src/modules/booking-agent/langgraph/prompts/extractor.prompt.ts
+++ b/src/modules/booking-agent/langgraph/prompts/extractor.prompt.ts
@@ -137,10 +137,19 @@ RULES:
 1. Only include fields in draftPatch that are EXPLICITLY mentioned - do NOT assume or infer missing fields
 2. Parse relative dates to absolute YYYY-MM-DD format
 3. Parse times to 24-hour HH:mm format
-4. If user says "for X days", set durationDays AND calculate dropoffDate from pickupDate
+4. If user says "for X days", set durationDays AND calculate dropoffDate based on bookingType:
+   - DAY: dropoffDate = pickupDate + (X - 1) days
+   - FULL_DAY: dropoffDate = pickupDate + X days (each leg is 24 hours)
+   - NIGHT: dropoffDate = pickupDate + X days (X nights)
 5. ONLY set dropoffLocation if user EXPLICITLY says "same location", "same as pickup", or specifies a different location
-6. If user says "from tomorrow for 3 days", calculate: pickupDate=tomorrow, dropoffDate=pickupDate+3days
+6. If user says "from tomorrow for 3 days":
+   - with DAY bookingType -> pickupDate=tomorrow, dropoffDate=pickupDate+2days
+   - with FULL_DAY bookingType -> pickupDate=tomorrow, dropoffDate=pickupDate+3days
 7. NEVER assume dropoffLocation equals pickupLocation unless user explicitly says so
 8. Be conservative with confidence - if unsure, use lower value
-9. If message is ambiguous, prefer ask_question intent`;
+9. If message is ambiguous, prefer ask_question intent
+10. If user explicitly says a brand/model with vehicle type, extract it:
+   - "Toyota SUV" -> make: "Toyota"
+   - "Toyota Highlander SUV" -> make: "Toyota", model: "Highlander"
+11. If user does NOT explicitly mention make/model, do NOT invent them`;
 }

--- a/src/modules/booking-agent/langgraph/search.node.spec.ts
+++ b/src/modules/booking-agent/langgraph/search.node.spec.ts
@@ -116,6 +116,8 @@ describe("SearchNode", () => {
         pickupDate: "2026-03-01",
         pickupTime: "09:00",
         dropoffDate: "2026-03-01",
+        vehicleType: "SUV",
+        make: "Toyota",
         pickupLocation: "Victoria Island",
         dropoffLocation: "Victoria Island",
       },
@@ -141,6 +143,13 @@ describe("SearchNode", () => {
     });
 
     expect(bookingAgentSearchServiceMock.searchVehiclesFromExtracted).toHaveBeenCalledTimes(1);
+    expect(bookingAgentSearchServiceMock.searchVehiclesFromExtracted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        vehicleType: "SUV",
+        make: "Toyota",
+      }),
+      "",
+    );
     expect(result.stage).toBe("presenting_options");
     expect(result.availableOptions).toHaveLength(1);
   });

--- a/src/modules/booking-agent/whatsapp/whatsapp-persistence.service.spec.ts
+++ b/src/modules/booking-agent/whatsapp/whatsapp-persistence.service.spec.ts
@@ -12,6 +12,7 @@ describe("WhatsAppPersistenceService", () => {
       updateMany: ReturnType<typeof vi.fn>;
       update: ReturnType<typeof vi.fn>;
       upsert: ReturnType<typeof vi.fn>;
+      findUnique: ReturnType<typeof vi.fn>;
     };
     whatsAppMessage: {
       update: ReturnType<typeof vi.fn>;
@@ -35,6 +36,7 @@ describe("WhatsAppPersistenceService", () => {
         updateMany: vi.fn(),
         update: vi.fn(),
         upsert: vi.fn(),
+        findUnique: vi.fn(),
       },
       whatsAppMessage: {
         update: vi.fn(),
@@ -79,6 +81,15 @@ describe("WhatsAppPersistenceService", () => {
     });
 
     await expect(service.getInboundMessageContext("msg-1")).resolves.toBeNull();
+  });
+
+  it("returns null link state when conversation is missing", async () => {
+    databaseService.whatsAppConversation.findUnique.mockResolvedValue(null);
+
+    await expect(service.getConversationLinkState("conv-missing")).resolves.toEqual({
+      linkedUserId: null,
+      linkStatus: null,
+    });
   });
 
   it("claims outbox atomically via updateMany", async () => {

--- a/src/modules/booking-agent/whatsapp/whatsapp-persistence.service.ts
+++ b/src/modules/booking-agent/whatsapp/whatsapp-persistence.service.ts
@@ -1,6 +1,11 @@
 import { randomUUID } from "node:crypto";
 import { Injectable, Logger } from "@nestjs/common";
-import { Prisma, WhatsAppMessageKind, WhatsAppOutboxStatus } from "@prisma/client";
+import {
+  Prisma,
+  WhatsAppLinkStatus,
+  WhatsAppMessageKind,
+  WhatsAppOutboxStatus,
+} from "@prisma/client";
 import type { MessageInstance } from "twilio/lib/rest/api/v2010/account/message";
 import { DatabaseService } from "../../database/database.service";
 import { WHATSAPP_PROCESSING_LOCK_TTL_MS } from "../booking-agent.const";
@@ -354,6 +359,23 @@ export class WhatsAppPersistenceService {
       where: { id: conversationId },
       select: { lastInboundAt: true },
     });
+  }
+
+  async getConversationLinkState(
+    conversationId: string,
+  ): Promise<{ linkedUserId: string | null; linkStatus: WhatsAppLinkStatus | null }> {
+    const conversation = await this.databaseService.whatsAppConversation.findUnique({
+      where: { id: conversationId },
+      select: {
+        linkedUserId: true,
+        linkStatus: true,
+      },
+    });
+
+    return {
+      linkedUserId: conversation?.linkedUserId ?? null,
+      linkStatus: conversation?.linkStatus ?? null,
+    };
   }
 
   isUniqueViolation(error: unknown): boolean {

--- a/src/modules/booking-agent/whatsapp/whatsapp.processor.spec.ts
+++ b/src/modules/booking-agent/whatsapp/whatsapp.processor.spec.ts
@@ -221,8 +221,6 @@ describe("WhatsAppProcessor", () => {
       rawPayload: {},
       conversation: {
         windowExpiresAt: new Date("2026-03-01T00:00:00.000Z"),
-        linkStatus: "LINKED",
-        linkedUserId: "user_linked_123",
       },
     });
     persistenceService.getConversationLinkState.mockResolvedValue({
@@ -242,6 +240,7 @@ describe("WhatsAppProcessor", () => {
       }),
     );
 
+    expect(persistenceService.getConversationLinkState).toHaveBeenCalledWith("conv-1");
     expect(orchestratorService.decide).toHaveBeenCalledWith(
       expect.objectContaining({
         customerId: "user_linked_123",

--- a/src/modules/booking-agent/whatsapp/whatsapp.processor.spec.ts
+++ b/src/modules/booking-agent/whatsapp/whatsapp.processor.spec.ts
@@ -46,6 +46,7 @@ describe("WhatsAppProcessor", () => {
   let persistenceService: {
     acquireProcessingLock: ReturnType<typeof vi.fn>;
     getConversationActivity: ReturnType<typeof vi.fn>;
+    getConversationLinkState: ReturnType<typeof vi.fn>;
     getInboundMessageContext: ReturnType<typeof vi.fn>;
     markConversationHandoff: ReturnType<typeof vi.fn>;
     markInboundMessageProcessed: ReturnType<typeof vi.fn>;
@@ -75,6 +76,9 @@ describe("WhatsAppProcessor", () => {
     persistenceService = {
       acquireProcessingLock: vi.fn(),
       getConversationActivity: vi.fn(),
+      getConversationLinkState: vi
+        .fn()
+        .mockResolvedValue({ linkedUserId: null, linkStatus: "UNLINKED" }),
       getInboundMessageContext: vi.fn(),
       markConversationHandoff: vi.fn(),
       markInboundMessageProcessed: vi.fn(),
@@ -163,6 +167,10 @@ describe("WhatsAppProcessor", () => {
       rawPayload: {},
       conversation: { windowExpiresAt: new Date("2026-03-01T00:00:00.000Z") },
     });
+    persistenceService.getConversationLinkState.mockResolvedValue({
+      linkedUserId: "user_linked_123",
+      linkStatus: "LINKED",
+    });
     orchestratorService.decide.mockResolvedValue({
       enqueueOutbox: [
         {
@@ -198,6 +206,46 @@ describe("WhatsAppProcessor", () => {
     expect(persistenceService.releaseProcessingLock).toHaveBeenCalledWith(
       "conv-1",
       expect.any(String),
+    );
+  });
+
+  it("forwards linked customerId from conversation context to orchestrator", async () => {
+    persistenceService.acquireProcessingLock.mockResolvedValue(true);
+    persistenceService.getInboundMessageContext.mockResolvedValue({
+      id: "msg-1",
+      conversationId: "conv-1",
+      body: "book me an suv",
+      kind: WhatsAppMessageKind.TEXT,
+      mediaUrl: null,
+      mediaContentType: null,
+      rawPayload: {},
+      conversation: {
+        windowExpiresAt: new Date("2026-03-01T00:00:00.000Z"),
+        linkStatus: "LINKED",
+        linkedUserId: "user_linked_123",
+      },
+    });
+    persistenceService.getConversationLinkState.mockResolvedValue({
+      linkedUserId: "user_linked_123",
+      linkStatus: "LINKED",
+    });
+    orchestratorService.decide.mockResolvedValue({
+      enqueueOutbox: [],
+      resultingStage: "collecting",
+    });
+
+    await processor.process(
+      buildJob(PROCESS_WHATSAPP_INBOUND_JOB, {
+        conversationId: "conv-1",
+        messageId: "msg-1",
+        dedupeKey: "dedupe-1",
+      }),
+    );
+
+    expect(orchestratorService.decide).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customerId: "user_linked_123",
+      }),
     );
   });
 

--- a/src/modules/booking-agent/whatsapp/whatsapp.processor.ts
+++ b/src/modules/booking-agent/whatsapp/whatsapp.processor.ts
@@ -139,10 +139,15 @@ export class WhatsAppProcessor extends WorkerHost {
   ): Promise<InboundMessageContext & { windowExpiresAt?: Date | null }> {
     const interactive = parseInteractiveReply(context.rawPayload);
     const resolvedInbound = await this.resolveInboundMessageContent(context, traceId);
+    const conversationLinkState = await this.persistenceService.getConversationLinkState(
+      context.conversationId,
+    );
 
     return {
       messageId: context.id,
       conversationId: context.conversationId,
+      customerId:
+        conversationLinkState.linkStatus === "LINKED" ? conversationLinkState.linkedUserId : null,
       body: resolvedInbound.body,
       kind: resolvedInbound.kind,
       windowExpiresAt: context.conversation.windowExpiresAt,

--- a/src/modules/booking/booking-confirmation.service.spec.ts
+++ b/src/modules/booking/booking-confirmation.service.spec.ts
@@ -387,6 +387,41 @@ describe("BookingConfirmationService", () => {
       );
     });
 
+    it("should skip all notifications when customer and owner have no contact channels", async () => {
+      const mockPayment = createMockPayment({
+        id: "payment-123",
+        bookingId: "booking-123",
+      });
+      const mockBooking = createMockBookingWithRelations({
+        id: "booking-123",
+        status: BookingStatus.CONFIRMED,
+        user: null,
+        guestUser: {
+          name: "No Contact Guest",
+          email: null,
+          phoneNumber: null,
+          guestContactSource: "WEB_GUEST_FORM",
+          preferredNotificationChannel: "EMAIL_AND_WHATSAPP",
+        },
+        car: createCar({
+          owner: createOwner({
+            email: null,
+            phoneNumber: null,
+          }),
+        }),
+      });
+
+      vi.mocked(databaseService.booking.updateMany).mockResolvedValueOnce({ count: 1 });
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValueOnce(mockBooking);
+      vi.mocked(databaseService.car.update).mockResolvedValueOnce(mockBooking.car);
+      vi.mocked(notificationQueue.add).mockResolvedValue(createMockJob());
+
+      const result = await service.confirmFromPayment(mockPayment);
+
+      expect(result).toBe(true);
+      expect(notificationQueue.add).not.toHaveBeenCalled();
+    });
+
     it("should not fail confirmation if fleet owner notification queueing fails", async () => {
       const mockPayment = createMockPayment({
         id: "payment-123",

--- a/src/modules/booking/booking-confirmation.service.ts
+++ b/src/modules/booking/booking-confirmation.service.ts
@@ -8,11 +8,14 @@ import type { BookingWithRelations } from "../../types";
 import { DatabaseService } from "../database/database.service";
 import {
   CLIENT_RECIPIENT_TYPE,
-  DEFAULT_CHANNELS,
   FLEET_OWNER_RECIPIENT_TYPE,
   SEND_NOTIFICATION_JOB_NAME,
 } from "../notification/notification.const";
-import { type NotificationJobData, NotificationType } from "../notification/notification.interface";
+import {
+  NotificationChannel,
+  type NotificationJobData,
+  NotificationType,
+} from "../notification/notification.interface";
 import {
   BOOKING_CONFIRMED_TEMPLATE_KIND,
   FLEET_OWNER_NEW_BOOKING_TEMPLATE_KIND,
@@ -170,10 +173,21 @@ export class BookingConfirmationService {
     bookingDetails: ReturnType<typeof normaliseBookingDetails>,
   ): Promise<void> {
     try {
+      const channels = this.determineChannels(
+        bookingDetails.customerEmail,
+        bookingDetails.customerPhone,
+      );
+      if (channels.length === 0) {
+        this.logger.warn("No customer delivery channel available for booking confirmation", {
+          bookingId,
+        });
+        return;
+      }
+
       const jobData: NotificationJobData = {
         id: `booking-confirmed-${bookingId}-${Date.now()}`,
         type: NotificationType.BOOKING_CONFIRMED,
-        channels: DEFAULT_CHANNELS,
+        channels,
         bookingId,
         recipients: {
           [CLIENT_RECIPIENT_TYPE]: {
@@ -227,7 +241,7 @@ export class BookingConfirmationService {
       const jobData: NotificationJobData = {
         id: `fleet-owner-new-booking-${booking.id}-${Date.now()}`,
         type: NotificationType.FLEET_OWNER_NEW_BOOKING,
-        channels: DEFAULT_CHANNELS,
+        channels: this.determineChannels(ownerEmail ?? undefined, ownerPhone ?? undefined),
         bookingId: booking.id,
         recipients: {
           [FLEET_OWNER_RECIPIENT_TYPE]: {
@@ -257,5 +271,16 @@ export class BookingConfirmationService {
         error: error instanceof Error ? error.message : String(error),
       });
     }
+  }
+
+  private determineChannels(email?: string, phoneNumber?: string): NotificationChannel[] {
+    const channels: NotificationChannel[] = [];
+    if (email) {
+      channels.push(NotificationChannel.EMAIL);
+    }
+    if (phoneNumber) {
+      channels.push(NotificationChannel.WHATSAPP);
+    }
+    return channels;
   }
 }

--- a/src/modules/booking/booking-confirmation.service.ts
+++ b/src/modules/booking/booking-confirmation.service.ts
@@ -11,11 +11,8 @@ import {
   FLEET_OWNER_RECIPIENT_TYPE,
   SEND_NOTIFICATION_JOB_NAME,
 } from "../notification/notification.const";
-import {
-  NotificationChannel,
-  type NotificationJobData,
-  NotificationType,
-} from "../notification/notification.interface";
+import { type NotificationJobData, NotificationType } from "../notification/notification.interface";
+import { deriveNotificationChannels } from "../notification/notification-channel.helper";
 import {
   BOOKING_CONFIRMED_TEMPLATE_KIND,
   FLEET_OWNER_NEW_BOOKING_TEMPLATE_KIND,
@@ -173,10 +170,7 @@ export class BookingConfirmationService {
     bookingDetails: ReturnType<typeof normaliseBookingDetails>,
   ): Promise<void> {
     try {
-      const channels = this.determineChannels(
-        bookingDetails.customerEmail,
-        bookingDetails.customerPhone,
-      );
+      const channels = deriveNotificationChannels(bookingDetails);
       if (channels.length === 0) {
         this.logger.warn("No customer delivery channel available for booking confirmation", {
           bookingId,
@@ -241,7 +235,10 @@ export class BookingConfirmationService {
       const jobData: NotificationJobData = {
         id: `fleet-owner-new-booking-${booking.id}-${Date.now()}`,
         type: NotificationType.FLEET_OWNER_NEW_BOOKING,
-        channels: this.determineChannels(ownerEmail ?? undefined, ownerPhone ?? undefined),
+        channels: deriveNotificationChannels({
+          email: ownerEmail ?? undefined,
+          phoneNumber: ownerPhone ?? undefined,
+        }),
         bookingId: booking.id,
         recipients: {
           [FLEET_OWNER_RECIPIENT_TYPE]: {
@@ -271,16 +268,5 @@ export class BookingConfirmationService {
         error: error instanceof Error ? error.message : String(error),
       });
     }
-  }
-
-  private determineChannels(email?: string, phoneNumber?: string): NotificationChannel[] {
-    const channels: NotificationChannel[] = [];
-    if (email) {
-      channels.push(NotificationChannel.EMAIL);
-    }
-    if (phoneNumber) {
-      channels.push(NotificationChannel.WHATSAPP);
-    }
-    return channels;
   }
 }

--- a/src/modules/booking/booking-creation.service.spec.ts
+++ b/src/modules/booking/booking-creation.service.spec.ts
@@ -245,7 +245,7 @@ describe("BookingCreationService", () => {
       const booking = createBookingInput();
       const user = createSessionUser();
 
-      const result = await service.createBooking(booking, user);
+      const result = await service.createBooking({ input: booking, sessionUser: user });
 
       expect(result).toEqual({
         bookingId: "booking-123",
@@ -273,7 +273,7 @@ describe("BookingCreationService", () => {
 
       const booking = createGuestBookingInput();
 
-      const result = await service.createBooking(booking, null);
+      const result = await service.createBooking({ input: booking, sessionUser: null });
 
       expect(result).toEqual({
         bookingId: "booking-123",
@@ -294,7 +294,7 @@ describe("BookingCreationService", () => {
       });
       const user = createSessionUser();
 
-      await service.createBooking(booking, user);
+      await service.createBooking({ input: booking, sessionUser: user });
 
       expect(validationService.validateDates).toHaveBeenCalledWith({
         startDate: new Date("2026-03-03T10:00:00.000Z"),
@@ -319,7 +319,7 @@ describe("BookingCreationService", () => {
       const booking = createBookingInput();
       const user = createSessionUser();
 
-      await expect(service.createBooking(booking, user)).rejects.toThrow(
+      await expect(service.createBooking({ input: booking, sessionUser: user })).rejects.toThrow(
         BookingValidationException,
       );
 
@@ -336,7 +336,9 @@ describe("BookingCreationService", () => {
       const booking = createBookingInput();
       const user = createSessionUser();
 
-      await expect(service.createBooking(booking, user)).rejects.toThrow(CarNotAvailableException);
+      await expect(service.createBooking({ input: booking, sessionUser: user })).rejects.toThrow(
+        CarNotAvailableException,
+      );
 
       expect(databaseService.car.findUnique).not.toHaveBeenCalled();
     });
@@ -352,7 +354,7 @@ describe("BookingCreationService", () => {
 
       const booking = createGuestBookingInput();
 
-      await expect(service.createBooking(booking, null)).rejects.toThrow(
+      await expect(service.createBooking({ input: booking, sessionUser: null })).rejects.toThrow(
         BookingValidationException,
       );
     });
@@ -368,7 +370,7 @@ describe("BookingCreationService", () => {
       const booking = createBookingInput();
 
       // Pass user: null with a non-guest booking
-      await expect(service.createBooking(booking, null)).rejects.toThrow(
+      await expect(service.createBooking({ input: booking, sessionUser: null })).rejects.toThrow(
         BookingValidationException,
       );
       expect(validationService.checkCarAvailability).not.toHaveBeenCalled();
@@ -383,7 +385,9 @@ describe("BookingCreationService", () => {
       const booking = createBookingInput();
       const user = createSessionUser();
 
-      await expect(service.createBooking(booking, user)).rejects.toThrow(CarNotFoundException);
+      await expect(service.createBooking({ input: booking, sessionUser: user })).rejects.toThrow(
+        CarNotFoundException,
+      );
     });
 
     it("should throw BookingValidationException when price does not match", async () => {
@@ -411,7 +415,7 @@ describe("BookingCreationService", () => {
       const booking = createBookingInput({ clientTotalAmount: "10000" });
       const user = createSessionUser();
 
-      await expect(service.createBooking(booking, user)).rejects.toThrow(
+      await expect(service.createBooking({ input: booking, sessionUser: user })).rejects.toThrow(
         BookingValidationException,
       );
     });
@@ -427,7 +431,7 @@ describe("BookingCreationService", () => {
       const booking = createBookingInput();
       const user = createSessionUser();
 
-      await expect(service.createBooking(booking, user)).rejects.toThrow(
+      await expect(service.createBooking({ input: booking, sessionUser: user })).rejects.toThrow(
         PaymentIntentFailedException,
       );
 
@@ -451,7 +455,7 @@ describe("BookingCreationService", () => {
       const booking = createBookingInput();
       const user = createSessionUser();
 
-      await expect(service.createBooking(booking, user)).rejects.toThrow(
+      await expect(service.createBooking({ input: booking, sessionUser: user })).rejects.toThrow(
         BookingCreationFailedException,
       );
     });
@@ -465,7 +469,7 @@ describe("BookingCreationService", () => {
       const booking = createBookingInput();
       const user = createSessionUser();
 
-      await expect(service.createBooking(booking, user)).rejects.toThrow(
+      await expect(service.createBooking({ input: booking, sessionUser: user })).rejects.toThrow(
         BookingPaymentSyncFailedException,
       );
       expect(databaseService.booking.updateMany).not.toHaveBeenCalled();
@@ -511,7 +515,7 @@ describe("BookingCreationService", () => {
       const booking = createBookingInput();
       const user = createSessionUser();
 
-      await expect(service.createBooking(booking, user)).rejects.toThrow(
+      await expect(service.createBooking({ input: booking, sessionUser: user })).rejects.toThrow(
         BookingCreationFailedException,
       );
 
@@ -600,7 +604,7 @@ describe("BookingCreationService", () => {
       });
       const user = createSessionUser();
 
-      const result = await service.createBooking(booking, user);
+      const result = await service.createBooking({ input: booking, sessionUser: user });
 
       expect(result.bookingId).toBe("booking-123");
       expect(flightAwareService.validateFlight).toHaveBeenCalledWith("BA74", "2025-02-01");
@@ -627,7 +631,9 @@ describe("BookingCreationService", () => {
       });
       const user = createSessionUser();
 
-      await expect(service.createBooking(booking, user)).rejects.toThrow(FlightNotFoundException);
+      await expect(service.createBooking({ input: booking, sessionUser: user })).rejects.toThrow(
+        FlightNotFoundException,
+      );
     });
 
     it("should throw FlightAlreadyLandedException when flight has already landed", async () => {
@@ -648,7 +654,7 @@ describe("BookingCreationService", () => {
       });
       const user = createSessionUser();
 
-      await expect(service.createBooking(booking, user)).rejects.toThrow(
+      await expect(service.createBooking({ input: booking, sessionUser: user })).rejects.toThrow(
         FlightAlreadyLandedException,
       );
     });
@@ -732,7 +738,7 @@ describe("BookingCreationService", () => {
       // Session user only has Better Auth fields, not referral info
       const sessionUser = createSessionUser();
 
-      const result = await service.createBooking(booking, sessionUser);
+      const result = await service.createBooking({ input: booking, sessionUser });
 
       expect(result.bookingId).toBe("booking-123");
 
@@ -823,7 +829,7 @@ describe("BookingCreationService", () => {
       // Session user only has Better Auth fields
       const sessionUser = createSessionUser();
 
-      await service.createBooking(booking, sessionUser);
+      await service.createBooking({ input: booking, sessionUser });
 
       // Verify that user.referralDiscountUsed was set to true WITHIN the transaction
       // This prevents the race condition where concurrent bookings could all receive the discount
@@ -894,7 +900,7 @@ describe("BookingCreationService", () => {
       const sessionUser = createSessionUser();
 
       // Should throw because fresh DB query shows discount was already used
-      await expect(service.createBooking(booking, sessionUser)).rejects.toThrow(
+      await expect(service.createBooking({ input: booking, sessionUser })).rejects.toThrow(
         ReferralDiscountNoLongerAvailableException,
       );
     });
@@ -952,7 +958,7 @@ describe("BookingCreationService", () => {
 
       const booking = createGuestBookingInput();
 
-      await service.createBooking(booking, null);
+      await service.createBooking({ input: booking, sessionUser: null });
 
       // Verify no referral discount was passed
       expect(calculationService.calculateBookingCost).toHaveBeenCalledWith(
@@ -1024,7 +1030,7 @@ describe("BookingCreationService", () => {
       const booking = createBookingInput();
       const user = createSessionUser();
 
-      await service.createBooking(booking, user);
+      await service.createBooking({ input: booking, sessionUser: user });
 
       // CRITICAL: Verify NO discount was applied (user already used it)
       expect(calculationService.calculateBookingCost).toHaveBeenCalledWith(

--- a/src/modules/booking/booking-creation.service.ts
+++ b/src/modules/booking/booking-creation.service.ts
@@ -38,6 +38,17 @@ import { BookingValidationService } from "./booking-validation.service";
 import type { CreateBookingInput, CreateGuestBookingDto } from "./dto/create-booking.dto";
 import { isGuestBooking } from "./dto/create-booking.dto";
 
+export type GuestContactSource = "WEB_GUEST_FORM" | "WHATSAPP_AGENT";
+type GuestPreferredNotificationChannel = "EMAIL_AND_WHATSAPP" | "EMAIL_ONLY" | "WHATSAPP_ONLY";
+export type BookingCreationContext = {
+  guestContactSource?: GuestContactSource;
+};
+export type CreateBookingRequest = {
+  input: CreateBookingInput;
+  sessionUser: AuthSession["user"] | null;
+  context?: BookingCreationContext;
+};
+
 /**
  * Service for orchestrating the complete booking creation flow.
  *
@@ -71,8 +82,7 @@ export class BookingCreationService {
   /**
    * Create a new booking.
    *
-   * @param booking - Validated booking DTO from request body
-   * @param sessionUser - Authenticated user from session (null for guest bookings)
+   * @param request - Booking input + session metadata + invocation context
    * @returns Booking ID and checkout URL
    * @throws BookingValidationException for validation errors
    * @throws CarNotFoundException if car not found
@@ -81,11 +91,9 @@ export class BookingCreationService {
    * @throws PaymentIntentFailedException if payment creation fails
    * @throws BookingCreationFailedException for other errors
    */
-  async createBooking(
-    booking: CreateBookingInput,
-    sessionUser: AuthSession["user"] | null,
-  ): Promise<CreateBookingResponse> {
-    const normalizedBooking = this.normalizeInput(booking);
+  async createBooking(request: CreateBookingRequest): Promise<CreateBookingResponse> {
+    const { input, sessionUser, context } = request;
+    const normalizedBooking = this.normalizeInput(input);
     this.validationService.validateGuestRequirements(normalizedBooking, sessionUser);
 
     this.logger.log("Starting booking creation", {
@@ -162,6 +170,7 @@ export class BookingCreationService {
     const result = await this.createBookingWithPayment({
       booking: normalizedBooking,
       sessionUser,
+      context,
       car,
       legs,
       financials,
@@ -336,6 +345,7 @@ export class BookingCreationService {
   private async createBookingWithPayment(params: {
     booking: CreateBookingInput;
     sessionUser: AuthSession["user"] | null;
+    context?: BookingCreationContext;
     car: CarWithPricing;
     legs: GeneratedLeg[];
     financials: BookingFinancials;
@@ -346,6 +356,7 @@ export class BookingCreationService {
     const {
       booking,
       sessionUser,
+      context,
       car,
       legs,
       financials,
@@ -361,6 +372,11 @@ export class BookingCreationService {
           email: customerDetails.email,
           name: customerDetails.name,
           phoneNumber: customerDetails.phoneNumber ?? null,
+          guestContactSource: context?.guestContactSource ?? "WEB_GUEST_FORM",
+          preferredNotificationChannel:
+            context?.guestContactSource === "WHATSAPP_AGENT"
+              ? ("WHATSAPP_ONLY" as GuestPreferredNotificationChannel)
+              : ("EMAIL_AND_WHATSAPP" as GuestPreferredNotificationChannel),
         };
 
     // Track flight record ID for post-transaction alert creation

--- a/src/modules/booking/booking-creation.service.ts
+++ b/src/modules/booking/booking-creation.service.ts
@@ -39,7 +39,6 @@ import type { CreateBookingInput, CreateGuestBookingDto } from "./dto/create-boo
 import { isGuestBooking } from "./dto/create-booking.dto";
 
 export type GuestContactSource = "WEB_GUEST_FORM" | "WHATSAPP_AGENT";
-type GuestPreferredNotificationChannel = "EMAIL_AND_WHATSAPP" | "EMAIL_ONLY" | "WHATSAPP_ONLY";
 export type BookingCreationContext = {
   guestContactSource?: GuestContactSource;
 };
@@ -365,6 +364,13 @@ export class BookingCreationService {
       preliminaryReferralEligibility,
     } = params;
 
+    const preferredNotificationChannel: "WHATSAPP_ONLY" | "EMAIL_AND_WHATSAPP" | "EMAIL_ONLY" =
+      context?.guestContactSource === "WHATSAPP_AGENT"
+        ? "WHATSAPP_ONLY"
+        : customerDetails.phoneNumber
+          ? "EMAIL_AND_WHATSAPP"
+          : "EMAIL_ONLY";
+
     // Build guest user JSON from customerDetails (if guest booking)
     const guestUser = sessionUser
       ? null
@@ -373,10 +379,7 @@ export class BookingCreationService {
           name: customerDetails.name,
           phoneNumber: customerDetails.phoneNumber ?? null,
           guestContactSource: context?.guestContactSource ?? "WEB_GUEST_FORM",
-          preferredNotificationChannel:
-            context?.guestContactSource === "WHATSAPP_AGENT"
-              ? ("WHATSAPP_ONLY" as GuestPreferredNotificationChannel)
-              : ("EMAIL_AND_WHATSAPP" as GuestPreferredNotificationChannel),
+          preferredNotificationChannel,
         };
 
     // Track flight record ID for post-transaction alert creation
@@ -500,27 +503,7 @@ export class BookingCreationService {
         throw error;
       }
 
-      // Step 3: Compensation - keep booking in unpaid state if payment creation fails
-      this.logger.warn("Payment intent failed, keeping booking in UNPAID state", {
-        bookingId: createdBooking.id,
-        bookingReference: createdBooking.bookingReference,
-      });
-
-      try {
-        await this.persistenceService.markBookingUnpaid(createdBooking.id);
-      } catch (markUnpaidError) {
-        this.logger.error("Failed to mark booking as UNPAID after payment failure", {
-          bookingId: createdBooking.id,
-          bookingReference: createdBooking.bookingReference,
-          error:
-            markUnpaidError instanceof Error ? markUnpaidError.message : String(markUnpaidError),
-          originalPaymentError: error instanceof Error ? error.message : String(error),
-        });
-
-        throw new BookingCreationFailedException(
-          "Payment failed and compensation failed to mark booking as UNPAID.",
-        );
-      }
+      await this.handlePaymentFailureCompensation(createdBooking, error);
 
       // Re-throw payment exception
       if (error instanceof PaymentIntentFailedException) {
@@ -535,6 +518,30 @@ export class BookingCreationService {
       bookingId: createdBooking.id,
       checkoutUrl,
     };
+  }
+
+  private async handlePaymentFailureCompensation(booking: Booking, originalError: unknown) {
+    // Step 3: Compensation - keep booking in unpaid state if payment creation fails
+    this.logger.warn("Payment intent failed, keeping booking in UNPAID state", {
+      bookingId: booking.id,
+      bookingReference: booking.bookingReference,
+    });
+
+    try {
+      await this.persistenceService.markBookingUnpaid(booking.id);
+    } catch (markUnpaidError) {
+      this.logger.error("Failed to mark booking as UNPAID after payment failure", {
+        bookingId: booking.id,
+        bookingReference: booking.bookingReference,
+        error: markUnpaidError instanceof Error ? markUnpaidError.message : String(markUnpaidError),
+        originalPaymentError:
+          originalError instanceof Error ? originalError.message : String(originalError),
+      });
+
+      throw new BookingCreationFailedException(
+        "Payment failed and compensation failed to mark booking as UNPAID.",
+      );
+    }
   }
 
   private async syncPaymentIntentWithBooking(

--- a/src/modules/booking/booking-leg.service.ts
+++ b/src/modules/booking/booking-leg.service.ts
@@ -1,6 +1,6 @@
 import { UTCDate } from "@date-fns/utc";
 import { Injectable } from "@nestjs/common";
-import { addDays, addHours, eachDayOfInterval, setHours, setMinutes, setSeconds } from "date-fns";
+import { addDays, addHours, setHours, setMinutes, setSeconds } from "date-fns";
 import {
   AIRPORT_PICKUP_BUFFER_MINUTES,
   AIRPORT_PICKUP_DRIVE_TIME_MULTIPLIER,
@@ -9,7 +9,7 @@ import {
   NIGHT_END_HOUR,
   NIGHT_START_HOUR,
 } from "./booking.const";
-import { getEffectiveEndDate } from "./booking.helper";
+import { calculateFullDayLegCount, calculateNightLegCount, getDayLegDates } from "./booking.helper";
 import { GeneratedLeg, LegGenerationInput } from "./booking.interface";
 
 /**
@@ -66,13 +66,7 @@ export class BookingLegService {
     const { startDate, endDate, pickupTime } = input;
 
     const { hours, minutes } = this.parsePickupTime(pickupTime);
-    const effectiveEndDate = getEffectiveEndDate(endDate, startDate);
-
-    // Convert to UTCDate for timezone-safe operations
-    const utcStart = new UTCDate(startDate);
-    const utcEnd = new UTCDate(effectiveEndDate);
-
-    const days = eachDayOfInterval({ start: utcStart, end: utcEnd });
+    const days = getDayLegDates(startDate, endDate);
 
     return days.map((day) => {
       const legStartTime = setSeconds(setMinutes(setHours(day, hours), minutes), 0);
@@ -101,11 +95,9 @@ export class BookingLegService {
     input: Extract<LegGenerationInput, { bookingType: "NIGHT" }>,
   ): GeneratedLeg[] {
     const { startDate, endDate } = input;
-    const effectiveEndDate = getEffectiveEndDate(endDate, startDate);
 
     const legs: GeneratedLeg[] = [];
-    const totalHours = (effectiveEndDate.getTime() - startDate.getTime()) / (1000 * 60 * 60);
-    const numberOfNights = Math.max(1, Math.ceil(totalHours / 24));
+    const numberOfNights = calculateNightLegCount(startDate, endDate);
 
     // Convert to UTCDate for timezone-safe operations
     const utcStart = new UTCDate(startDate);
@@ -147,7 +139,6 @@ export class BookingLegService {
     const { startDate, endDate, pickupTime } = input;
 
     const { hours, minutes } = this.parsePickupTime(pickupTime);
-    const effectiveEndDate = getEffectiveEndDate(endDate, startDate);
 
     // Convert to UTCDate for timezone-safe operations
     const utcStart = new UTCDate(startDate);
@@ -156,9 +147,7 @@ export class BookingLegService {
     const baseStartTime = setSeconds(setMinutes(setHours(utcStart, hours), minutes), 0);
 
     // Calculate total hours and number of legs
-    const totalMs = effectiveEndDate.getTime() - baseStartTime.getTime();
-    const totalHours = totalMs / (1000 * 60 * 60);
-    const numberOfLegs = Math.max(1, Math.ceil(totalHours / FULL_DAY_DURATION_HOURS));
+    const numberOfLegs = calculateFullDayLegCount(startDate, endDate, baseStartTime);
 
     const legs: GeneratedLeg[] = [];
 

--- a/src/modules/booking/booking-persistence.service.ts
+++ b/src/modules/booking/booking-persistence.service.ts
@@ -100,7 +100,13 @@ export class BookingPersistenceService {
       bookingReference: string;
       car: CarWithPricing;
       userId: string | null;
-      guestUser: { email: string; name: string; phoneNumber: string | null } | null;
+      guestUser: {
+        email: string;
+        name: string;
+        phoneNumber: string | null;
+        guestContactSource: "WEB_GUEST_FORM" | "WHATSAPP_AGENT";
+        preferredNotificationChannel: "EMAIL_AND_WHATSAPP" | "EMAIL_ONLY" | "WHATSAPP_ONLY";
+      } | null;
       booking: CreateBookingInput;
       financials: BookingFinancials;
       referralEligibility: ReferralEligibility;
@@ -116,7 +122,13 @@ export class BookingPersistenceService {
     bookingReference: string;
     car: CarWithPricing;
     userId: string | null;
-    guestUser: { email: string; name: string; phoneNumber: string | null } | null;
+    guestUser: {
+      email: string;
+      name: string;
+      phoneNumber: string | null;
+      guestContactSource: "WEB_GUEST_FORM" | "WHATSAPP_AGENT";
+      preferredNotificationChannel: "EMAIL_AND_WHATSAPP" | "EMAIL_ONLY" | "WHATSAPP_ONLY";
+    } | null;
     booking: CreateBookingInput;
     financials: BookingFinancials;
     referralEligibility: ReferralEligibility;

--- a/src/modules/booking/booking.controller.spec.ts
+++ b/src/modules/booking/booking.controller.spec.ts
@@ -152,19 +152,21 @@ describe("BookingController", () => {
         expect(result).toEqual(mockCreateBookingResponse);
         expect(bookingCreationService.createBooking).toHaveBeenCalledWith(
           expect.objectContaining({
-            carId: "car-123",
-            bookingType: "DAY",
+            input: expect.objectContaining({
+              carId: "car-123",
+              bookingType: "DAY",
+            }),
+            sessionUser: {
+              id: "user-123",
+              email: "user@example.com",
+              name: "Test User",
+              emailVerified: true,
+              image: null,
+              roles: ["user"],
+              createdAt: expect.any(Date),
+              updatedAt: expect.any(Date),
+            },
           }),
-          {
-            id: "user-123",
-            email: "user@example.com",
-            name: "Test User",
-            emailVerified: true,
-            image: null,
-            roles: ["user"],
-            createdAt: expect.any(Date),
-            updatedAt: expect.any(Date),
-          },
         );
       });
 
@@ -194,12 +196,14 @@ describe("BookingController", () => {
         expect(result).toEqual(mockCreateBookingResponse);
         expect(bookingCreationService.createBooking).toHaveBeenCalledWith(
           expect.objectContaining({
-            carId: "car-123",
-            guestEmail: "guest@example.com",
-            guestName: "Guest User",
-            guestPhone: "08098765432",
+            input: expect.objectContaining({
+              carId: "car-123",
+              guestEmail: "guest@example.com",
+              guestName: "Guest User",
+              guestPhone: "08098765432",
+            }),
+            sessionUser: null,
           }),
-          null,
         );
       });
 
@@ -266,10 +270,12 @@ describe("BookingController", () => {
         expect(result).toEqual(mockCreateBookingResponse);
         expect(bookingCreationService.createBooking).toHaveBeenCalledWith(
           expect.objectContaining({
-            sameLocation: false,
-            dropOffAddress: "456 Other St, Lagos",
+            input: expect.objectContaining({
+              sameLocation: false,
+              dropOffAddress: "456 Other St, Lagos",
+            }),
+            sessionUser: expect.any(Object),
           }),
-          expect.any(Object),
         );
       });
     });

--- a/src/modules/booking/booking.controller.ts
+++ b/src/modules/booking/booking.controller.ts
@@ -65,7 +65,10 @@ export class BookingController {
     @ValidatedBookingBody() booking: CreateBookingInput,
     @CurrentUser() sessionUser: AuthSession["user"] | null,
   ): Promise<CreateBookingResponse> {
-    return this.bookingCreationService.createBooking(booking, sessionUser);
+    return this.bookingCreationService.createBooking({
+      input: booking,
+      sessionUser,
+    });
   }
 
   @Post(":bookingId/extensions")

--- a/src/modules/booking/booking.helper.ts
+++ b/src/modules/booking/booking.helper.ts
@@ -46,20 +46,23 @@ export function calculateLegCount(
  * Calculate leg count for DAY bookings.
  * Uses eachDayOfInterval with UTC dates for consistent results.
  */
-function calculateDayLegCount(startDate: Date, endDate: Date): number {
+export function getDayLegDates(startDate: Date, endDate: Date): Date[] {
   const effectiveEndDate = getEffectiveEndDate(endDate, startDate);
-  const utcStart = new UTCDate(startDate);
-  const utcEnd = new UTCDate(effectiveEndDate);
+  return eachDayOfInterval({
+    start: new UTCDate(startDate),
+    end: new UTCDate(effectiveEndDate),
+  });
+}
 
-  const days = eachDayOfInterval({ start: utcStart, end: utcEnd });
-  return days.length;
+export function calculateDayLegCount(startDate: Date, endDate: Date): number {
+  return getDayLegDates(startDate, endDate).length;
 }
 
 /**
  * Calculate leg count for NIGHT bookings.
  * Number of nights = ceil(totalHours / 24), minimum 1.
  */
-function calculateNightLegCount(startDate: Date, endDate: Date): number {
+export function calculateNightLegCount(startDate: Date, endDate: Date): number {
   const effectiveEndDate = getEffectiveEndDate(endDate, startDate);
   const totalHours = (effectiveEndDate.getTime() - startDate.getTime()) / (1000 * 60 * 60);
   return Math.max(1, Math.ceil(totalHours / 24));
@@ -69,9 +72,13 @@ function calculateNightLegCount(startDate: Date, endDate: Date): number {
  * Calculate leg count for FULL_DAY bookings.
  * Number of legs = ceil(totalHours / 24), minimum 1.
  */
-function calculateFullDayLegCount(startDate: Date, endDate: Date): number {
+export function calculateFullDayLegCount(
+  startDate: Date,
+  endDate: Date,
+  baseStartTime: Date = startDate,
+): number {
   const effectiveEndDate = getEffectiveEndDate(endDate, startDate);
-  const totalMs = effectiveEndDate.getTime() - startDate.getTime();
+  const totalMs = effectiveEndDate.getTime() - baseStartTime.getTime();
   const totalHours = totalMs / (1000 * 60 * 60);
   return Math.max(1, Math.ceil(totalHours / 24));
 }

--- a/src/modules/booking/extension-confirmation.service.spec.ts
+++ b/src/modules/booking/extension-confirmation.service.spec.ts
@@ -109,10 +109,73 @@ describe("ExtensionConfirmationService", () => {
       expect.any(String),
       expect.objectContaining({
         type: NotificationType.BOOKING_EXTENSION_CONFIRMED,
-        channels: [NotificationChannel.EMAIL],
+        channels: [NotificationChannel.EMAIL, NotificationChannel.WHATSAPP],
       }),
       expect.objectContaining({
         jobId: "booking-extension-confirmed-extension-1",
+      }),
+    );
+  });
+
+  it("queues WhatsApp-only extension confirmation for WhatsApp-agent guest", async () => {
+    txMock.extension.updateMany.mockResolvedValueOnce({ count: 1 });
+    txMock.extension.findUnique.mockResolvedValueOnce({
+      id: "extension-2",
+      bookingLegId: "leg-2",
+      extendedDurationHours: 1,
+      extensionStartTime: new Date("2026-02-20T10:00:00.000Z"),
+      extensionEndTime: new Date("2026-02-20T11:00:00.000Z"),
+      bookingLeg: {
+        id: "leg-2",
+        legDate: new Date("2026-02-20T00:00:00.000Z"),
+        legEndTime: new Date("2026-02-20T10:00:00.000Z"),
+        booking: {
+          id: "booking-2",
+          bookingReference: "BOOK-2",
+          status: "ACTIVE",
+          pickupLocation: "A",
+          returnLocation: "B",
+          startDate: new Date("2026-02-20T08:00:00.000Z"),
+          endDate: new Date("2026-02-20T10:00:00.000Z"),
+          totalAmount: { toFixed: () => "10000.00" },
+          cancellationReason: null,
+          user: null,
+          guestUser: {
+            name: "WhatsApp Guest",
+            email: "whatsapp.2348012345678@tripdly.com",
+            phoneNumber: "+2348012345678",
+            guestContactSource: "WHATSAPP_AGENT",
+            preferredNotificationChannel: "WHATSAPP_ONLY",
+          },
+          chauffeur: null,
+          car: {
+            make: "Toyota",
+            model: "Camry",
+            year: 2022,
+            owner: { name: "Owner", username: null, email: "owner@example.com" },
+          },
+          legs: [{ extensions: [] }],
+        },
+      },
+    });
+    txMock.bookingLeg.updateMany.mockResolvedValueOnce({ count: 1 });
+    queueMock.add.mockResolvedValueOnce(undefined);
+
+    const result = await service.confirmFromPayment({
+      id: "payment-2",
+      txRef: "tx-2",
+      extensionId: "extension-2",
+    } as never);
+
+    expect(result).toBe(true);
+    expect(queueMock.add).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        type: NotificationType.BOOKING_EXTENSION_CONFIRMED,
+        channels: [NotificationChannel.WHATSAPP],
+      }),
+      expect.objectContaining({
+        jobId: "booking-extension-confirmed-extension-2",
       }),
     );
   });

--- a/src/modules/booking/extension-confirmation.service.ts
+++ b/src/modules/booking/extension-confirmation.service.ts
@@ -94,6 +94,21 @@ export class ExtensionConfirmationService {
 
     const bookingDetails = normaliseBookingDetails(updatedExtension.bookingLeg.booking);
     const extensionDetails = normaliseExtensionDetails(updatedExtension);
+    const channels: NotificationChannel[] = [];
+    if (bookingDetails.customerEmail) {
+      channels.push(NotificationChannel.EMAIL);
+    }
+    if (bookingDetails.customerPhone) {
+      channels.push(NotificationChannel.WHATSAPP);
+    }
+
+    if (channels.length === 0) {
+      this.logger.warn("No customer delivery channel available for extension confirmation", {
+        extensionId: updatedExtension.id,
+        bookingId: updatedExtension.bookingLeg.booking.id,
+      });
+      return true;
+    }
 
     const notificationJobId = `booking-extension-confirmed-${updatedExtension.id}`;
     await this.notificationQueue.add(
@@ -101,7 +116,7 @@ export class ExtensionConfirmationService {
       {
         id: notificationJobId,
         type: NotificationType.BOOKING_EXTENSION_CONFIRMED,
-        channels: [NotificationChannel.EMAIL],
+        channels,
         bookingId: updatedExtension.bookingLeg.booking.id,
         recipients: {
           [CLIENT_RECIPIENT_TYPE]: {

--- a/src/modules/booking/extension-confirmation.service.ts
+++ b/src/modules/booking/extension-confirmation.service.ts
@@ -9,11 +9,8 @@ import {
   CLIENT_RECIPIENT_TYPE,
   SEND_NOTIFICATION_JOB_NAME,
 } from "../notification/notification.const";
-import {
-  NotificationChannel,
-  type NotificationJobData,
-  NotificationType,
-} from "../notification/notification.interface";
+import { type NotificationJobData, NotificationType } from "../notification/notification.interface";
+import { deriveNotificationChannels } from "../notification/notification-channel.helper";
 import { BOOKING_EXTENSION_CONFIRMED_TEMPLATE_KIND } from "../notification/template-data.interface";
 
 @Injectable()
@@ -94,13 +91,7 @@ export class ExtensionConfirmationService {
 
     const bookingDetails = normaliseBookingDetails(updatedExtension.bookingLeg.booking);
     const extensionDetails = normaliseExtensionDetails(updatedExtension);
-    const channels: NotificationChannel[] = [];
-    if (bookingDetails.customerEmail) {
-      channels.push(NotificationChannel.EMAIL);
-    }
-    if (bookingDetails.customerPhone) {
-      channels.push(NotificationChannel.WHATSAPP);
-    }
+    const channels = deriveNotificationChannels(bookingDetails);
 
     if (channels.length === 0) {
       this.logger.warn("No customer delivery channel available for extension confirmation", {

--- a/src/modules/notification/notification-channel.helper.ts
+++ b/src/modules/notification/notification-channel.helper.ts
@@ -1,0 +1,23 @@
+import { NotificationChannel } from "./notification.interface";
+
+type NotificationChannelInput = {
+  customerEmail?: string;
+  customerPhone?: string;
+  email?: string;
+  phoneNumber?: string;
+};
+
+export function deriveNotificationChannels(input: NotificationChannelInput): NotificationChannel[] {
+  const email = input.customerEmail ?? input.email;
+  const phoneNumber = input.customerPhone ?? input.phoneNumber;
+  const channels: NotificationChannel[] = [];
+
+  if (email) {
+    channels.push(NotificationChannel.EMAIL);
+  }
+  if (phoneNumber) {
+    channels.push(NotificationChannel.WHATSAPP);
+  }
+
+  return channels;
+}

--- a/src/modules/notification/notification.processor.ts
+++ b/src/modules/notification/notification.processor.ts
@@ -43,6 +43,7 @@ import {
 import {
   BookingCancelledMapper,
   BookingConfirmedMapper,
+  BookingExtensionConfirmedMapper,
   BookingReminderEndMapper,
   BookingReminderStartMapper,
   BookingStatusMapper,
@@ -67,6 +68,7 @@ export class NotificationProcessor extends WorkerHost {
     // Initialize template mappers in order of specificity
     this.templateMappers = [
       new BookingConfirmedMapper(),
+      new BookingExtensionConfirmedMapper(),
       new BookingCancelledMapper(),
       new FleetOwnerNewBookingMapper(),
       new BookingStatusMapper(),

--- a/src/modules/notification/notification.service.spec.ts
+++ b/src/modules/notification/notification.service.spec.ts
@@ -84,6 +84,106 @@ describe("NotificationService", () => {
         { priority: 1 },
       );
     });
+
+    it("should queue WhatsApp-only status notification for WhatsApp-agent guest", async () => {
+      const booking = createBooking({
+        status: BookingStatus.ACTIVE,
+        car: createCar({ owner: createOwner() }),
+        chauffeur: createChauffeur(),
+        user: null,
+        guestUser: {
+          name: "WhatsApp Guest",
+          email: "whatsapp.2348012345678@tripdly.com",
+          phoneNumber: "+2348012345678",
+          guestContactSource: "WHATSAPP_AGENT",
+          preferredNotificationChannel: "WHATSAPP_ONLY",
+        },
+      });
+
+      await service.queueBookingStatusNotifications(
+        booking,
+        BookingStatus.CONFIRMED,
+        BookingStatus.ACTIVE,
+      );
+
+      expect(mockQueue.add).toHaveBeenCalledWith(
+        SEND_NOTIFICATION_JOB_NAME,
+        expect.objectContaining({
+          type: NotificationType.BOOKING_STATUS_CHANGE,
+          channels: [NotificationChannel.WHATSAPP],
+          bookingId: booking.id,
+          recipients: expect.objectContaining({
+            [CLIENT_RECIPIENT_TYPE]: expect.objectContaining({
+              email: undefined,
+              phoneNumber: "+2348012345678",
+            }),
+          }),
+        }),
+        { priority: 1 },
+      );
+    });
+
+    it("should queue email-only status notification when guest prefers email", async () => {
+      const booking = createBooking({
+        status: BookingStatus.ACTIVE,
+        car: createCar({ owner: createOwner() }),
+        chauffeur: createChauffeur(),
+        user: null,
+        guestUser: {
+          name: "Email Guest",
+          email: "guest@example.com",
+          phoneNumber: "+2348012345678",
+          guestContactSource: "WEB_GUEST_FORM",
+          preferredNotificationChannel: "EMAIL_ONLY",
+        },
+      });
+
+      await service.queueBookingStatusNotifications(
+        booking,
+        BookingStatus.CONFIRMED,
+        BookingStatus.ACTIVE,
+      );
+
+      expect(mockQueue.add).toHaveBeenCalledWith(
+        SEND_NOTIFICATION_JOB_NAME,
+        expect.objectContaining({
+          type: NotificationType.BOOKING_STATUS_CHANGE,
+          channels: [NotificationChannel.EMAIL],
+          bookingId: booking.id,
+          recipients: expect.objectContaining({
+            [CLIENT_RECIPIENT_TYPE]: expect.objectContaining({
+              email: "guest@example.com",
+              phoneNumber: undefined,
+            }),
+          }),
+        }),
+        { priority: 1 },
+      );
+    });
+
+    it("should skip status notification when customer has no deliverable channels", async () => {
+      const booking = createBooking({
+        status: BookingStatus.ACTIVE,
+        car: createCar({ owner: createOwner() }),
+        chauffeur: createChauffeur(),
+        user: null,
+        guestUser: {
+          name: "No Contact Guest",
+          email: null,
+          phoneNumber: null,
+          guestContactSource: "WEB_GUEST_FORM",
+          preferredNotificationChannel: "EMAIL_AND_WHATSAPP",
+        },
+      });
+
+      await service.queueBookingStatusNotifications(
+        booking,
+        BookingStatus.CONFIRMED,
+        BookingStatus.ACTIVE,
+      );
+
+      expect(mockQueue.add).not.toHaveBeenCalled();
+    });
   });
 
   describe("queueBookingReminderNotifications", () => {

--- a/src/modules/notification/notification.service.ts
+++ b/src/modules/notification/notification.service.ts
@@ -147,7 +147,7 @@ export class NotificationService {
       });
       this.recordNotificationSkippedNoChannel({
         bookingId: bookingDetails.id,
-        oldStatus: "CANCELLED",
+        oldStatus: booking.status,
         newStatus: "CANCELLED",
       });
       return;
@@ -406,8 +406,14 @@ export class NotificationService {
     oldStatus: string;
     newStatus: string;
   }): void {
-    this.notificationSkippedNoChannelCounter.add(1, {
+    this.logger.debug("Incrementing notification_skipped_no_channel counter", {
       bookingId: input.bookingId,
+      oldStatus: input.oldStatus,
+      newStatus: input.newStatus,
+      reason: "no_channel",
+    });
+
+    this.notificationSkippedNoChannelCounter.add(1, {
       oldStatus: input.oldStatus,
       newStatus: input.newStatus,
       reason: "no_channel",

--- a/src/modules/notification/notification.service.ts
+++ b/src/modules/notification/notification.service.ts
@@ -11,7 +11,6 @@ import {
 import {
   CHAUFFEUR_RECIPIENT_TYPE,
   CLIENT_RECIPIENT_TYPE,
-  DEFAULT_CHANNELS,
   FLEET_OWNER_RECIPIENT_TYPE,
   HIGH_PRIORITY_JOB_OPTIONS,
   SEND_NOTIFICATION_JOB_NAME,
@@ -57,6 +56,14 @@ export class NotificationService {
       newStatus,
       showReviewRequest,
     });
+    if (jobData.channels.length === 0) {
+      this.logger.warn("No customer delivery channel available for booking status notification", {
+        bookingId: booking.id,
+        oldStatus,
+        newStatus,
+      });
+      return;
+    }
 
     await this.addJobToQueue(jobData, HIGH_PRIORITY_JOB_OPTIONS);
 
@@ -78,7 +85,7 @@ export class NotificationService {
     const customerJobData: NotificationJobData = {
       id: `cancelled-client-${bookingDetails.id}-${Date.now()}`,
       type: NotificationType.BOOKING_CANCELLED,
-      channels: DEFAULT_CHANNELS,
+      channels: this.determineChannels(bookingDetails.customerEmail, bookingDetails.customerPhone),
       bookingId: bookingDetails.id,
       recipients: {
         [CLIENT_RECIPIENT_TYPE]: {
@@ -89,12 +96,17 @@ export class NotificationService {
       templateData,
     };
 
+    const jobs: Promise<unknown>[] = [];
+    if (customerJobData.channels.length > 0) {
+      jobs.push(this.addJobToQueue(customerJobData, HIGH_PRIORITY_JOB_OPTIONS));
+    } else {
+      this.logger.warn("No customer delivery channel available for booking cancellation", {
+        bookingId: bookingDetails.id,
+      });
+    }
+
     const ownerEmail = booking.car?.owner?.email;
     const ownerPhone = booking.car?.owner?.phoneNumber;
-
-    const jobs: Promise<unknown>[] = [
-      this.addJobToQueue(customerJobData, HIGH_PRIORITY_JOB_OPTIONS),
-    ];
 
     if (ownerEmail || ownerPhone) {
       const ownerJobData: NotificationJobData = {
@@ -114,6 +126,13 @@ export class NotificationService {
         },
       };
       jobs.push(this.addJobToQueue(ownerJobData, HIGH_PRIORITY_JOB_OPTIONS));
+    }
+
+    if (jobs.length === 0) {
+      this.logger.warn("No delivery channels available for booking cancellation notifications", {
+        bookingId: bookingDetails.id,
+      });
+      return;
     }
 
     await Promise.all(jobs);
@@ -204,7 +223,7 @@ export class NotificationService {
     return {
       id: `status-${bookingDetails.id}-${Date.now()}`,
       type: NotificationType.BOOKING_STATUS_CHANGE,
-      channels: DEFAULT_CHANNELS,
+      channels: this.determineChannels(bookingDetails.customerEmail, bookingDetails.customerPhone),
       bookingId: bookingDetails.id,
       recipients: {
         [CLIENT_RECIPIENT_TYPE]: {

--- a/src/modules/notification/notification.service.ts
+++ b/src/modules/notification/notification.service.ts
@@ -1,5 +1,6 @@
 import { InjectQueue } from "@nestjs/bullmq";
 import { Injectable, Logger } from "@nestjs/common";
+import { metrics } from "@opentelemetry/api";
 import { Job, JobsOptions, Queue } from "bullmq";
 import { NOTIFICATIONS_QUEUE } from "src/config/constants";
 import { normaliseBookingDetails, normaliseBookingLegDetails } from "../../shared/helper";
@@ -22,6 +23,7 @@ import {
   NotificationType,
   QueueReviewReceivedNotificationParams,
 } from "./notification.interface";
+import { deriveNotificationChannels } from "./notification-channel.helper";
 import {
   BOOKING_CANCELLED_TEMPLATE_KIND,
   BOOKING_REMINDER_TEMPLATE_KIND,
@@ -33,6 +35,9 @@ import {
 @Injectable()
 export class NotificationService {
   private readonly logger = new Logger(NotificationService.name);
+  private readonly notificationSkippedNoChannelCounter = metrics
+    .getMeter("notification-service")
+    .createCounter("notification_skipped_no_channel");
 
   constructor(
     @InjectQueue(NOTIFICATIONS_QUEUE)
@@ -62,6 +67,11 @@ export class NotificationService {
         oldStatus,
         newStatus,
       });
+      this.recordNotificationSkippedNoChannel({
+        bookingId: booking.id,
+        oldStatus,
+        newStatus,
+      });
       return;
     }
 
@@ -85,7 +95,7 @@ export class NotificationService {
     const customerJobData: NotificationJobData = {
       id: `cancelled-client-${bookingDetails.id}-${Date.now()}`,
       type: NotificationType.BOOKING_CANCELLED,
-      channels: this.determineChannels(bookingDetails.customerEmail, bookingDetails.customerPhone),
+      channels: deriveNotificationChannels(bookingDetails),
       bookingId: bookingDetails.id,
       recipients: {
         [CLIENT_RECIPIENT_TYPE]: {
@@ -112,7 +122,10 @@ export class NotificationService {
       const ownerJobData: NotificationJobData = {
         id: `cancelled-owner-${bookingDetails.id}-${Date.now()}`,
         type: NotificationType.BOOKING_CANCELLED,
-        channels: this.determineChannels(ownerEmail ?? undefined, ownerPhone ?? undefined),
+        channels: deriveNotificationChannels({
+          email: ownerEmail ?? undefined,
+          phoneNumber: ownerPhone ?? undefined,
+        }),
         bookingId: bookingDetails.id,
         recipients: {
           [FLEET_OWNER_RECIPIENT_TYPE]: {
@@ -131,6 +144,11 @@ export class NotificationService {
     if (jobs.length === 0) {
       this.logger.warn("No delivery channels available for booking cancellation notifications", {
         bookingId: bookingDetails.id,
+      });
+      this.recordNotificationSkippedNoChannel({
+        bookingId: bookingDetails.id,
+        oldStatus: "CANCELLED",
+        newStatus: "CANCELLED",
       });
       return;
     }
@@ -223,7 +241,7 @@ export class NotificationService {
     return {
       id: `status-${bookingDetails.id}-${Date.now()}`,
       type: NotificationType.BOOKING_STATUS_CHANGE,
-      channels: this.determineChannels(bookingDetails.customerEmail, bookingDetails.customerPhone),
+      channels: deriveNotificationChannels(bookingDetails),
       bookingId: bookingDetails.id,
       recipients: {
         [CLIENT_RECIPIENT_TYPE]: {
@@ -259,20 +277,6 @@ export class NotificationService {
     await this.addJobToQueue(customerJobData);
   }
 
-  private determineChannels(email?: string, phoneNumber?: string): NotificationChannel[] {
-    const channels: NotificationChannel[] = [];
-
-    if (email) {
-      channels.push(NotificationChannel.EMAIL);
-    }
-
-    if (phoneNumber) {
-      channels.push(NotificationChannel.WHATSAPP);
-    }
-
-    return channels;
-  }
-
   private createReminderJobData({
     bookingLegDetails,
     recipientType,
@@ -294,7 +298,7 @@ export class NotificationService {
     return {
       id: `reminder-${recipientType}-${bookingLegDetails.bookingLegId}-${type}-${Date.now()}`,
       type,
-      channels: this.determineChannels(email, phoneNumber),
+      channels: deriveNotificationChannels({ email, phoneNumber }),
       bookingId: bookingLegDetails.bookingId,
       recipients: {
         [recipientType]: { email, phoneNumber },
@@ -357,8 +361,14 @@ export class NotificationService {
     this.logger.log("Queued booking reminder notifications", {
       bookingLegId: bookingLegDetails.bookingLegId,
       type,
-      customerChannels: this.determineChannels(customerEmail, customerPhone),
-      chauffeurChannels: this.determineChannels(chauffeurEmail, chauffeurPhone),
+      customerChannels: deriveNotificationChannels({
+        email: customerEmail,
+        phoneNumber: customerPhone,
+      }),
+      chauffeurChannels: deriveNotificationChannels({
+        email: chauffeurEmail,
+        phoneNumber: chauffeurPhone,
+      }),
     });
   }
 
@@ -389,5 +399,18 @@ export class NotificationService {
     return type === NotificationType.BOOKING_REMINDER_START
       ? "Booking Reminder - You have a service starting in approximately 1 hour"
       : "Booking Reminder - Your assigned booking for today ends in approximately 1 hour";
+  }
+
+  private recordNotificationSkippedNoChannel(input: {
+    bookingId: string;
+    oldStatus: string;
+    newStatus: string;
+  }): void {
+    this.notificationSkippedNoChannelCounter.add(1, {
+      bookingId: input.bookingId,
+      oldStatus: input.oldStatus,
+      newStatus: input.newStatus,
+      reason: "no_channel",
+    });
   }
 }

--- a/src/modules/notification/template-mappers/index.ts
+++ b/src/modules/notification/template-mappers/index.ts
@@ -1,6 +1,7 @@
 export { BaseTemplateMapper, type TemplateVariableMapper } from "./base-template-mapper";
 export { BookingCancelledMapper } from "./booking-cancelled-mapper";
 export { BookingConfirmedMapper } from "./booking-confirmed-mapper";
+export { BookingExtensionConfirmedMapper } from "./booking-extension-confirmed-mapper";
 export { BookingReminderEndMapper } from "./booking-reminder-end-mapper";
 export { BookingReminderStartMapper } from "./booking-reminder-start-mapper";
 export { BookingStatusMapper } from "./booking-status-mapper";

--- a/src/shared/helper.spec.ts
+++ b/src/shared/helper.spec.ts
@@ -141,6 +141,46 @@ describe("Helper Functions", () => {
       });
     });
 
+    it("should suppress guest email for WhatsApp-only notification preference", () => {
+      const booking = createBooking({
+        user: null,
+        guestUser: {
+          name: "WhatsApp Guest",
+          email: "whatsapp.2348012345678@tripdly.com",
+          phoneNumber: "+2348012345678",
+          guestContactSource: "WHATSAPP_AGENT",
+          preferredNotificationChannel: "WHATSAPP_ONLY",
+        },
+      });
+      const result = getCustomerDetails(booking);
+
+      expect(result).toEqual({
+        email: "",
+        name: "WhatsApp Guest",
+        phone_number: "+2348012345678",
+      });
+    });
+
+    it("should suppress guest phone for email-only notification preference", () => {
+      const booking = createBooking({
+        user: null,
+        guestUser: {
+          name: "Email Guest",
+          email: "email.guest@example.com",
+          phoneNumber: "+2348011111111",
+          guestContactSource: "WEB_GUEST_FORM",
+          preferredNotificationChannel: "EMAIL_ONLY",
+        },
+      });
+      const result = getCustomerDetails(booking);
+
+      expect(result).toEqual({
+        email: "email.guest@example.com",
+        name: "Email Guest",
+        phone_number: "",
+      });
+    });
+
     it("should return empty strings when no user data available", () => {
       const booking = createBooking({ user: null, guestUser: null });
       const result = getCustomerDetails(booking);

--- a/src/shared/helper.ts
+++ b/src/shared/helper.ts
@@ -111,10 +111,13 @@ export function getCustomerDetails(
     booking.guestUser !== null
   ) {
     const guestDetails = booking.guestUser as GuestUserDetails;
+    const preferredNotificationChannel =
+      guestDetails.preferredNotificationChannel ?? "EMAIL_AND_WHATSAPP";
 
-    email = guestDetails.email ?? "";
+    email = preferredNotificationChannel === "WHATSAPP_ONLY" ? "" : (guestDetails.email ?? "");
+    phone_number =
+      preferredNotificationChannel === "EMAIL_ONLY" ? "" : (guestDetails.phoneNumber ?? "");
     name = guestDetails.name ?? "";
-    phone_number = guestDetails.phoneNumber ?? "";
   }
 
   return { email, name, phone_number };

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,8 @@ export interface GuestUserDetails {
   name?: string | null;
   email?: string | null;
   phoneNumber?: string | null;
+  guestContactSource?: "WEB_GUEST_FORM" | "WHATSAPP_AGENT" | null;
+  preferredNotificationChannel?: "EMAIL_AND_WHATSAPP" | "EMAIL_ONLY" | "WHATSAPP_ONLY" | null;
 }
 
 export type NormalisedBookingDetails = {


### PR DESCRIPTION
Align WhatsApp booking flows to derive consistent drop-off dates and leg-based pricing across DAY, FULL_DAY, and NIGHT scenarios, and improve summaries with explicit start/end windows.

Add conversation link-state persistence and notification routing so linked users and WhatsApp guests receive confirmation updates through the correct channels.

Summary
Added WhatsApp conversation link-state persistence (Prisma migration + schema updates) and integrated it into booking-agent orchestration/persistence flow.
Improved booking-agent booking-window normalization and presentation:
Fixed duration-to-dropoff normalization across DAY, FULL_DAY, and NIGHT.
Added explicit Start/End display in booking summaries.
Updated summary phrasing to Booked for with billed-leg clarity.
Switched ordinal date rendering to native date-fns ordinal formatting.
Extended notification routing so linked users vs WhatsApp guests receive confirmations through the correct channel.
Updated/expanded tests across booking-agent, booking, notification, and shared helpers to cover new behavior and regressions.
Why
Prevent mismatches where displayed duration and billed legs diverged (especially around inclusive date semantics).
Ensure FULL_DAY behaves as true 24-hour legs.
Improve user trust with clearer booking windows and consistent pricing basis.
Support reliable notification delivery based on WhatsApp link state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches booking creation, leg/date normalization, and notification routing, plus a Prisma migration; mistakes could mis-bill durations or suppress/route notifications incorrectly.
> 
> **Overview**
> Adds a persisted WhatsApp conversation **link state** (new `WhatsAppLinkStatus` enum + `linkedUserId` fields) and threads the resolved `customerId` through the WhatsApp processor/orchestrator into LangGraph and booking creation so verified-linked conversations create bookings as authenticated users instead of guests.
> 
> Normalizes booking window semantics across `DAY`/`FULL_DAY`/`NIGHT` by deriving/adjusting `dropoffDate` from `durationDays`, aligning leg generation helpers, and updating booking summaries to show explicit *Start/End* timestamps plus “Booked for” with billed-leg counts.
> 
> Refactors `BookingCreationService.createBooking` to accept a request object with optional context, records guest contact source + preferred notification channel for WhatsApp-agent guests, and updates confirmation/status/extension/cancellation notifications to derive channels from available contact info (skipping and emitting a metric when none). Also adds Dependabot config, preview environment docs, and broad test updates for the new behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efc1207f8e423a39bc478120a7c2e4035badb905. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->