### PR TITLE
refactor(booking): simplify validation flow and prune tests

### DIFF
--- a/src/modules/booking/booking-validation.service.spec.ts
+++ b/src/modules/booking/booking-validation.service.spec.ts
@@ -113,10 +113,10 @@ describe("BookingValidationService", () => {
     });
 
     it("should throw BookingValidationException for same-day DAY booking after 11 AM", () => {
-      // Mock current time to be 11 AM or later
+      // Mock current time to be after 11 AM
       vi.useFakeTimers();
       const now = new Date();
-      now.setHours(11, 0, 0, 0);
+      now.setHours(11, 1, 0, 0);
       vi.setSystemTime(now);
 
       const startDate = new Date(now);
@@ -136,18 +136,17 @@ describe("BookingValidationService", () => {
       vi.useRealTimers();
     });
 
-    it("should not throw for same-day DAY booking before 11 AM", () => {
-      // Mock current time to be 9 AM
+    it("should allow same-day DAY booking exactly at 11:00 AM cutoff", () => {
       vi.useFakeTimers();
       const now = new Date();
-      now.setHours(9, 0, 0, 0);
+      now.setHours(11, 0, 0, 0);
       vi.setSystemTime(now);
 
       const startDate = new Date(now);
-      startDate.setHours(14, 0, 0, 0); // 2 PM same day
+      startDate.setHours(11, 0, 0, 0);
 
       const endDate = new Date(startDate);
-      endDate.setHours(18, 0, 0, 0); // 6 PM same day
+      endDate.setHours(23, 0, 0, 0);
 
       expect(() =>
         service.validateDates({
@@ -158,6 +157,115 @@ describe("BookingValidationService", () => {
       ).not.toThrow();
 
       vi.useRealTimers();
+    });
+
+    it("should not throw for same-day DAY booking before 11 AM", () => {
+      // Mock current time to be 9 AM
+      vi.useFakeTimers();
+      const now = new Date();
+      now.setHours(9, 0, 0, 0);
+      vi.setSystemTime(now);
+
+      const startDate = new Date(now);
+      startDate.setHours(10, 0, 0, 0); // 10 AM same day
+
+      const endDate = new Date(startDate);
+      endDate.setHours(22, 0, 0, 0); // 10 PM same day
+
+      expect(() =>
+        service.validateDates({
+          startDate,
+          endDate,
+          bookingType: "DAY",
+        }),
+      ).not.toThrow();
+
+      vi.useRealTimers();
+    });
+
+    it("should throw BookingValidationException when DAY booking starts before 7 AM", () => {
+      const startDate = new Date();
+      startDate.setDate(startDate.getDate() + 1);
+      startDate.setHours(6, 30, 0, 0);
+
+      const endDate = new Date(startDate);
+      endDate.setHours(18, 30, 0, 0);
+
+      expect(() =>
+        service.validateDates({
+          startDate,
+          endDate,
+          bookingType: "DAY",
+        }),
+      ).toThrow(BookingValidationException);
+    });
+
+    it("should throw BookingValidationException when DAY booking starts after 11 AM", () => {
+      const startDate = new Date();
+      startDate.setDate(startDate.getDate() + 1);
+      startDate.setHours(11, 1, 0, 0);
+
+      const endDate = new Date(startDate);
+      endDate.setHours(23, 1, 0, 0);
+
+      expect(() =>
+        service.validateDates({
+          startDate,
+          endDate,
+          bookingType: "DAY",
+        }),
+      ).toThrow(BookingValidationException);
+    });
+
+    it("should not throw when FULL_DAY booking starts within 6 AM to 11 PM", () => {
+      const startDate = new Date();
+      startDate.setDate(startDate.getDate() + 1);
+      startDate.setHours(23, 0, 0, 0);
+
+      const endDate = new Date(startDate);
+      endDate.setDate(endDate.getDate() + 1);
+
+      expect(() =>
+        service.validateDates({
+          startDate,
+          endDate,
+          bookingType: "FULL_DAY",
+        }),
+      ).not.toThrow();
+    });
+
+    it("should throw BookingValidationException when FULL_DAY booking starts before 6 AM", () => {
+      const startDate = new Date();
+      startDate.setDate(startDate.getDate() + 1);
+      startDate.setHours(5, 59, 0, 0);
+
+      const endDate = new Date(startDate);
+      endDate.setDate(endDate.getDate() + 1);
+
+      expect(() =>
+        service.validateDates({
+          startDate,
+          endDate,
+          bookingType: "FULL_DAY",
+        }),
+      ).toThrow(BookingValidationException);
+    });
+
+    it("should throw BookingValidationException when FULL_DAY booking starts after 11 PM", () => {
+      const startDate = new Date();
+      startDate.setDate(startDate.getDate() + 1);
+      startDate.setHours(23, 1, 0, 0);
+
+      const endDate = new Date(startDate);
+      endDate.setDate(endDate.getDate() + 1);
+
+      expect(() =>
+        service.validateDates({
+          startDate,
+          endDate,
+          bookingType: "FULL_DAY",
+        }),
+      ).toThrow(BookingValidationException);
     });
 
     it("should throw BookingValidationException for airport pickup without 1-hour advance notice", () => {
@@ -273,71 +381,11 @@ describe("BookingValidationService", () => {
       expect(databaseService.booking.findMany).not.toHaveBeenCalled();
     });
 
-    it("should throw CarNotAvailableException when car approval status is REJECTED", async () => {
-      vi.mocked(databaseService.car.findUnique).mockResolvedValueOnce(
-        mockCar({
-          id: "car-123",
-          status: Status.AVAILABLE,
-          approvalStatus: CarApprovalStatus.REJECTED,
-        }),
-      );
-
-      await expect(
-        service.checkCarAvailability({
-          carId: "car-123",
-          startDate: new Date(),
-          endDate: new Date(),
-        }),
-      ).rejects.toThrow(CarNotAvailableException);
-
-      expect(databaseService.booking.findMany).not.toHaveBeenCalled();
-    });
-
     it("should throw CarNotAvailableException when car status is HOLD", async () => {
       vi.mocked(databaseService.car.findUnique).mockResolvedValueOnce(
         mockCar({
           id: "car-123",
           status: Status.HOLD,
-          approvalStatus: CarApprovalStatus.APPROVED,
-        }),
-      );
-
-      await expect(
-        service.checkCarAvailability({
-          carId: "car-123",
-          startDate: new Date(),
-          endDate: new Date(),
-        }),
-      ).rejects.toThrow(CarNotAvailableException);
-
-      expect(databaseService.booking.findMany).not.toHaveBeenCalled();
-    });
-
-    it("should throw CarNotAvailableException when car status is IN_SERVICE", async () => {
-      vi.mocked(databaseService.car.findUnique).mockResolvedValueOnce(
-        mockCar({
-          id: "car-123",
-          status: Status.IN_SERVICE,
-          approvalStatus: CarApprovalStatus.APPROVED,
-        }),
-      );
-
-      await expect(
-        service.checkCarAvailability({
-          carId: "car-123",
-          startDate: new Date(),
-          endDate: new Date(),
-        }),
-      ).rejects.toThrow(CarNotAvailableException);
-
-      expect(databaseService.booking.findMany).not.toHaveBeenCalled();
-    });
-
-    it("should throw CarNotAvailableException when car status is BOOKED", async () => {
-      vi.mocked(databaseService.car.findUnique).mockResolvedValueOnce(
-        mockCar({
-          id: "car-123",
-          status: Status.BOOKED,
           approvalStatus: CarApprovalStatus.APPROVED,
         }),
       );
@@ -609,159 +657,6 @@ describe("BookingValidationService", () => {
 
       const sessionUser = { id: "user-123" };
       expect(() => service.validateGuestRequirements(input, sessionUser)).not.toThrow();
-    });
-  });
-
-  describe("validateAll", () => {
-    it("should throw BookingValidationException when date validation fails", async () => {
-      const yesterday = new Date();
-      yesterday.setDate(yesterday.getDate() - 1);
-
-      const input: CreateBookingDto = {
-        carId: "car-123",
-        startDate: yesterday,
-        endDate: yesterday,
-        pickupAddress: "123 Main St",
-        bookingType: "DAY",
-        sameLocation: true,
-        includeSecurityDetail: false,
-        requiresFullTank: false,
-        useCredits: 0,
-      };
-
-      await expect(service.validateAll(input)).rejects.toThrow(BookingValidationException);
-    });
-
-    it("should not throw when all validations pass", async () => {
-      vi.mocked(databaseService.car.findUnique).mockResolvedValueOnce(
-        mockCar({
-          id: "car-123",
-          status: Status.AVAILABLE,
-          approvalStatus: CarApprovalStatus.APPROVED,
-        }),
-      );
-      vi.mocked(databaseService.booking.findMany).mockResolvedValueOnce([]);
-
-      const tomorrow = new Date();
-      tomorrow.setDate(tomorrow.getDate() + 1);
-      tomorrow.setHours(10, 0, 0, 0);
-
-      const dayAfterTomorrow = new Date(tomorrow);
-      dayAfterTomorrow.setDate(dayAfterTomorrow.getDate() + 1);
-
-      const input: CreateBookingDto = {
-        carId: "car-123",
-        startDate: tomorrow,
-        endDate: dayAfterTomorrow,
-        pickupAddress: "123 Main St",
-        bookingType: "DAY",
-        pickupTime: "9 AM",
-        sameLocation: true,
-        includeSecurityDetail: false,
-        requiresFullTank: false,
-        useCredits: 0,
-      };
-
-      await expect(service.validateAll(input)).resolves.toBeUndefined();
-    });
-
-    it("should throw BookingValidationException when price validation fails", async () => {
-      vi.mocked(databaseService.car.findUnique).mockResolvedValueOnce(
-        mockCar({
-          id: "car-123",
-          status: Status.AVAILABLE,
-          approvalStatus: CarApprovalStatus.APPROVED,
-        }),
-      );
-      vi.mocked(databaseService.booking.findMany).mockResolvedValueOnce([]);
-
-      const tomorrow = new Date();
-      tomorrow.setDate(tomorrow.getDate() + 1);
-      tomorrow.setHours(10, 0, 0, 0);
-
-      const dayAfterTomorrow = new Date(tomorrow);
-      dayAfterTomorrow.setDate(dayAfterTomorrow.getDate() + 1);
-
-      const input: CreateBookingDto = {
-        carId: "car-123",
-        startDate: tomorrow,
-        endDate: dayAfterTomorrow,
-        pickupAddress: "123 Main St",
-        bookingType: "DAY",
-        pickupTime: "9 AM",
-        sameLocation: true,
-        includeSecurityDetail: false,
-        requiresFullTank: false,
-        useCredits: 0,
-        clientTotalAmount: "5000", // Intentionally wrong
-      };
-
-      await expect(service.validateAll(input, new Decimal("10000"))).rejects.toThrow(
-        BookingValidationException,
-      );
-    });
-
-    it("should throw CarNotFoundException when car does not exist", async () => {
-      vi.mocked(databaseService.car.findUnique).mockResolvedValueOnce(null);
-
-      const tomorrow = new Date();
-      tomorrow.setDate(tomorrow.getDate() + 1);
-      tomorrow.setHours(10, 0, 0, 0);
-
-      const dayAfterTomorrow = new Date(tomorrow);
-      dayAfterTomorrow.setDate(dayAfterTomorrow.getDate() + 1);
-
-      const input: CreateBookingDto = {
-        carId: "non-existent-car",
-        startDate: tomorrow,
-        endDate: dayAfterTomorrow,
-        pickupAddress: "123 Main St",
-        bookingType: "DAY",
-        sameLocation: true,
-        includeSecurityDetail: false,
-        requiresFullTank: false,
-        useCredits: 0,
-      };
-
-      await expect(service.validateAll(input)).rejects.toThrow(CarNotFoundException);
-    });
-
-    it("should throw BookingValidationException for guest with registered email", async () => {
-      vi.mocked(databaseService.car.findUnique).mockResolvedValueOnce(
-        mockCar({
-          id: "car-123",
-          status: Status.AVAILABLE,
-          approvalStatus: CarApprovalStatus.APPROVED,
-        }),
-      );
-      vi.mocked(databaseService.booking.findMany).mockResolvedValueOnce([]);
-      vi.mocked(databaseService.user.findUnique).mockResolvedValueOnce(
-        mockUser({ id: "existing-user" }),
-      );
-
-      const tomorrow = new Date();
-      tomorrow.setDate(tomorrow.getDate() + 1);
-      tomorrow.setHours(10, 0, 0, 0);
-
-      const dayAfterTomorrow = new Date(tomorrow);
-      dayAfterTomorrow.setDate(dayAfterTomorrow.getDate() + 1);
-
-      const input: CreateGuestBookingDto = {
-        carId: "car-123",
-        startDate: tomorrow,
-        endDate: dayAfterTomorrow,
-        pickupAddress: "123 Main St",
-        bookingType: "DAY",
-        sameLocation: true,
-        includeSecurityDetail: false,
-        requiresFullTank: false,
-        useCredits: 0,
-        guestEmail: "existing@example.com",
-        guestName: "John Doe",
-        guestPhone: "1234567890",
-      };
-
-      await expect(service.validateAll(input)).rejects.toThrow(BookingValidationException);
     });
   });
 });

--- a/src/modules/booking/booking-validation.service.spec.ts
+++ b/src/modules/booking/booking-validation.service.spec.ts
@@ -5,6 +5,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createBooking, createCar, createUser } from "../../shared/helper.fixtures";
 import { DatabaseService } from "../database/database.service";
 import {
+  DAY_END_HOUR,
+  DAY_START_HOUR,
+  FULL_DAY_END_HOUR,
+  FULL_DAY_START_HOUR,
+  SAME_DAY_BOOKING_CUTOFF_HOUR,
+} from "./booking.const";
+import {
   BookingValidationException,
   CarNotAvailableException,
   CarNotFoundException,
@@ -111,7 +118,7 @@ describe("BookingValidationService", () => {
       // Mock current time to be after 11 AM
       vi.useFakeTimers();
       const now = new Date();
-      now.setHours(11, 1, 0, 0);
+      now.setHours(SAME_DAY_BOOKING_CUTOFF_HOUR, 1, 0, 0);
       vi.setSystemTime(now);
 
       const startDate = new Date(now);
@@ -134,14 +141,14 @@ describe("BookingValidationService", () => {
     it("should allow same-day DAY booking exactly at 11:00 AM cutoff", () => {
       vi.useFakeTimers();
       const now = new Date();
-      now.setHours(11, 0, 0, 0);
+      now.setHours(SAME_DAY_BOOKING_CUTOFF_HOUR, 0, 0, 0);
       vi.setSystemTime(now);
 
       const startDate = new Date(now);
-      startDate.setHours(11, 0, 0, 0);
+      startDate.setHours(SAME_DAY_BOOKING_CUTOFF_HOUR, 0, 0, 0);
 
       const endDate = new Date(startDate);
-      endDate.setHours(23, 0, 0, 0);
+      endDate.setHours(FULL_DAY_END_HOUR, 0, 0, 0);
 
       expect(() =>
         service.validateDates({
@@ -157,10 +164,10 @@ describe("BookingValidationService", () => {
     it("should not throw when DAY booking starts exactly at 7:00 AM", () => {
       const startDate = new Date();
       startDate.setDate(startDate.getDate() + 1);
-      startDate.setHours(7, 0, 0, 0);
+      startDate.setHours(DAY_START_HOUR, 0, 0, 0);
 
       const endDate = new Date(startDate);
-      endDate.setHours(11, 0, 0, 0);
+      endDate.setHours(DAY_END_HOUR, 0, 0, 0);
 
       expect(() =>
         service.validateDates({
@@ -174,7 +181,7 @@ describe("BookingValidationService", () => {
     it("should not throw when FULL_DAY booking starts exactly at 6:00 AM", () => {
       const startDate = new Date();
       startDate.setDate(startDate.getDate() + 1);
-      startDate.setHours(6, 0, 0, 0);
+      startDate.setHours(FULL_DAY_START_HOUR, 0, 0, 0);
 
       const endDate = new Date(startDate);
       endDate.setDate(endDate.getDate() + 1);
@@ -215,7 +222,7 @@ describe("BookingValidationService", () => {
     it("should throw BookingValidationException when DAY booking starts before 7 AM", () => {
       const startDate = new Date();
       startDate.setDate(startDate.getDate() + 1);
-      startDate.setHours(6, 30, 0, 0);
+      startDate.setHours(DAY_START_HOUR - 1, 30, 0, 0);
 
       const endDate = new Date(startDate);
       endDate.setHours(18, 30, 0, 0);
@@ -232,10 +239,10 @@ describe("BookingValidationService", () => {
     it("should throw BookingValidationException when DAY booking starts after 11 AM", () => {
       const startDate = new Date();
       startDate.setDate(startDate.getDate() + 1);
-      startDate.setHours(11, 1, 0, 0);
+      startDate.setHours(DAY_END_HOUR, 1, 0, 0);
 
       const endDate = new Date(startDate);
-      endDate.setHours(23, 1, 0, 0);
+      endDate.setHours(FULL_DAY_END_HOUR, 1, 0, 0);
 
       expect(() =>
         service.validateDates({
@@ -249,7 +256,7 @@ describe("BookingValidationService", () => {
     it("should not throw when FULL_DAY booking starts within 6 AM to 11 PM", () => {
       const startDate = new Date();
       startDate.setDate(startDate.getDate() + 1);
-      startDate.setHours(23, 0, 0, 0);
+      startDate.setHours(FULL_DAY_END_HOUR, 0, 0, 0);
 
       const endDate = new Date(startDate);
       endDate.setDate(endDate.getDate() + 1);
@@ -283,7 +290,7 @@ describe("BookingValidationService", () => {
     it("should throw BookingValidationException when FULL_DAY booking starts after 11 PM", () => {
       const startDate = new Date();
       startDate.setDate(startDate.getDate() + 1);
-      startDate.setHours(23, 1, 0, 0);
+      startDate.setHours(FULL_DAY_END_HOUR, 1, 0, 0);
 
       const endDate = new Date(startDate);
       endDate.setDate(endDate.getDate() + 1);
@@ -333,7 +340,7 @@ describe("BookingValidationService", () => {
       vi.setSystemTime(now);
 
       const startDate = new Date(now);
-      startDate.setHours(23, 0, 0, 0); // 11 PM same day
+      startDate.setHours(FULL_DAY_END_HOUR, 0, 0, 0); // 11 PM same day
 
       const endDate = new Date(startDate);
       endDate.setDate(endDate.getDate() + 1);
@@ -375,6 +382,46 @@ describe("BookingValidationService", () => {
           endDate: dayAfterTomorrow,
         }),
       ).resolves.toBeUndefined();
+    });
+
+    it("should throw CarNotAvailableException when car status is BOOKED", async () => {
+      vi.mocked(databaseService.car.findUnique).mockResolvedValueOnce(
+        createCar({
+          id: "car-123",
+          status: Status.BOOKED,
+          approvalStatus: CarApprovalStatus.APPROVED,
+        }),
+      );
+
+      await expect(
+        service.checkCarAvailability({
+          carId: "car-123",
+          startDate: new Date(),
+          endDate: new Date(),
+        }),
+      ).rejects.toThrow(CarNotAvailableException);
+
+      expect(databaseService.booking.findMany).not.toHaveBeenCalled();
+    });
+
+    it("should throw CarNotAvailableException when car status is IN_SERVICE", async () => {
+      vi.mocked(databaseService.car.findUnique).mockResolvedValueOnce(
+        createCar({
+          id: "car-123",
+          status: Status.IN_SERVICE,
+          approvalStatus: CarApprovalStatus.APPROVED,
+        }),
+      );
+
+      await expect(
+        service.checkCarAvailability({
+          carId: "car-123",
+          startDate: new Date(),
+          endDate: new Date(),
+        }),
+      ).rejects.toThrow(CarNotAvailableException);
+
+      expect(databaseService.booking.findMany).not.toHaveBeenCalled();
     });
 
     it("should throw CarNotFoundException when car does not exist", async () => {

--- a/src/modules/booking/booking-validation.service.spec.ts
+++ b/src/modules/booking/booking-validation.service.spec.ts
@@ -1,8 +1,8 @@
 import { Test, TestingModule } from "@nestjs/testing";
-import type { Booking, Car, User } from "@prisma/client";
 import { BookingStatus, CarApprovalStatus, PaymentStatus, Status } from "@prisma/client";
 import Decimal from "decimal.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createBooking, createCar, createUser } from "../../shared/helper.fixtures";
 import { DatabaseService } from "../database/database.service";
 import {
   BookingValidationException,
@@ -11,11 +11,6 @@ import {
 } from "./booking.error";
 import { BookingValidationService } from "./booking-validation.service";
 import type { CreateBookingDto, CreateGuestBookingDto } from "./dto/create-booking.dto";
-
-// Helper to create partial mock data with type safety
-const mockCar = (data: Partial<Car>) => data as Car;
-const mockBooking = (data: Partial<Booking>) => data as Booking;
-const mockUser = (data: Partial<User>) => data as User;
 
 describe("BookingValidationService", () => {
   let service: BookingValidationService;
@@ -157,6 +152,40 @@ describe("BookingValidationService", () => {
       ).not.toThrow();
 
       vi.useRealTimers();
+    });
+
+    it("should not throw when DAY booking starts exactly at 7:00 AM", () => {
+      const startDate = new Date();
+      startDate.setDate(startDate.getDate() + 1);
+      startDate.setHours(7, 0, 0, 0);
+
+      const endDate = new Date(startDate);
+      endDate.setHours(11, 0, 0, 0);
+
+      expect(() =>
+        service.validateDates({
+          startDate,
+          endDate,
+          bookingType: "DAY",
+        }),
+      ).not.toThrow();
+    });
+
+    it("should not throw when FULL_DAY booking starts exactly at 6:00 AM", () => {
+      const startDate = new Date();
+      startDate.setDate(startDate.getDate() + 1);
+      startDate.setHours(6, 0, 0, 0);
+
+      const endDate = new Date(startDate);
+      endDate.setDate(endDate.getDate() + 1);
+
+      expect(() =>
+        service.validateDates({
+          startDate,
+          endDate,
+          bookingType: "FULL_DAY",
+        }),
+      ).not.toThrow();
     });
 
     it("should not throw for same-day DAY booking before 11 AM", () => {
@@ -325,7 +354,7 @@ describe("BookingValidationService", () => {
   describe("checkCarAvailability", () => {
     it("should not throw when car exists, is approved, available, and no conflicting bookings", async () => {
       vi.mocked(databaseService.car.findUnique).mockResolvedValueOnce(
-        mockCar({
+        createCar({
           id: "car-123",
           status: Status.AVAILABLE,
           approvalStatus: CarApprovalStatus.APPROVED,
@@ -362,7 +391,7 @@ describe("BookingValidationService", () => {
 
     it("should throw CarNotAvailableException when car approval status is PENDING", async () => {
       vi.mocked(databaseService.car.findUnique).mockResolvedValueOnce(
-        mockCar({
+        createCar({
           id: "car-123",
           status: Status.AVAILABLE,
           approvalStatus: CarApprovalStatus.PENDING,
@@ -383,7 +412,7 @@ describe("BookingValidationService", () => {
 
     it("should throw CarNotAvailableException when car status is HOLD", async () => {
       vi.mocked(databaseService.car.findUnique).mockResolvedValueOnce(
-        mockCar({
+        createCar({
           id: "car-123",
           status: Status.HOLD,
           approvalStatus: CarApprovalStatus.APPROVED,
@@ -403,14 +432,14 @@ describe("BookingValidationService", () => {
 
     it("should throw CarNotAvailableException when there are conflicting bookings", async () => {
       vi.mocked(databaseService.car.findUnique).mockResolvedValueOnce(
-        mockCar({
+        createCar({
           id: "car-123",
           status: Status.AVAILABLE,
           approvalStatus: CarApprovalStatus.APPROVED,
         }),
       );
       vi.mocked(databaseService.booking.findMany).mockResolvedValueOnce([
-        mockBooking({
+        createBooking({
           id: "existing-booking",
           startDate: new Date("2025-02-01T09:00:00Z"),
           endDate: new Date("2025-02-01T21:00:00Z"),
@@ -429,7 +458,7 @@ describe("BookingValidationService", () => {
 
     it("should exclude specified booking when checking availability", async () => {
       vi.mocked(databaseService.car.findUnique).mockResolvedValueOnce(
-        mockCar({
+        createCar({
           id: "car-123",
           status: Status.AVAILABLE,
           approvalStatus: CarApprovalStatus.APPROVED,
@@ -455,7 +484,7 @@ describe("BookingValidationService", () => {
 
     it("should only check bookings with CONFIRMED/ACTIVE status and PAID payment", async () => {
       vi.mocked(databaseService.car.findUnique).mockResolvedValueOnce(
-        mockCar({
+        createCar({
           id: "car-123",
           status: Status.AVAILABLE,
           approvalStatus: CarApprovalStatus.APPROVED,
@@ -481,7 +510,7 @@ describe("BookingValidationService", () => {
 
     it("should use strict inequality (lt/gt) to allow exactly 2-hour buffer gaps", async () => {
       vi.mocked(databaseService.car.findUnique).mockResolvedValueOnce(
-        mockCar({
+        createCar({
           id: "car-123",
           status: Status.AVAILABLE,
           approvalStatus: CarApprovalStatus.APPROVED,
@@ -556,7 +585,7 @@ describe("BookingValidationService", () => {
 
     it("should throw BookingValidationException for guest booking with already registered email", async () => {
       vi.mocked(databaseService.user.findUnique).mockResolvedValueOnce(
-        mockUser({ id: "existing-user" }),
+        createUser({ id: "existing-user" }),
       );
 
       const input: CreateGuestBookingDto = {

--- a/src/modules/booking/booking-validation.service.ts
+++ b/src/modules/booking/booking-validation.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { BookingStatus, CarApprovalStatus, PaymentStatus, Status } from "@prisma/client";
+import { isSameDay } from "date-fns";
 import Decimal from "decimal.js";
 import type { FieldError } from "src/common/errors/problem-details.interface";
 import { maskEmail } from "src/shared/helper";
@@ -47,56 +48,129 @@ export class BookingValidationService {
    * @throws BookingValidationException if any date rules are violated
    */
   validateDates(input: DateValidationInput): void {
-    const errors: FieldError[] = [];
     const now = new Date();
-
-    const { startDate, endDate, bookingType } = input;
-
-    // Rule: End date must be > start date (zero-duration bookings not allowed)
-    if (endDate <= startDate) {
-      errors.push({
-        field: "endDate",
-        message: "End date must be after start date",
-      });
-    }
-
-    // Rule: Airport pickup requires minimum 1-hour advance notice
-    if (bookingType === "AIRPORT_PICKUP") {
-      const oneHourFromNow = new Date(now.getTime() + AIRPORT_PICKUP_MIN_ADVANCE_MS);
-      if (startDate < oneHourFromNow) {
-        errors.push({
-          field: "startDate",
-          message: "Airport pickup bookings require at least 1 hour advance notice",
-        });
-      }
-    } else {
-      // Rule: Cannot book in the past (for non-airport bookings)
-      if (startDate < now) {
-        errors.push({
-          field: "startDate",
-          message: "Booking start time cannot be in the past",
-        });
-      }
-
-      // Rule: Same-day DAY bookings not allowed after 11 AM
-      if (bookingType === "DAY") {
-        const isSameDay =
-          startDate.getFullYear() === now.getFullYear() &&
-          startDate.getMonth() === now.getMonth() &&
-          startDate.getDate() === now.getDate();
-
-        if (isSameDay && now.getHours() >= SAME_DAY_BOOKING_CUTOFF_HOUR) {
-          errors.push({
-            field: "startDate",
-            message: "Same-day DAY bookings cannot be made at or after 11 AM",
-          });
-        }
-      }
-    }
+    const errors: FieldError[] = [
+      ...this.validateDateOrder(input.startDate, input.endDate),
+      ...(input.bookingType === "AIRPORT_PICKUP"
+        ? this.validateAirportPickupAdvanceNotice(input.startDate, now)
+        : this.validateNonAirportDates(input.startDate, input.bookingType, now)),
+    ];
 
     if (errors.length > 0) {
       throw new BookingValidationException(errors);
     }
+  }
+
+  private validateDateOrder(startDate: Date, endDate: Date): FieldError[] {
+    if (endDate > startDate) {
+      return [];
+    }
+
+    return [
+      {
+        field: "endDate",
+        message: "End date must be after start date",
+      },
+    ];
+  }
+
+  private validateAirportPickupAdvanceNotice(startDate: Date, now: Date): FieldError[] {
+    const oneHourFromNow = new Date(now.getTime() + AIRPORT_PICKUP_MIN_ADVANCE_MS);
+    if (startDate >= oneHourFromNow) {
+      return [];
+    }
+
+    return [
+      {
+        field: "startDate",
+        message: "Airport pickup bookings require at least 1 hour advance notice",
+      },
+    ];
+  }
+
+  private validateNonAirportDates(
+    startDate: Date,
+    bookingType: DateValidationInput["bookingType"],
+    now: Date,
+  ): FieldError[] {
+    const errors: FieldError[] = [];
+    if (startDate < now) {
+      errors.push({
+        field: "startDate",
+        message: "Booking start time cannot be in the past",
+      });
+    }
+
+    this.validateBookingTypeStartWindow(startDate, bookingType, errors);
+
+    if (bookingType === "DAY" && isSameDay(startDate, now) && this.isAfterSameDayCutoff(now)) {
+      errors.push({
+        field: "startDate",
+        message: "Same-day DAY bookings cannot be made at or after 11 AM",
+      });
+    }
+
+    return errors;
+  }
+
+  private validateBookingTypeStartWindow(
+    startDate: Date,
+    bookingType: DateValidationInput["bookingType"],
+    errors: FieldError[],
+  ): void {
+    if (
+      bookingType === "DAY" &&
+      !this.isTimeWithinWindow(startDate, {
+        startHour: 7,
+        startMinute: 0,
+        endHour: 11,
+        endMinute: 0,
+      })
+    ) {
+      errors.push({
+        field: "startDate",
+        message: "DAY bookings must start between 7:00 AM and 11:00 AM",
+      });
+    }
+
+    if (
+      bookingType === "FULL_DAY" &&
+      !this.isTimeWithinWindow(startDate, {
+        startHour: 6,
+        startMinute: 0,
+        endHour: 23,
+        endMinute: 0,
+      })
+    ) {
+      errors.push({
+        field: "startDate",
+        message: "FULL_DAY bookings must start between 6:00 AM and 11:00 PM",
+      });
+    }
+  }
+
+  private isTimeWithinWindow(
+    date: Date,
+    window: {
+      startHour: number;
+      startMinute: number;
+      endHour: number;
+      endMinute: number;
+    },
+  ): boolean {
+    const minutesSinceMidnight = date.getHours() * 60 + date.getMinutes();
+    const windowStart = window.startHour * 60 + window.startMinute;
+    const windowEnd = window.endHour * 60 + window.endMinute;
+
+    return minutesSinceMidnight >= windowStart && minutesSinceMidnight <= windowEnd;
+  }
+
+  private isAfterSameDayCutoff(now: Date): boolean {
+    return (
+      now.getHours() > SAME_DAY_BOOKING_CUTOFF_HOUR ||
+      (now.getHours() === SAME_DAY_BOOKING_CUTOFF_HOUR &&
+        (now.getMinutes() > 0 || now.getSeconds() > 0 || now.getMilliseconds() > 0))
+    );
   }
 
   /**
@@ -291,39 +365,6 @@ export class BookingValidationService {
         ],
         "Guest information is required when booking without authentication",
       );
-    }
-  }
-
-  /**
-   * Run all validations. Each method throws its own exception on failure.
-   *
-   * @param input - Booking input
-   * @param serverTotal - Server-calculated total (optional)
-   * @throws BookingValidationException for validation errors
-   * @throws CarNotFoundException if car doesn't exist
-   * @throws CarNotAvailableException if car is not available
-   */
-  async validateAll(input: CreateBookingInput, serverTotal?: Decimal): Promise<void> {
-    // Date validation (throws BookingValidationException)
-    this.validateDates({
-      startDate: input.startDate,
-      endDate: input.endDate,
-      bookingType: input.bookingType,
-    });
-
-    // Car availability (throws CarNotFoundException or CarNotAvailableException)
-    await this.checkCarAvailability({
-      carId: input.carId,
-      startDate: input.startDate,
-      endDate: input.endDate,
-    });
-
-    // Guest email validation (throws BookingValidationException)
-    await this.validateGuestEmail(input);
-
-    // Price validation (throws BookingValidationException)
-    if (serverTotal) {
-      this.validatePriceMatch(input.clientTotalAmount, serverTotal);
     }
   }
 }

--- a/src/modules/booking/booking-validation.service.ts
+++ b/src/modules/booking/booking-validation.service.ts
@@ -8,6 +8,10 @@ import { buildBufferedBookingInterval } from "../../shared/availability-buffer.h
 import { DatabaseService } from "../database/database.service";
 import {
   AIRPORT_PICKUP_MIN_ADVANCE_MS,
+  DAY_END_HOUR,
+  DAY_START_HOUR,
+  FULL_DAY_END_HOUR,
+  FULL_DAY_START_HOUR,
   PRICE_TOLERANCE,
   SAME_DAY_BOOKING_CUTOFF_HOUR,
 } from "./booking.const";
@@ -121,9 +125,9 @@ export class BookingValidationService {
     if (
       bookingType === "DAY" &&
       !this.isTimeWithinWindow(startDate, {
-        startHour: 7,
+        startHour: DAY_START_HOUR,
         startMinute: 0,
-        endHour: 11,
+        endHour: DAY_END_HOUR,
         endMinute: 0,
       })
     ) {
@@ -136,9 +140,9 @@ export class BookingValidationService {
     if (
       bookingType === "FULL_DAY" &&
       !this.isTimeWithinWindow(startDate, {
-        startHour: 6,
+        startHour: FULL_DAY_START_HOUR,
         startMinute: 0,
-        endHour: 23,
+        endHour: FULL_DAY_END_HOUR,
         endMinute: 0,
       })
     ) {

--- a/src/modules/booking/booking-validation.service.ts
+++ b/src/modules/booking/booking-validation.service.ts
@@ -106,7 +106,7 @@ export class BookingValidationService {
     if (bookingType === "DAY" && isSameDay(startDate, now) && this.isAfterSameDayCutoff(now)) {
       errors.push({
         field: "startDate",
-        message: "Same-day DAY bookings cannot be made at or after 11 AM",
+        message: "Same-day DAY bookings cannot be made after 11 AM",
       });
     }
 

--- a/src/modules/booking/booking.const.ts
+++ b/src/modules/booking/booking.const.ts
@@ -30,3 +30,8 @@ export const AIRPORT_PICKUP_DRIVE_TIME_MULTIPLIER = 1.2;
 
 /** Maximum number of legs eligible for fuel upgrade */
 export const MAX_LEGS_FOR_FUEL_UPGRADE = 2;
+
+export const DAY_START_HOUR = 7;
+export const DAY_END_HOUR = 11;
+export const FULL_DAY_START_HOUR = 6;
+export const FULL_DAY_END_HOUR = 23;


### PR DESCRIPTION
Refactor date checks into helper returns, remove unused validateAll, and fix 11am cutoff.

## Summary
- Refactor booking date validation to compose helper-returned field errors instead of mutating a shared array across methods.
- Remove unused `validateAll` from `BookingValidationService` and its spec coverage (it was not used in production code).
- Enforce same-day DAY cutoff as **after** 11:00 AM (allow exactly 11:00 AM).
- Add boundary-focused tests for:
  - DAY start window (before 7 AM / after 11 AM)
  - FULL_DAY start window (before 6 AM / after 11 PM)
  - same-day DAY cutoff exact boundary at 11:00 AM
- Prune redundant `checkCarAvailability` tests that asserted duplicate exception paths without additional behavior coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core booking date/time validation rules (same-day cutoff and allowed start windows), which can affect whether users can create bookings and may introduce edge-case regressions around time boundaries.
> 
> **Overview**
> Refactors `BookingValidationService.validateDates` to compose validation via small helper methods that *return* `FieldError[]`, and switches same-day checks to `date-fns` `isSameDay`.
> 
> Tightens/clarifies booking time rules by (a) allowing same-day `DAY` bookings **exactly at 11:00** while rejecting times after, and (b) enforcing explicit start-time windows for `DAY` (7:00–11:00) and `FULL_DAY` (6:00–23:00).
> 
> Removes the unused `validateAll` API and its test coverage, updates tests to use shared fixtures (`createCar`/`createBooking`/`createUser`), adds boundary-focused date tests, and prunes redundant `checkCarAvailability` cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c767635d02d1d5407b7c39bcf1d7fe1444d2ca4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->