### PR TITLE
feat(car): enrich car read responses with promotion data

### DIFF
--- a/src/modules/booking-agent/booking-agent-search.service.spec.ts
+++ b/src/modules/booking-agent/booking-agent-search.service.spec.ts
@@ -46,6 +46,7 @@ describe("BookingAgentSearchService", () => {
     serviceTier: "STANDARD",
     images: [{ url: `https://cdn.tripdly.test/${id}.jpg` }],
     owner: { username: "fleet-owner", name: "Fleet Owner" },
+    promotion: null,
     ...overrides,
   });
 

--- a/src/modules/car/car-categories.service.spec.ts
+++ b/src/modules/car/car-categories.service.spec.ts
@@ -300,5 +300,14 @@ describe("CarCategoriesService", () => {
       expect(result.allCars[0]?.promotion).toBeNull();
       expect(result.allCars[0]).not.toHaveProperty("ownerId");
     });
+
+    it("uses query.from as promotion reference date when provided", async () => {
+      const from = new Date("2026-03-10T10:00:00.000Z");
+      databaseServiceMock.car.findMany.mockResolvedValueOnce([]);
+
+      await service.getCategorizedCars({ limit: 50, from });
+
+      expect(promotionServiceMock.getActivePromotionsForCars).toHaveBeenCalledWith([], from);
+    });
   });
 });

--- a/src/modules/car/car-categories.service.spec.ts
+++ b/src/modules/car/car-categories.service.spec.ts
@@ -283,5 +283,20 @@ describe("CarCategoriesService", () => {
       });
       expect(result.allCars[0]).not.toHaveProperty("ownerId");
     });
+
+    it("fails open when promotion enrichment throws and still returns cars", async () => {
+      const cars = [createMockCar({ id: "car-1" })];
+      databaseServiceMock.car.findMany.mockResolvedValueOnce(cars);
+      promotionServiceMock.getActivePromotionsForCars.mockRejectedValueOnce(
+        new Error("promotion service unavailable"),
+      );
+
+      const result = await service.getCategorizedCars({ limit: 50 });
+
+      expect(result.allCars).toHaveLength(1);
+      expect(result.allCars[0]?.id).toBe("car-1");
+      expect(result.allCars[0]?.promotion).toBeNull();
+      expect(result.allCars[0]).not.toHaveProperty("ownerId");
+    });
   });
 });

--- a/src/modules/car/car-categories.service.spec.ts
+++ b/src/modules/car/car-categories.service.spec.ts
@@ -5,6 +5,7 @@ import { DatabaseService } from "../database/database.service";
 import { PromotionService } from "../promotion/promotion.service";
 import { CarFetchFailedException } from "./car.error";
 import { CarCategoriesService } from "./car-categories.service";
+import { CarPromotionEnrichmentService } from "./car-promotion.enrichment";
 import type { PublicCarDto } from "./dto/car-categories.dto";
 
 describe("CarCategoriesService", () => {
@@ -45,6 +46,7 @@ describe("CarCategoriesService", () => {
         CarCategoriesService,
         { provide: DatabaseService, useValue: databaseServiceMock },
         { provide: PromotionService, useValue: promotionServiceMock },
+        CarPromotionEnrichmentService,
       ],
     }).compile();
 

--- a/src/modules/car/car-categories.service.spec.ts
+++ b/src/modules/car/car-categories.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, type TestingModule } from "@nestjs/testing";
 import { ServiceTier, VehicleType } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DatabaseService } from "../database/database.service";
+import { PromotionService } from "../promotion/promotion.service";
 import { CarFetchFailedException } from "./car.error";
 import { CarCategoriesService } from "./car-categories.service";
 import type { PublicCarDto } from "./dto/car-categories.dto";
@@ -14,9 +15,15 @@ describe("CarCategoriesService", () => {
       findMany: vi.fn(),
     },
   };
+  const promotionServiceMock = {
+    getActivePromotionsForCars: vi.fn(),
+  };
 
-  const createMockCar = (overrides: Partial<PublicCarDto> = {}): PublicCarDto => ({
+  const createMockCar = (
+    overrides: Partial<PublicCarDto & { ownerId: string }> = {},
+  ): PublicCarDto & { ownerId: string } => ({
     id: `car-${Math.random().toString(36).slice(2, 9)}`,
+    ownerId: "owner-1",
     make: "Toyota",
     model: "Camry",
     year: 2022,
@@ -26,15 +33,18 @@ describe("CarCategoriesService", () => {
     vehicleType: VehicleType.SEDAN,
     serviceTier: ServiceTier.STANDARD,
     images: [{ url: "https://example.com/car.jpg" }],
+    promotion: null,
     ...overrides,
   });
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    promotionServiceMock.getActivePromotionsForCars.mockResolvedValue(new Map());
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CarCategoriesService,
         { provide: DatabaseService, useValue: databaseServiceMock },
+        { provide: PromotionService, useValue: promotionServiceMock },
       ],
     }).compile();
 
@@ -246,6 +256,32 @@ describe("CarCategoriesService", () => {
       await expect(service.getCategorizedCars({ limit: 50 })).rejects.toThrow(
         CarFetchFailedException,
       );
+    });
+
+    it("enriches cars with promotion and removes ownerId from API shape", async () => {
+      const cars = [createMockCar({ id: "car-1" })];
+      databaseServiceMock.car.findMany.mockResolvedValueOnce(cars);
+      promotionServiceMock.getActivePromotionsForCars.mockResolvedValueOnce(
+        new Map([
+          [
+            "car-1",
+            {
+              id: "promo-1",
+              name: "Weekend Deal",
+              discountValue: 10,
+            },
+          ],
+        ]),
+      );
+
+      const result = await service.getCategorizedCars({ limit: 50 });
+
+      expect(result.allCars[0]?.promotion).toEqual({
+        id: "promo-1",
+        name: "Weekend Deal",
+        discountValue: 10,
+      });
+      expect(result.allCars[0]).not.toHaveProperty("ownerId");
     });
   });
 });

--- a/src/modules/car/car-categories.service.ts
+++ b/src/modules/car/car-categories.service.ts
@@ -1,6 +1,8 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { CarApprovalStatus, Status } from "@prisma/client";
 import { DatabaseService } from "../database/database.service";
+import type { ActivePromotion } from "../promotion/promotion.interface";
+import { PromotionService } from "../promotion/promotion.service";
 import { CarException, CarFetchFailedException } from "./car.error";
 import type {
   CarCategoriesQueryDto,
@@ -10,12 +12,28 @@ import type {
   PublicCarDto,
 } from "./dto/car-categories.dto";
 import { CATEGORY_DEFINITIONS, MIN_CATEGORY_SIZE } from "./dto/car-categories.dto";
+import type { CarPromotionDto } from "./dto/car-promotion.dto";
 
 @Injectable()
 export class CarCategoriesService {
   private readonly logger = new Logger(CarCategoriesService.name);
 
-  constructor(private readonly databaseService: DatabaseService) {}
+  constructor(
+    private readonly databaseService: DatabaseService,
+    private readonly promotionService: PromotionService,
+  ) {}
+
+  private toPromotionDto(promotion: ActivePromotion | null): CarPromotionDto | null {
+    if (!promotion) {
+      return null;
+    }
+
+    return {
+      id: promotion.id,
+      name: promotion.name,
+      discountValue: Number(promotion.discountValue.toString()),
+    };
+  }
 
   /**
    * Categorizes cars into meaningful groups for display.
@@ -60,6 +78,7 @@ export class CarCategoriesService {
         },
         select: {
           id: true,
+          ownerId: true,
           make: true,
           model: true,
           year: true,
@@ -73,13 +92,26 @@ export class CarCategoriesService {
         orderBy: [{ updatedAt: "desc" }, { dayRate: "asc" }],
         take: query.limit,
       });
+      const promotionsByCarId = await this.promotionService.getActivePromotionsForCars(
+        cars.map((car) => ({ id: car.id, ownerId: car.ownerId })),
+        new Date(),
+      );
+      const enrichedCars = cars.map((car) => {
+        const publicCar = { ...car };
+        delete publicCar.ownerId;
 
-      const categories = this.categorizeCars(cars);
+        return {
+          ...publicCar,
+          promotion: this.toPromotionDto(promotionsByCarId.get(car.id) ?? null),
+        };
+      });
+
+      const categories = this.categorizeCars(enrichedCars);
 
       return {
         categories,
-        allCars: cars,
-        total: cars.length,
+        allCars: enrichedCars,
+        total: enrichedCars.length,
       };
     } catch (error) {
       if (error instanceof CarException) {

--- a/src/modules/car/car-categories.service.ts
+++ b/src/modules/car/car-categories.service.ts
@@ -78,21 +78,19 @@ export class CarCategoriesService {
         orderBy: [{ updatedAt: "desc" }, { dayRate: "asc" }],
         take: query.limit,
       });
-      const promotionTargets = cars.map((car) => ({ id: car.id, ownerId: car.ownerId }));
-      const promotionsByCarId = await this.carPromotionEnrichmentService.resolvePromotionsForCars({
-        targets: promotionTargets,
-        referenceDate: new Date(),
+
+      const carsWithPromotion = await this.carPromotionEnrichmentService.enrichCarsWithPromotion({
+        cars,
+        referenceDate: query.from ?? new Date(),
         failureMessage:
           "Promotion enrichment failed for categorized cars; returning cars without promotions",
       });
-      const enrichedCars = cars.map((car) => {
+
+      const enrichedCars = carsWithPromotion.map((car) => {
         const publicCar = { ...car };
         delete publicCar.ownerId;
 
-        return {
-          ...publicCar,
-          promotion: promotionsByCarId.get(car.id) ?? null,
-        };
+        return publicCar;
       });
 
       const categories = this.categorizeCars(enrichedCars);

--- a/src/modules/car/car-categories.service.ts
+++ b/src/modules/car/car-categories.service.ts
@@ -92,10 +92,23 @@ export class CarCategoriesService {
         orderBy: [{ updatedAt: "desc" }, { dayRate: "asc" }],
         take: query.limit,
       });
-      const promotionsByCarId = await this.promotionService.getActivePromotionsForCars(
-        cars.map((car) => ({ id: car.id, ownerId: car.ownerId })),
-        new Date(),
-      );
+      const promotionTargets = cars.map((car) => ({ id: car.id, ownerId: car.ownerId }));
+      let promotionsByCarId = new Map<string, ActivePromotion>();
+      try {
+        promotionsByCarId = await this.promotionService.getActivePromotionsForCars(
+          promotionTargets,
+          new Date(),
+        );
+      } catch (error) {
+        this.logger.warn(
+          "Promotion enrichment failed for categorized cars; returning cars without promotions",
+          {
+            carIds: promotionTargets.map((target) => target.id),
+            ownerIds: [...new Set(promotionTargets.map((target) => target.ownerId))],
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+      }
       const enrichedCars = cars.map((car) => {
         const publicCar = { ...car };
         delete publicCar.ownerId;

--- a/src/modules/car/car-categories.service.ts
+++ b/src/modules/car/car-categories.service.ts
@@ -1,9 +1,8 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { CarApprovalStatus, Status } from "@prisma/client";
 import { DatabaseService } from "../database/database.service";
-import type { ActivePromotion } from "../promotion/promotion.interface";
-import { PromotionService } from "../promotion/promotion.service";
 import { CarException, CarFetchFailedException } from "./car.error";
+import { CarPromotionEnrichmentService } from "./car-promotion.enrichment";
 import type {
   CarCategoriesQueryDto,
   CarCategoriesResponseDto,
@@ -12,7 +11,6 @@ import type {
   PublicCarDto,
 } from "./dto/car-categories.dto";
 import { CATEGORY_DEFINITIONS, MIN_CATEGORY_SIZE } from "./dto/car-categories.dto";
-import type { CarPromotionDto } from "./dto/car-promotion.dto";
 
 @Injectable()
 export class CarCategoriesService {
@@ -20,20 +18,8 @@ export class CarCategoriesService {
 
   constructor(
     private readonly databaseService: DatabaseService,
-    private readonly promotionService: PromotionService,
+    private readonly carPromotionEnrichmentService: CarPromotionEnrichmentService,
   ) {}
-
-  private toPromotionDto(promotion: ActivePromotion | null): CarPromotionDto | null {
-    if (!promotion) {
-      return null;
-    }
-
-    return {
-      id: promotion.id,
-      name: promotion.name,
-      discountValue: Number(promotion.discountValue.toString()),
-    };
-  }
 
   /**
    * Categorizes cars into meaningful groups for display.
@@ -93,29 +79,19 @@ export class CarCategoriesService {
         take: query.limit,
       });
       const promotionTargets = cars.map((car) => ({ id: car.id, ownerId: car.ownerId }));
-      let promotionsByCarId = new Map<string, ActivePromotion>();
-      try {
-        promotionsByCarId = await this.promotionService.getActivePromotionsForCars(
-          promotionTargets,
-          new Date(),
-        );
-      } catch (error) {
-        this.logger.warn(
+      const promotionsByCarId = await this.carPromotionEnrichmentService.resolvePromotionsForCars({
+        targets: promotionTargets,
+        referenceDate: new Date(),
+        failureMessage:
           "Promotion enrichment failed for categorized cars; returning cars without promotions",
-          {
-            carIds: promotionTargets.map((target) => target.id),
-            ownerIds: [...new Set(promotionTargets.map((target) => target.ownerId))],
-            error: error instanceof Error ? error.message : String(error),
-          },
-        );
-      }
+      });
       const enrichedCars = cars.map((car) => {
         const publicCar = { ...car };
         delete publicCar.ownerId;
 
         return {
           ...publicCar,
-          promotion: this.toPromotionDto(promotionsByCarId.get(car.id) ?? null),
+          promotion: promotionsByCarId.get(car.id) ?? null,
         };
       });
 

--- a/src/modules/car/car-categories.service.ts
+++ b/src/modules/car/car-categories.service.ts
@@ -86,12 +86,7 @@ export class CarCategoriesService {
           "Promotion enrichment failed for categorized cars; returning cars without promotions",
       });
 
-      const enrichedCars = carsWithPromotion.map((car) => {
-        const publicCar = { ...car };
-        delete publicCar.ownerId;
-
-        return publicCar;
-      });
+      const enrichedCars = carsWithPromotion.map(({ ownerId: _ownerId, ...car }) => car);
 
       const categories = this.categorizeCars(enrichedCars);
 

--- a/src/modules/car/car-promotion.enrichment.spec.ts
+++ b/src/modules/car/car-promotion.enrichment.spec.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+import { CarPromotionEnrichmentService, type PromotionTarget } from "./car-promotion.enrichment";
+
+describe("car-promotion.enrichment", () => {
+  const createSut = () => {
+    const promotionService = {
+      getActivePromotionsForCars: vi.fn(),
+      getActivePromotionForCar: vi.fn(),
+    };
+    const service = new CarPromotionEnrichmentService(promotionService as never);
+    const loggerWarnSpy = vi.spyOn(service["logger"], "warn").mockImplementation(() => undefined);
+
+    return { service, promotionService, loggerWarnSpy };
+  };
+
+  it("maps active promotions for multiple cars", async () => {
+    const { service, promotionService } = createSut();
+    const targets: PromotionTarget[] = [
+      { id: "car-1", ownerId: "owner-1" },
+      { id: "car-2", ownerId: "owner-1" },
+    ];
+    promotionService.getActivePromotionsForCars.mockResolvedValueOnce(
+      new Map([
+        [
+          "car-1",
+          {
+            id: "promo-1",
+            name: "Weekend Deal",
+            discountValue: 20,
+          },
+        ],
+      ]),
+    );
+
+    const result = await service.resolvePromotionsForCars({
+      targets,
+      referenceDate: new Date("2026-03-01T00:00:00.000Z"),
+      failureMessage: "promotion batch failed",
+    });
+
+    expect(result.get("car-1")).toEqual({
+      id: "promo-1",
+      name: "Weekend Deal",
+      discountValue: 20,
+    });
+    expect(result.get("car-2")).toBeNull();
+  });
+
+  it("fails open for multiple cars when promotion lookup throws", async () => {
+    const { service, promotionService, loggerWarnSpy } = createSut();
+    const targets: PromotionTarget[] = [{ id: "car-1", ownerId: "owner-1" }];
+    promotionService.getActivePromotionsForCars.mockRejectedValueOnce(new Error("promotion down"));
+
+    const result = await service.resolvePromotionsForCars({
+      targets,
+      referenceDate: new Date("2026-03-01T00:00:00.000Z"),
+      failureMessage: "promotion batch failed",
+    });
+
+    expect(result.get("car-1")).toBeNull();
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      "promotion batch failed",
+      expect.objectContaining({
+        carIds: ["car-1"],
+        ownerIds: ["owner-1"],
+      }),
+    );
+  });
+
+  it("maps active promotion for a single car", async () => {
+    const { service, promotionService } = createSut();
+    promotionService.getActivePromotionForCar.mockResolvedValueOnce({
+      id: "promo-1",
+      name: "Weekend Deal",
+      discountValue: 25,
+    });
+
+    const result = await service.resolvePromotionForCar({
+      target: { id: "car-1", ownerId: "owner-1" },
+      referenceDate: new Date("2026-03-01T00:00:00.000Z"),
+      failureMessage: "promotion single failed",
+    });
+
+    expect(result).toEqual({
+      id: "promo-1",
+      name: "Weekend Deal",
+      discountValue: 25,
+    });
+  });
+
+  it("fails open for a single car when promotion lookup throws", async () => {
+    const { service, promotionService, loggerWarnSpy } = createSut();
+    promotionService.getActivePromotionForCar.mockRejectedValueOnce(new Error("promotion down"));
+
+    const result = await service.resolvePromotionForCar({
+      target: { id: "car-1", ownerId: "owner-1" },
+      referenceDate: new Date("2026-03-01T00:00:00.000Z"),
+      failureMessage: "promotion single failed",
+    });
+
+    expect(result).toBeNull();
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      "promotion single failed",
+      expect.objectContaining({
+        carId: "car-1",
+        ownerId: "owner-1",
+      }),
+    );
+  });
+});

--- a/src/modules/car/car-promotion.enrichment.spec.ts
+++ b/src/modules/car/car-promotion.enrichment.spec.ts
@@ -61,8 +61,8 @@ describe("car-promotion.enrichment", () => {
     expect(loggerWarnSpy).toHaveBeenCalledWith(
       "promotion batch failed",
       expect.objectContaining({
-        carIds: ["car-1"],
-        ownerIds: ["owner-1"],
+        carCount: 1,
+        ownerCount: 1,
       }),
     );
   });
@@ -103,8 +103,78 @@ describe("car-promotion.enrichment", () => {
       "promotion single failed",
       expect.objectContaining({
         carId: "car-1",
-        ownerId: "owner-1",
+        ownerIdPresent: true,
       }),
     );
+  });
+
+  it("enriches cars with promotions using shared helper", async () => {
+    const { service, promotionService } = createSut();
+    promotionService.getActivePromotionsForCars.mockResolvedValueOnce(
+      new Map([
+        [
+          "car-1",
+          {
+            id: "promo-1",
+            name: "Weekend Deal",
+            discountValue: 18,
+          },
+        ],
+      ]),
+    );
+
+    const result = await service.enrichCarsWithPromotion({
+      cars: [
+        { id: "car-1", ownerId: "owner-1", make: "Toyota" },
+        { id: "car-2", ownerId: "owner-1", make: "Honda" },
+      ],
+      referenceDate: new Date("2026-03-01T00:00:00.000Z"),
+      failureMessage: "promotion batch helper failed",
+    });
+
+    expect(result).toEqual([
+      {
+        id: "car-1",
+        ownerId: "owner-1",
+        make: "Toyota",
+        promotion: {
+          id: "promo-1",
+          name: "Weekend Deal",
+          discountValue: 18,
+        },
+      },
+      {
+        id: "car-2",
+        ownerId: "owner-1",
+        make: "Honda",
+        promotion: null,
+      },
+    ]);
+  });
+
+  it("enriches single car with promotion using shared helper", async () => {
+    const { service, promotionService } = createSut();
+    promotionService.getActivePromotionForCar.mockResolvedValueOnce({
+      id: "promo-1",
+      name: "Weekend Deal",
+      discountValue: 25,
+    });
+
+    const result = await service.enrichCarWithPromotion({
+      car: { id: "car-1", ownerId: "owner-1", make: "Toyota" },
+      referenceDate: new Date("2026-03-01T00:00:00.000Z"),
+      failureMessage: "promotion single helper failed",
+    });
+
+    expect(result).toEqual({
+      id: "car-1",
+      ownerId: "owner-1",
+      make: "Toyota",
+      promotion: {
+        id: "promo-1",
+        name: "Weekend Deal",
+        discountValue: 25,
+      },
+    });
   });
 });

--- a/src/modules/car/car-promotion.enrichment.ts
+++ b/src/modules/car/car-promotion.enrichment.ts
@@ -1,0 +1,78 @@
+import { Injectable, Logger } from "@nestjs/common";
+import type { ActivePromotion } from "../promotion/promotion.interface";
+import { PromotionService } from "../promotion/promotion.service";
+import type { CarPromotionDto } from "./dto/car-promotion.dto";
+import { mapActivePromotionToCarPromotionDto } from "./dto/car-promotion.mapper";
+
+export interface PromotionTarget {
+  id: string;
+  ownerId: string;
+}
+
+interface ResolvePromotionsForCarsParams {
+  targets: PromotionTarget[];
+  referenceDate: Date;
+  failureMessage: string;
+}
+
+interface ResolvePromotionForCarParams {
+  target: PromotionTarget;
+  referenceDate: Date;
+  failureMessage: string;
+}
+
+@Injectable()
+export class CarPromotionEnrichmentService {
+  private readonly logger = new Logger(CarPromotionEnrichmentService.name);
+
+  constructor(private readonly promotionService: PromotionService) {}
+
+  async resolvePromotionsForCars({
+    targets,
+    referenceDate,
+    failureMessage,
+  }: ResolvePromotionsForCarsParams): Promise<Map<string, CarPromotionDto | null>> {
+    let activePromotionsByCarId = new Map<string, ActivePromotion>();
+    try {
+      activePromotionsByCarId = await this.promotionService.getActivePromotionsForCars(
+        targets,
+        referenceDate,
+      );
+    } catch (promotionError) {
+      this.logger.warn(failureMessage, {
+        carIds: targets.map((target) => target.id),
+        ownerIds: [...new Set(targets.map((target) => target.ownerId))],
+        error: promotionError instanceof Error ? promotionError.message : String(promotionError),
+      });
+    }
+
+    return new Map(
+      targets.map((target) => [
+        target.id,
+        mapActivePromotionToCarPromotionDto(activePromotionsByCarId.get(target.id) ?? null),
+      ]),
+    );
+  }
+
+  async resolvePromotionForCar({
+    target,
+    referenceDate,
+    failureMessage,
+  }: ResolvePromotionForCarParams): Promise<CarPromotionDto | null> {
+    try {
+      const promotion = await this.promotionService.getActivePromotionForCar(
+        target.id,
+        target.ownerId,
+        referenceDate,
+      );
+      return mapActivePromotionToCarPromotionDto(promotion);
+    } catch (promotionError) {
+      this.logger.warn(failureMessage, {
+        carId: target.id,
+        ownerId: target.ownerId,
+        error: promotionError instanceof Error ? promotionError.message : String(promotionError),
+      });
+      return null;
+    }
+  }
+}

--- a/src/modules/car/car-promotion.enrichment.ts
+++ b/src/modules/car/car-promotion.enrichment.ts
@@ -21,6 +21,18 @@ interface ResolvePromotionForCarParams {
   failureMessage: string;
 }
 
+interface EnrichCarsWithPromotionParams<T extends PromotionTarget> {
+  cars: T[];
+  referenceDate: Date;
+  failureMessage: string;
+}
+
+interface EnrichCarWithPromotionParams<T extends PromotionTarget> {
+  car: T;
+  referenceDate: Date;
+  failureMessage: string;
+}
+
 @Injectable()
 export class CarPromotionEnrichmentService {
   private readonly logger = new Logger(CarPromotionEnrichmentService.name);
@@ -40,8 +52,8 @@ export class CarPromotionEnrichmentService {
       );
     } catch (promotionError) {
       this.logger.warn(failureMessage, {
-        carIds: targets.map((target) => target.id),
-        ownerIds: [...new Set(targets.map((target) => target.ownerId))],
+        carCount: targets.length,
+        ownerCount: new Set(targets.map((target) => target.ownerId)).size,
         error: promotionError instanceof Error ? promotionError.message : String(promotionError),
       });
     }
@@ -69,10 +81,45 @@ export class CarPromotionEnrichmentService {
     } catch (promotionError) {
       this.logger.warn(failureMessage, {
         carId: target.id,
-        ownerId: target.ownerId,
+        ownerIdPresent: Boolean(target.ownerId),
         error: promotionError instanceof Error ? promotionError.message : String(promotionError),
       });
       return null;
     }
+  }
+
+  async enrichCarsWithPromotion<T extends PromotionTarget>({
+    cars,
+    referenceDate,
+    failureMessage,
+  }: EnrichCarsWithPromotionParams<T>): Promise<Array<T & { promotion: CarPromotionDto | null }>> {
+    const targets = cars.map(({ id, ownerId }) => ({ id, ownerId }));
+    const promotionsByCarId = await this.resolvePromotionsForCars({
+      targets,
+      referenceDate,
+      failureMessage,
+    });
+
+    return cars.map((car) => ({
+      ...car,
+      promotion: promotionsByCarId.get(car.id) ?? null,
+    }));
+  }
+
+  async enrichCarWithPromotion<T extends PromotionTarget>({
+    car,
+    referenceDate,
+    failureMessage,
+  }: EnrichCarWithPromotionParams<T>): Promise<T & { promotion: CarPromotionDto | null }> {
+    const promotion = await this.resolvePromotionForCar({
+      target: { id: car.id, ownerId: car.ownerId },
+      referenceDate,
+      failureMessage,
+    });
+
+    return {
+      ...car,
+      promotion,
+    };
   }
 }

--- a/src/modules/car/car-search.service.spec.ts
+++ b/src/modules/car/car-search.service.spec.ts
@@ -8,6 +8,7 @@ import {
 } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DatabaseService } from "../database/database.service";
+import { PromotionService } from "../promotion/promotion.service";
 import { CarFetchFailedException, CarNotFoundException } from "./car.error";
 import { CarSearchService } from "./car-search.service";
 import type { SearchCarDto } from "./dto/car-search.dto";
@@ -30,9 +31,16 @@ describe("CarSearchService", () => {
       findMany: vi.fn(),
     },
   };
+  const promotionServiceMock = {
+    getActivePromotionsForCars: vi.fn(),
+    getActivePromotionForCar: vi.fn(),
+  };
 
-  const createMockCar = (overrides: Partial<SearchCarDto> = {}): SearchCarDto => ({
+  const createMockCar = (
+    overrides: Partial<SearchCarDto & { ownerId: string }> = {},
+  ): SearchCarDto & { ownerId: string } => ({
     id: `car-${mockCarIdCounter++}`,
+    ownerId: "owner-1",
     make: "Toyota",
     model: "Camry",
     year: 2022,
@@ -47,6 +55,7 @@ describe("CarSearchService", () => {
     serviceTier: ServiceTier.STANDARD,
     images: [{ url: "https://example.com/car.jpg" }],
     owner: { username: "fleetowner1", name: "Fleet Owner" },
+    promotion: null,
     ...overrides,
   });
 
@@ -54,8 +63,14 @@ describe("CarSearchService", () => {
     vi.clearAllMocks();
     mockCarIdCounter = 0;
     databaseServiceMock.booking.findMany.mockResolvedValue([]);
+    promotionServiceMock.getActivePromotionsForCars.mockResolvedValue(new Map());
+    promotionServiceMock.getActivePromotionForCar.mockResolvedValue(null);
     const module: TestingModule = await Test.createTestingModule({
-      providers: [CarSearchService, { provide: DatabaseService, useValue: databaseServiceMock }],
+      providers: [
+        CarSearchService,
+        { provide: DatabaseService, useValue: databaseServiceMock },
+        { provide: PromotionService, useValue: promotionServiceMock },
+      ],
     }).compile();
 
     service = module.get<CarSearchService>(CarSearchService);
@@ -103,6 +118,10 @@ describe("CarSearchService", () => {
       expect(result.cars).toEqual([]);
       expect(result.pagination.total).toBe(0);
       expect(result.pagination.totalPages).toBe(0);
+      expect(promotionServiceMock.getActivePromotionsForCars).toHaveBeenCalledWith(
+        [],
+        expect.any(Date),
+      );
     });
 
     it("returns cars matching serviceTier filter", async () => {
@@ -375,6 +394,43 @@ describe("CarSearchService", () => {
       );
     });
 
+    it("enriches returned cars with promotion when available", async () => {
+      const cars = [createMockCar({ id: "car-promoted" })];
+      databaseServiceMock.car.count.mockResolvedValueOnce(1);
+      databaseServiceMock.car.findMany.mockResolvedValueOnce(cars);
+      promotionServiceMock.getActivePromotionsForCars.mockResolvedValueOnce(
+        new Map([
+          [
+            "car-promoted",
+            {
+              id: "promo-1",
+              name: "Weekend Deal",
+              discountValue: 20,
+            },
+          ],
+        ]),
+      );
+
+      const result = await service.searchCars({ page: 1, limit: 12 });
+
+      expect(result.cars[0]?.promotion).toEqual({
+        id: "promo-1",
+        name: "Weekend Deal",
+        discountValue: 20,
+      });
+    });
+
+    it("uses query.from as promotion reference date when provided", async () => {
+      const from = new Date("2026-03-01T00:00:00.000Z");
+      databaseServiceMock.user.findMany.mockResolvedValueOnce([]);
+      databaseServiceMock.car.count.mockResolvedValueOnce(0);
+      databaseServiceMock.car.findMany.mockResolvedValueOnce([]);
+
+      await service.searchCars({ from, page: 1, limit: 12 });
+
+      expect(promotionServiceMock.getActivePromotionsForCars).toHaveBeenCalledWith([], from);
+    });
+
     it("combines multiple filters", async () => {
       const cars = [
         createMockCar({
@@ -412,7 +468,12 @@ describe("CarSearchService", () => {
 
       const result = await service.getPublicCarById("car-123");
 
-      expect(result).toEqual(mockCar);
+      expect(result).toMatchObject({
+        id: "car-123",
+        owner: { username: "fleetowner1", name: "Fleet Owner" },
+        promotion: null,
+      });
+      expect("ownerId" in result).toBe(false);
       expect(databaseServiceMock.car.findFirst).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
@@ -434,6 +495,33 @@ describe("CarSearchService", () => {
       databaseServiceMock.car.findFirst.mockRejectedValueOnce(new Error("Database error"));
 
       await expect(service.getPublicCarById("car-123")).rejects.toThrow(CarFetchFailedException);
+    });
+
+    it("returns promotion on public car detail when one is active", async () => {
+      const mockCar = {
+        ...createMockCar({ id: "car-123", ownerId: "owner-123" }),
+        hourlyRate: 5000,
+        fuelUpgradeRate: 10000,
+      };
+      databaseServiceMock.car.findFirst.mockResolvedValueOnce(mockCar);
+      promotionServiceMock.getActivePromotionForCar.mockResolvedValueOnce({
+        id: "promo-1",
+        name: "Weekend Deal",
+        discountValue: 25,
+      });
+
+      const result = await service.getPublicCarById("car-123");
+
+      expect(result.promotion).toEqual({
+        id: "promo-1",
+        name: "Weekend Deal",
+        discountValue: 25,
+      });
+      expect(promotionServiceMock.getActivePromotionForCar).toHaveBeenCalledWith(
+        "car-123",
+        "owner-123",
+        expect.any(Date),
+      );
     });
   });
 });

--- a/src/modules/car/car-search.service.spec.ts
+++ b/src/modules/car/car-search.service.spec.ts
@@ -541,6 +541,24 @@ describe("CarSearchService", () => {
       );
     });
 
+    it("uses provided reference date for public car promotion lookup", async () => {
+      const referenceDate = new Date("2026-03-20T09:30:00.000Z");
+      const mockCar = {
+        ...createMockCar({ id: "car-123", ownerId: "owner-123" }),
+        hourlyRate: 5000,
+        fuelUpgradeRate: 10000,
+      };
+      databaseServiceMock.car.findFirst.mockResolvedValueOnce(mockCar);
+
+      await service.getPublicCarById("car-123", referenceDate);
+
+      expect(promotionServiceMock.getActivePromotionForCar).toHaveBeenCalledWith(
+        "car-123",
+        "owner-123",
+        referenceDate,
+      );
+    });
+
     it("returns public car detail when promotion enrichment fails", async () => {
       const mockCar = {
         ...createMockCar({ id: "car-123", ownerId: "owner-123" }),

--- a/src/modules/car/car-search.service.spec.ts
+++ b/src/modules/car/car-search.service.spec.ts
@@ -431,6 +431,21 @@ describe("CarSearchService", () => {
       expect(promotionServiceMock.getActivePromotionsForCars).toHaveBeenCalledWith([], from);
     });
 
+    it("returns cars when promotion enrichment fails", async () => {
+      const cars = [createMockCar({ id: "car-1" })];
+      databaseServiceMock.car.count.mockResolvedValueOnce(1);
+      databaseServiceMock.car.findMany.mockResolvedValueOnce(cars);
+      promotionServiceMock.getActivePromotionsForCars.mockRejectedValueOnce(
+        new Error("promotion down"),
+      );
+
+      const result = await service.searchCars({ page: 1, limit: 12 });
+
+      expect(result.cars).toHaveLength(1);
+      expect(result.cars[0]?.id).toBe("car-1");
+      expect(result.cars[0]?.promotion).toBeNull();
+    });
+
     it("combines multiple filters", async () => {
       const cars = [
         createMockCar({
@@ -522,6 +537,23 @@ describe("CarSearchService", () => {
         "owner-123",
         expect.any(Date),
       );
+    });
+
+    it("returns public car detail when promotion enrichment fails", async () => {
+      const mockCar = {
+        ...createMockCar({ id: "car-123", ownerId: "owner-123" }),
+        hourlyRate: 5000,
+        fuelUpgradeRate: 10000,
+      };
+      databaseServiceMock.car.findFirst.mockResolvedValueOnce(mockCar);
+      promotionServiceMock.getActivePromotionForCar.mockRejectedValueOnce(
+        new Error("promotion down"),
+      );
+
+      const result = await service.getPublicCarById("car-123");
+
+      expect(result.id).toBe("car-123");
+      expect(result.promotion).toBeNull();
     });
   });
 });

--- a/src/modules/car/car-search.service.spec.ts
+++ b/src/modules/car/car-search.service.spec.ts
@@ -10,6 +10,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DatabaseService } from "../database/database.service";
 import { PromotionService } from "../promotion/promotion.service";
 import { CarFetchFailedException, CarNotFoundException } from "./car.error";
+import { CarPromotionEnrichmentService } from "./car-promotion.enrichment";
 import { CarSearchService } from "./car-search.service";
 import type { SearchCarDto } from "./dto/car-search.dto";
 import { mapQueryToFilters } from "./dto/car-search.dto";
@@ -70,6 +71,7 @@ describe("CarSearchService", () => {
         CarSearchService,
         { provide: DatabaseService, useValue: databaseServiceMock },
         { provide: PromotionService, useValue: promotionServiceMock },
+        CarPromotionEnrichmentService,
       ],
     }).compile();
 

--- a/src/modules/car/car-search.service.ts
+++ b/src/modules/car/car-search.service.ts
@@ -284,11 +284,8 @@ export class CarSearchService {
         referenceDate,
         failureMessage: "Failed to enrich search results with promotions",
       });
-      const enrichedCars = carsWithPromotion.map((car) => {
-        const { ownerId: _ownerId, ...publicCar } = car;
 
-        return publicCar;
-      });
+      const enrichedCars = carsWithPromotion.map(({ ownerId: _ownerId, ...car }) => car);
 
       // Calculate pagination
       const totalPages = Math.ceil(totalCount / query.limit);

--- a/src/modules/car/car-search.service.ts
+++ b/src/modules/car/car-search.service.ts
@@ -10,7 +10,10 @@ import {
 import { buildBufferedBookingInterval } from "../../shared/availability-buffer.helper";
 import { normalizeBookingTimeWindow } from "../../shared/booking-time-window.helper";
 import { DatabaseService } from "../database/database.service";
+import type { ActivePromotion } from "../promotion/promotion.interface";
+import { PromotionService } from "../promotion/promotion.service";
 import { CarException, CarFetchFailedException, CarNotFoundException } from "./car.error";
+import type { CarPromotionDto } from "./dto/car-promotion.dto";
 import type {
   CarSearchQueryDto,
   CarSearchResponseDto,
@@ -28,7 +31,22 @@ interface AvailabilityInterval {
 export class CarSearchService {
   private readonly logger = new Logger(CarSearchService.name);
 
-  constructor(private readonly databaseService: DatabaseService) {}
+  constructor(
+    private readonly databaseService: DatabaseService,
+    private readonly promotionService: PromotionService,
+  ) {}
+
+  private toPromotionDto(promotion: ActivePromotion | null): CarPromotionDto | null {
+    if (!promotion) {
+      return null;
+    }
+
+    return {
+      id: promotion.id,
+      name: promotion.name,
+      discountValue: Number(promotion.discountValue.toString()),
+    };
+  }
 
   /**
    * Parses search query params, applying free-text mapping if needed.
@@ -253,6 +271,7 @@ export class CarSearchService {
           where: searchWhereClause,
           select: {
             id: true,
+            ownerId: true,
             make: true,
             model: true,
             year: true,
@@ -273,6 +292,20 @@ export class CarSearchService {
           take,
         }),
       ]);
+      const referenceDate = query.from ?? new Date();
+      const promotionsByCarId = await this.promotionService.getActivePromotionsForCars(
+        cars.map((car) => ({ id: car.id, ownerId: car.ownerId })),
+        referenceDate,
+      );
+      const enrichedCars = cars.map((car) => {
+        const publicCar = { ...car };
+        delete publicCar.ownerId;
+
+        return {
+          ...publicCar,
+          promotion: this.toPromotionDto(promotionsByCarId.get(car.id) ?? null),
+        };
+      });
 
       // Calculate pagination
       const totalPages = Math.ceil(totalCount / query.limit);
@@ -287,7 +320,7 @@ export class CarSearchService {
       });
 
       return {
-        cars,
+        cars: enrichedCars,
         filters: {
           serviceTier: serviceTier ?? null,
           vehicleType: vehicleType ?? null,
@@ -329,6 +362,7 @@ export class CarSearchService {
         },
         select: {
           id: true,
+          ownerId: true,
           make: true,
           model: true,
           year: true,
@@ -352,7 +386,18 @@ export class CarSearchService {
         throw new CarNotFoundException();
       }
 
-      return car;
+      const promotion = await this.promotionService.getActivePromotionForCar(
+        car.id,
+        car.ownerId,
+        new Date(),
+      );
+      const publicCar = { ...car };
+      delete publicCar.ownerId;
+
+      return {
+        ...publicCar,
+        promotion: this.toPromotionDto(promotion),
+      };
     } catch (error) {
       if (error instanceof CarException) {
         throw error;

--- a/src/modules/car/car-search.service.ts
+++ b/src/modules/car/car-search.service.ts
@@ -279,19 +279,15 @@ export class CarSearchService {
         }),
       ]);
       const referenceDate = query.from ?? new Date();
-      const promotionTargets = cars.map((car) => ({ id: car.id, ownerId: car.ownerId }));
-      const promotionsByCarId = await this.carPromotionEnrichmentService.resolvePromotionsForCars({
-        targets: promotionTargets,
+      const carsWithPromotion = await this.carPromotionEnrichmentService.enrichCarsWithPromotion({
+        cars,
         referenceDate,
         failureMessage: "Failed to enrich search results with promotions",
       });
-      const enrichedCars = cars.map((car) => {
+      const enrichedCars = carsWithPromotion.map((car) => {
         const { ownerId: _ownerId, ...publicCar } = car;
 
-        return {
-          ...publicCar,
-          promotion: promotionsByCarId.get(car.id) ?? null,
-        };
+        return publicCar;
       });
 
       // Calculate pagination
@@ -338,7 +334,7 @@ export class CarSearchService {
    * Fetches a single car by ID for public display.
    * Only returns approved cars from approved fleet owners.
    */
-  async getPublicCarById(carId: string): Promise<PublicCarDetailDto> {
+  async getPublicCarById(carId: string, referenceDate?: Date): Promise<PublicCarDetailDto> {
     try {
       const car = await this.databaseService.car.findFirst({
         where: {
@@ -373,17 +369,14 @@ export class CarSearchService {
         throw new CarNotFoundException();
       }
 
-      const promotion = await this.carPromotionEnrichmentService.resolvePromotionForCar({
-        target: { id: car.id, ownerId: car.ownerId },
-        referenceDate: new Date(),
+      const carWithPromotion = await this.carPromotionEnrichmentService.enrichCarWithPromotion({
+        car,
+        referenceDate: referenceDate ?? new Date(),
         failureMessage: "Failed to enrich public car with promotion",
       });
-      const { ownerId: _ownerId, ...publicCar } = car;
+      const { ownerId: _ownerId, ...publicCar } = carWithPromotion;
 
-      return {
-        ...publicCar,
-        promotion,
-      };
+      return publicCar;
     } catch (error) {
       if (error instanceof CarException) {
         throw error;

--- a/src/modules/car/car-search.service.ts
+++ b/src/modules/car/car-search.service.ts
@@ -10,10 +10,8 @@ import {
 import { buildBufferedBookingInterval } from "../../shared/availability-buffer.helper";
 import { normalizeBookingTimeWindow } from "../../shared/booking-time-window.helper";
 import { DatabaseService } from "../database/database.service";
-import type { ActivePromotion } from "../promotion/promotion.interface";
-import { PromotionService } from "../promotion/promotion.service";
 import { CarException, CarFetchFailedException, CarNotFoundException } from "./car.error";
-import type { CarPromotionDto } from "./dto/car-promotion.dto";
+import { CarPromotionEnrichmentService } from "./car-promotion.enrichment";
 import type {
   CarSearchQueryDto,
   CarSearchResponseDto,
@@ -33,20 +31,8 @@ export class CarSearchService {
 
   constructor(
     private readonly databaseService: DatabaseService,
-    private readonly promotionService: PromotionService,
+    private readonly carPromotionEnrichmentService: CarPromotionEnrichmentService,
   ) {}
-
-  private toPromotionDto(promotion: ActivePromotion | null): CarPromotionDto | null {
-    if (!promotion) {
-      return null;
-    }
-
-    return {
-      id: promotion.id,
-      name: promotion.name,
-      discountValue: Number(promotion.discountValue.toString()),
-    };
-  }
 
   /**
    * Parses search query params, applying free-text mapping if needed.
@@ -294,26 +280,17 @@ export class CarSearchService {
       ]);
       const referenceDate = query.from ?? new Date();
       const promotionTargets = cars.map((car) => ({ id: car.id, ownerId: car.ownerId }));
-      let promotionsByCarId = new Map<string, ActivePromotion>();
-      try {
-        promotionsByCarId = await this.promotionService.getActivePromotionsForCars(
-          promotionTargets,
-          referenceDate,
-        );
-      } catch (promotionError) {
-        this.logger.warn("Failed to enrich search results with promotions", {
-          carIds: promotionTargets.map((target) => target.id),
-          ownerIds: [...new Set(promotionTargets.map((target) => target.ownerId))],
-          error: promotionError instanceof Error ? promotionError.message : String(promotionError),
-        });
-      }
+      const promotionsByCarId = await this.carPromotionEnrichmentService.resolvePromotionsForCars({
+        targets: promotionTargets,
+        referenceDate,
+        failureMessage: "Failed to enrich search results with promotions",
+      });
       const enrichedCars = cars.map((car) => {
-        const publicCar = { ...car };
-        delete publicCar.ownerId;
+        const { ownerId: _ownerId, ...publicCar } = car;
 
         return {
           ...publicCar,
-          promotion: this.toPromotionDto(promotionsByCarId.get(car.id) ?? null),
+          promotion: promotionsByCarId.get(car.id) ?? null,
         };
       });
 
@@ -396,26 +373,16 @@ export class CarSearchService {
         throw new CarNotFoundException();
       }
 
-      let promotion: ActivePromotion | null = null;
-      try {
-        promotion = await this.promotionService.getActivePromotionForCar(
-          car.id,
-          car.ownerId,
-          new Date(),
-        );
-      } catch (promotionError) {
-        this.logger.warn("Failed to enrich public car with promotion", {
-          carId,
-          ownerId: car.ownerId,
-          error: promotionError instanceof Error ? promotionError.message : String(promotionError),
-        });
-      }
-      const publicCar = { ...car };
-      delete publicCar.ownerId;
+      const promotion = await this.carPromotionEnrichmentService.resolvePromotionForCar({
+        target: { id: car.id, ownerId: car.ownerId },
+        referenceDate: new Date(),
+        failureMessage: "Failed to enrich public car with promotion",
+      });
+      const { ownerId: _ownerId, ...publicCar } = car;
 
       return {
         ...publicCar,
-        promotion: this.toPromotionDto(promotion),
+        promotion,
       };
     } catch (error) {
       if (error instanceof CarException) {

--- a/src/modules/car/car-search.service.ts
+++ b/src/modules/car/car-search.service.ts
@@ -293,10 +293,20 @@ export class CarSearchService {
         }),
       ]);
       const referenceDate = query.from ?? new Date();
-      const promotionsByCarId = await this.promotionService.getActivePromotionsForCars(
-        cars.map((car) => ({ id: car.id, ownerId: car.ownerId })),
-        referenceDate,
-      );
+      const promotionTargets = cars.map((car) => ({ id: car.id, ownerId: car.ownerId }));
+      let promotionsByCarId = new Map<string, ActivePromotion>();
+      try {
+        promotionsByCarId = await this.promotionService.getActivePromotionsForCars(
+          promotionTargets,
+          referenceDate,
+        );
+      } catch (promotionError) {
+        this.logger.warn("Failed to enrich search results with promotions", {
+          carIds: promotionTargets.map((target) => target.id),
+          ownerIds: [...new Set(promotionTargets.map((target) => target.ownerId))],
+          error: promotionError instanceof Error ? promotionError.message : String(promotionError),
+        });
+      }
       const enrichedCars = cars.map((car) => {
         const publicCar = { ...car };
         delete publicCar.ownerId;
@@ -386,11 +396,20 @@ export class CarSearchService {
         throw new CarNotFoundException();
       }
 
-      const promotion = await this.promotionService.getActivePromotionForCar(
-        car.id,
-        car.ownerId,
-        new Date(),
-      );
+      let promotion: ActivePromotion | null = null;
+      try {
+        promotion = await this.promotionService.getActivePromotionForCar(
+          car.id,
+          car.ownerId,
+          new Date(),
+        );
+      } catch (promotionError) {
+        this.logger.warn("Failed to enrich public car with promotion", {
+          carId,
+          ownerId: car.ownerId,
+          error: promotionError instanceof Error ? promotionError.message : String(promotionError),
+        });
+      }
       const publicCar = { ...car };
       delete publicCar.ownerId;
 

--- a/src/modules/car/car.controller.spec.ts
+++ b/src/modules/car/car.controller.spec.ts
@@ -23,6 +23,7 @@ describe("CarController", () => {
     vehicleType: VehicleType.SEDAN,
     serviceTier: ServiceTier.STANDARD,
     images: [{ url: "https://example.com/car.jpg" }],
+    promotion: null,
     ...overrides,
   });
 
@@ -42,6 +43,7 @@ describe("CarController", () => {
     serviceTier: ServiceTier.STANDARD,
     images: [{ url: "https://example.com/car.jpg" }],
     owner: { username: "fleetowner1", name: "Fleet Owner" },
+    promotion: null,
     ...overrides,
   });
 

--- a/src/modules/car/car.controller.spec.ts
+++ b/src/modules/car/car.controller.spec.ts
@@ -224,7 +224,21 @@ describe("CarController", () => {
       const result = await controller.getPublicCarById("car-123");
 
       expect(result).toEqual(mockCar);
-      expect(carSearchService.getPublicCarById).toHaveBeenCalledWith("car-123");
+      expect(carSearchService.getPublicCarById).toHaveBeenCalledWith("car-123", undefined);
+    });
+
+    it("passes query.from to service for promotion reference date", async () => {
+      const from = new Date("2026-03-01T00:00:00.000Z");
+      const mockCar = {
+        ...createMockSearchCar({ id: "car-123" }),
+        hourlyRate: 5000,
+        fuelUpgradeRate: 10000,
+      };
+      vi.mocked(carSearchService.getPublicCarById).mockResolvedValueOnce(mockCar);
+
+      await controller.getPublicCarById("car-123", { from });
+
+      expect(carSearchService.getPublicCarById).toHaveBeenCalledWith("car-123", from);
     });
   });
 });

--- a/src/modules/car/car.controller.ts
+++ b/src/modules/car/car.controller.ts
@@ -3,7 +3,12 @@ import { ZodParam, ZodQuery } from "../../common/decorators/zod-validation.decor
 import { CarCategoriesService } from "./car-categories.service";
 import { CarSearchService } from "./car-search.service";
 import { type CarCategoriesQueryDto, carCategoriesQuerySchema } from "./dto/car-categories.dto";
-import { type CarSearchQueryDto, carSearchQuerySchema } from "./dto/car-search.dto";
+import {
+  type CarSearchQueryDto,
+  carSearchQuerySchema,
+  type PublicCarDetailQueryDto,
+  publicCarDetailQuerySchema,
+} from "./dto/car-search.dto";
 import { carIdParamSchema } from "./dto/update-car.dto";
 
 @Controller("api/cars")
@@ -27,7 +32,10 @@ export class CarController {
 
   @Get(":carId")
   @Header("Cache-Control", "public, max-age=60, stale-while-revalidate=300")
-  async getPublicCarById(@ZodParam("carId", carIdParamSchema) carId: string) {
-    return this.carSearchService.getPublicCarById(carId);
+  async getPublicCarById(
+    @ZodParam("carId", carIdParamSchema) carId: string,
+    @ZodQuery(publicCarDetailQuerySchema) query: PublicCarDetailQueryDto = {},
+  ) {
+    return this.carSearchService.getPublicCarById(carId, query.from);
   }
 }

--- a/src/modules/car/car.module.ts
+++ b/src/modules/car/car.module.ts
@@ -5,13 +5,14 @@ import { StorageModule } from "../storage/storage.module";
 import { CarController } from "./car.controller";
 import { CarService } from "./car.service";
 import { CarCategoriesService } from "./car-categories.service";
+import { CarPromotionEnrichmentService } from "./car-promotion.enrichment";
 import { CarSearchService } from "./car-search.service";
 import { FleetOwnerCarController } from "./fleet-owner-car.controller";
 
 @Module({
   imports: [AuthModule, StorageModule, PromotionModule],
   controllers: [CarController, FleetOwnerCarController],
-  providers: [CarService, CarCategoriesService, CarSearchService],
+  providers: [CarService, CarCategoriesService, CarSearchService, CarPromotionEnrichmentService],
   exports: [CarService, CarCategoriesService, CarSearchService],
 })
 export class CarModule {}

--- a/src/modules/car/car.module.ts
+++ b/src/modules/car/car.module.ts
@@ -1,5 +1,6 @@
 import { Module } from "@nestjs/common";
 import { AuthModule } from "../auth/auth.module";
+import { PromotionModule } from "../promotion/promotion.module";
 import { StorageModule } from "../storage/storage.module";
 import { CarController } from "./car.controller";
 import { CarService } from "./car.service";
@@ -8,7 +9,7 @@ import { CarSearchService } from "./car-search.service";
 import { FleetOwnerCarController } from "./fleet-owner-car.controller";
 
 @Module({
-  imports: [AuthModule, StorageModule],
+  imports: [AuthModule, StorageModule, PromotionModule],
   controllers: [CarController, FleetOwnerCarController],
   providers: [CarService, CarCategoriesService, CarSearchService],
   exports: [CarService, CarCategoriesService, CarSearchService],

--- a/src/modules/car/car.service.spec.ts
+++ b/src/modules/car/car.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, type TestingModule } from "@nestjs/testing";
 import { ServiceTier, Status, VehicleType } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DatabaseService } from "../database/database.service";
+import { PromotionService } from "../promotion/promotion.service";
 import { StorageService } from "../storage/storage.service";
 import {
   CarCreateFailedException,
@@ -70,14 +71,21 @@ describe("CarService", () => {
     uploadBuffer: vi.fn(),
     deleteObjectByKey: vi.fn(),
   };
+  const promotionServiceMock = {
+    getActivePromotionsForCars: vi.fn(),
+    getActivePromotionForCar: vi.fn(),
+  };
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    promotionServiceMock.getActivePromotionsForCars.mockResolvedValue(new Map());
+    promotionServiceMock.getActivePromotionForCar.mockResolvedValue(null);
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CarService,
         { provide: DatabaseService, useValue: databaseServiceMock },
         { provide: StorageService, useValue: storageServiceMock },
+        { provide: PromotionService, useValue: promotionServiceMock },
       ],
     }).compile();
 
@@ -85,11 +93,17 @@ describe("CarService", () => {
   });
 
   it("lists owner cars ordered by latest updates", async () => {
-    databaseServiceMock.car.findMany.mockResolvedValueOnce([{ id: "car-1" }, { id: "car-2" }]);
+    databaseServiceMock.car.findMany.mockResolvedValueOnce([
+      { id: "car-1", ownerId: "owner-1" },
+      { id: "car-2", ownerId: "owner-1" },
+    ]);
 
     const result = await service.listOwnerCars("owner-1");
 
-    expect(result).toEqual([{ id: "car-1" }, { id: "car-2" }]);
+    expect(result).toEqual([
+      { id: "car-1", ownerId: "owner-1", promotion: null },
+      { id: "car-2", ownerId: "owner-1", promotion: null },
+    ]);
     expect(databaseServiceMock.car.findMany).toHaveBeenCalledWith(
       expect.objectContaining({ where: { ownerId: "owner-1" }, orderBy: { updatedAt: "desc" } }),
     );
@@ -100,7 +114,7 @@ describe("CarService", () => {
 
     const result = await service.getOwnerCarById("car-1", "owner-1");
 
-    expect(result).toEqual({ id: "car-1", ownerId: "owner-1" });
+    expect(result).toEqual({ id: "car-1", ownerId: "owner-1", promotion: null });
   });
 
   it("throws CarNotFoundException for unknown owner car", async () => {
@@ -148,6 +162,7 @@ describe("CarService", () => {
     const result = await service.createCar("owner-1", createCarDto("ABC-123XY"), createCarFiles());
 
     expect(result).toEqual({ id: "car-1", ownerId: "owner-1" });
+    expect(promotionServiceMock.getActivePromotionForCar).not.toHaveBeenCalled();
     expect(databaseServiceMock.car.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
@@ -164,12 +179,18 @@ describe("CarService", () => {
     });
     databaseServiceMock.car.update.mockResolvedValueOnce({
       id: "car-1",
+      ownerId: "owner-1",
       status: Status.HOLD,
     });
 
     const result = await service.updateCar("car-1", "owner-1", { status: Status.HOLD });
 
-    expect(result).toEqual({ id: "car-1", status: Status.HOLD });
+    expect(result).toEqual({
+      id: "car-1",
+      ownerId: "owner-1",
+      status: Status.HOLD,
+      promotion: null,
+    });
   });
 
   it("rejects update when registration number conflicts after normalization", async () => {
@@ -211,5 +232,35 @@ describe("CarService", () => {
     databaseServiceMock.car.findMany.mockRejectedValueOnce(new Error("db down"));
 
     await expect(service.listOwnerCars("owner-1")).rejects.toBeInstanceOf(CarFetchFailedException);
+  });
+
+  it("enriches owner car list with active promotion when present", async () => {
+    databaseServiceMock.car.findMany.mockResolvedValueOnce([{ id: "car-1", ownerId: "owner-1" }]);
+    promotionServiceMock.getActivePromotionsForCars.mockResolvedValueOnce(
+      new Map([
+        [
+          "car-1",
+          {
+            id: "promo-1",
+            name: "Weekend Deal",
+            discountValue: 15,
+          },
+        ],
+      ]),
+    );
+
+    const result = await service.listOwnerCars("owner-1");
+
+    expect(result).toEqual([
+      {
+        id: "car-1",
+        ownerId: "owner-1",
+        promotion: {
+          id: "promo-1",
+          name: "Weekend Deal",
+          discountValue: 15,
+        },
+      },
+    ]);
   });
 });

--- a/src/modules/car/car.service.spec.ts
+++ b/src/modules/car/car.service.spec.ts
@@ -12,6 +12,7 @@ import {
   RegistrationNumberAlreadyExistsException,
 } from "./car.error";
 import { CarService } from "./car.service";
+import { CarPromotionEnrichmentService } from "./car-promotion.enrichment";
 
 describe("CarService", () => {
   let service: CarService;
@@ -86,6 +87,7 @@ describe("CarService", () => {
         { provide: DatabaseService, useValue: databaseServiceMock },
         { provide: StorageService, useValue: storageServiceMock },
         { provide: PromotionService, useValue: promotionServiceMock },
+        CarPromotionEnrichmentService,
       ],
     }).compile();
 
@@ -234,6 +236,17 @@ describe("CarService", () => {
     await expect(service.listOwnerCars("owner-1")).rejects.toBeInstanceOf(CarFetchFailedException);
   });
 
+  it("returns owner cars when promotion enrichment fails", async () => {
+    databaseServiceMock.car.findMany.mockResolvedValueOnce([{ id: "car-1", ownerId: "owner-1" }]);
+    promotionServiceMock.getActivePromotionsForCars.mockRejectedValueOnce(
+      new Error("promotion down"),
+    );
+
+    const result = await service.listOwnerCars("owner-1");
+
+    expect(result).toEqual([{ id: "car-1", ownerId: "owner-1", promotion: null }]);
+  });
+
   it("enriches owner car list with active promotion when present", async () => {
     databaseServiceMock.car.findMany.mockResolvedValueOnce([{ id: "car-1", ownerId: "owner-1" }]);
     promotionServiceMock.getActivePromotionsForCars.mockResolvedValueOnce(
@@ -262,5 +275,40 @@ describe("CarService", () => {
         },
       },
     ]);
+  });
+
+  it("returns owner car detail when promotion enrichment fails", async () => {
+    databaseServiceMock.car.findFirst.mockResolvedValueOnce({ id: "car-1", ownerId: "owner-1" });
+    promotionServiceMock.getActivePromotionForCar.mockRejectedValueOnce(
+      new Error("promotion down"),
+    );
+
+    const result = await service.getOwnerCarById("car-1", "owner-1");
+
+    expect(result).toEqual({ id: "car-1", ownerId: "owner-1", promotion: null });
+  });
+
+  it("returns updated car when promotion enrichment fails", async () => {
+    databaseServiceMock.car.findFirst.mockResolvedValueOnce({
+      id: "car-1",
+      registrationNumber: "ABC-123XY",
+    });
+    databaseServiceMock.car.update.mockResolvedValueOnce({
+      id: "car-1",
+      ownerId: "owner-1",
+      status: Status.HOLD,
+    });
+    promotionServiceMock.getActivePromotionForCar.mockRejectedValueOnce(
+      new Error("promotion down"),
+    );
+
+    const result = await service.updateCar("car-1", "owner-1", { status: Status.HOLD });
+
+    expect(result).toEqual({
+      id: "car-1",
+      ownerId: "owner-1",
+      status: Status.HOLD,
+      promotion: null,
+    });
   });
 });

--- a/src/modules/car/car.service.ts
+++ b/src/modules/car/car.service.ts
@@ -15,7 +15,6 @@ import {
 } from "./car.error";
 import type { CarCreateFiles, UploadedCarFile, UploadedFiles } from "./car.interface";
 import { CarPromotionEnrichmentService } from "./car-promotion.enrichment";
-import type { CarPromotionDto } from "./dto/car-promotion.dto";
 import type { CreateCarMultipartBodyDto } from "./dto/create-car.dto";
 import type { UpdateCarBodyDto } from "./dto/update-car.dto";
 
@@ -55,37 +54,6 @@ export class CarService {
     private readonly storageService: StorageService,
     private readonly carPromotionEnrichmentService: CarPromotionEnrichmentService,
   ) {}
-
-  private async enrichCarsWithPromotion<T extends { id: string; ownerId: string }>(
-    cars: T[],
-  ): Promise<Array<T & { promotion: CarPromotionDto | null }>> {
-    const promotionTargets = cars.map((car) => ({ id: car.id, ownerId: car.ownerId }));
-    const promotionsByCarId = await this.carPromotionEnrichmentService.resolvePromotionsForCars({
-      targets: promotionTargets,
-      referenceDate: new Date(),
-      failureMessage: "Failed to enrich owner cars with promotions",
-    });
-
-    return cars.map((car) => ({
-      ...car,
-      promotion: promotionsByCarId.get(car.id) ?? null,
-    }));
-  }
-
-  private async enrichCarWithPromotion<T extends { id: string; ownerId: string }>(
-    car: T,
-  ): Promise<T & { promotion: CarPromotionDto | null }> {
-    const promotion = await this.carPromotionEnrichmentService.resolvePromotionForCar({
-      target: { id: car.id, ownerId: car.ownerId },
-      referenceDate: new Date(),
-      failureMessage: "Failed to enrich owner car with promotion",
-    });
-
-    return {
-      ...car,
-      promotion,
-    };
-  }
 
   private getObjectKey(ownerId: string, carId: string, fileName: string, category: string): string {
     const timestamp = Date.now();
@@ -266,7 +234,11 @@ export class CarService {
         orderBy: { updatedAt: "desc" },
       });
 
-      return await this.enrichCarsWithPromotion(cars);
+      return await this.carPromotionEnrichmentService.enrichCarsWithPromotion({
+        cars,
+        referenceDate: new Date(),
+        failureMessage: "Failed to enrich owner cars with promotions",
+      });
     } catch (error) {
       if (error instanceof CarException) {
         throw error;
@@ -290,7 +262,11 @@ export class CarService {
         throw new CarNotFoundException();
       }
 
-      return await this.enrichCarWithPromotion(car);
+      return await this.carPromotionEnrichmentService.enrichCarWithPromotion({
+        car,
+        referenceDate: new Date(),
+        failureMessage: "Failed to enrich owner car with promotion",
+      });
     } catch (error) {
       if (error instanceof CarException) {
         throw error;
@@ -366,7 +342,11 @@ export class CarService {
         },
         include: this.carDetailsInclude,
       });
-      return await this.enrichCarWithPromotion(car);
+      return await this.carPromotionEnrichmentService.enrichCarWithPromotion({
+        car,
+        referenceDate: new Date(),
+        failureMessage: "Failed to enrich owner car with promotion",
+      });
     } catch (error) {
       if (error instanceof CarException) {
         throw error;

--- a/src/modules/car/car.service.ts
+++ b/src/modules/car/car.service.ts
@@ -1,6 +1,8 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { CarApprovalStatus, DocumentStatus, DocumentType, Prisma, Status } from "@prisma/client";
 import { DatabaseService } from "../database/database.service";
+import type { ActivePromotion } from "../promotion/promotion.interface";
+import { PromotionService } from "../promotion/promotion.service";
 import { StorageService } from "../storage/storage.service";
 import { CAR_S3_CATEGORY_DOCUMENTS, CAR_S3_CATEGORY_IMAGES } from "./car.const";
 import {
@@ -14,6 +16,7 @@ import {
   RegistrationNumberAlreadyExistsException,
 } from "./car.error";
 import type { CarCreateFiles, UploadedCarFile, UploadedFiles } from "./car.interface";
+import type { CarPromotionDto } from "./dto/car-promotion.dto";
 import type { CreateCarMultipartBodyDto } from "./dto/create-car.dto";
 import type { UpdateCarBodyDto } from "./dto/update-car.dto";
 
@@ -51,7 +54,53 @@ export class CarService {
   constructor(
     private readonly databaseService: DatabaseService,
     private readonly storageService: StorageService,
+    private readonly promotionService: PromotionService,
   ) {}
+
+  private toPromotionDto(promotion: ActivePromotion | null): CarPromotionDto | null {
+    if (!promotion) {
+      return null;
+    }
+
+    return {
+      id: promotion.id,
+      name: promotion.name,
+      discountValue: Number(promotion.discountValue.toString()),
+    };
+  }
+
+  private async enrichCarsWithPromotion<T extends { id: string; ownerId: string }>(
+    cars: T[],
+  ): Promise<Array<T & { promotion: CarPromotionDto | null }>> {
+    if (cars.length === 0) {
+      return [];
+    }
+
+    const promotionsByCarId = await this.promotionService.getActivePromotionsForCars(
+      cars.map((car) => ({ id: car.id, ownerId: car.ownerId })),
+      new Date(),
+    );
+
+    return cars.map((car) => ({
+      ...car,
+      promotion: this.toPromotionDto(promotionsByCarId.get(car.id) ?? null),
+    }));
+  }
+
+  private async enrichCarWithPromotion<T extends { id: string; ownerId: string }>(
+    car: T,
+  ): Promise<T & { promotion: CarPromotionDto | null }> {
+    const promotion = await this.promotionService.getActivePromotionForCar(
+      car.id,
+      car.ownerId,
+      new Date(),
+    );
+
+    return {
+      ...car,
+      promotion: this.toPromotionDto(promotion),
+    };
+  }
 
   private getObjectKey(ownerId: string, carId: string, fileName: string, category: string): string {
     const timestamp = Date.now();
@@ -226,11 +275,13 @@ export class CarService {
 
   async listOwnerCars(ownerId: string) {
     try {
-      return await this.databaseService.car.findMany({
+      const cars = await this.databaseService.car.findMany({
         where: { ownerId },
         include: this.carDetailsInclude,
         orderBy: { updatedAt: "desc" },
       });
+
+      return await this.enrichCarsWithPromotion(cars);
     } catch (error) {
       if (error instanceof CarException) {
         throw error;
@@ -254,7 +305,7 @@ export class CarService {
         throw new CarNotFoundException();
       }
 
-      return car;
+      return await this.enrichCarWithPromotion(car);
     } catch (error) {
       if (error instanceof CarException) {
         throw error;
@@ -318,7 +369,7 @@ export class CarService {
         await this.assertRegistrationNumberUnique(ownerId, dto.registrationNumber, carId);
       }
 
-      return await this.databaseService.car.update({
+      const car = await this.databaseService.car.update({
         where: { id: carId },
         data: {
           ...dto,
@@ -330,6 +381,7 @@ export class CarService {
         },
         include: this.carDetailsInclude,
       });
+      return await this.enrichCarWithPromotion(car);
     } catch (error) {
       if (error instanceof CarException) {
         throw error;

--- a/src/modules/car/car.service.ts
+++ b/src/modules/car/car.service.ts
@@ -1,8 +1,6 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { CarApprovalStatus, DocumentStatus, DocumentType, Prisma, Status } from "@prisma/client";
 import { DatabaseService } from "../database/database.service";
-import type { ActivePromotion } from "../promotion/promotion.interface";
-import { PromotionService } from "../promotion/promotion.service";
 import { StorageService } from "../storage/storage.service";
 import { CAR_S3_CATEGORY_DOCUMENTS, CAR_S3_CATEGORY_IMAGES } from "./car.const";
 import {
@@ -16,6 +14,7 @@ import {
   RegistrationNumberAlreadyExistsException,
 } from "./car.error";
 import type { CarCreateFiles, UploadedCarFile, UploadedFiles } from "./car.interface";
+import { CarPromotionEnrichmentService } from "./car-promotion.enrichment";
 import type { CarPromotionDto } from "./dto/car-promotion.dto";
 import type { CreateCarMultipartBodyDto } from "./dto/create-car.dto";
 import type { UpdateCarBodyDto } from "./dto/update-car.dto";
@@ -54,51 +53,37 @@ export class CarService {
   constructor(
     private readonly databaseService: DatabaseService,
     private readonly storageService: StorageService,
-    private readonly promotionService: PromotionService,
+    private readonly carPromotionEnrichmentService: CarPromotionEnrichmentService,
   ) {}
-
-  private toPromotionDto(promotion: ActivePromotion | null): CarPromotionDto | null {
-    if (!promotion) {
-      return null;
-    }
-
-    return {
-      id: promotion.id,
-      name: promotion.name,
-      discountValue: Number(promotion.discountValue.toString()),
-    };
-  }
 
   private async enrichCarsWithPromotion<T extends { id: string; ownerId: string }>(
     cars: T[],
   ): Promise<Array<T & { promotion: CarPromotionDto | null }>> {
-    if (cars.length === 0) {
-      return [];
-    }
-
-    const promotionsByCarId = await this.promotionService.getActivePromotionsForCars(
-      cars.map((car) => ({ id: car.id, ownerId: car.ownerId })),
-      new Date(),
-    );
+    const promotionTargets = cars.map((car) => ({ id: car.id, ownerId: car.ownerId }));
+    const promotionsByCarId = await this.carPromotionEnrichmentService.resolvePromotionsForCars({
+      targets: promotionTargets,
+      referenceDate: new Date(),
+      failureMessage: "Failed to enrich owner cars with promotions",
+    });
 
     return cars.map((car) => ({
       ...car,
-      promotion: this.toPromotionDto(promotionsByCarId.get(car.id) ?? null),
+      promotion: promotionsByCarId.get(car.id) ?? null,
     }));
   }
 
   private async enrichCarWithPromotion<T extends { id: string; ownerId: string }>(
     car: T,
   ): Promise<T & { promotion: CarPromotionDto | null }> {
-    const promotion = await this.promotionService.getActivePromotionForCar(
-      car.id,
-      car.ownerId,
-      new Date(),
-    );
+    const promotion = await this.carPromotionEnrichmentService.resolvePromotionForCar({
+      target: { id: car.id, ownerId: car.ownerId },
+      referenceDate: new Date(),
+      failureMessage: "Failed to enrich owner car with promotion",
+    });
 
     return {
       ...car,
-      promotion: this.toPromotionDto(promotion),
+      promotion,
     };
   }
 

--- a/src/modules/car/dto/car-categories.dto.ts
+++ b/src/modules/car/dto/car-categories.dto.ts
@@ -10,6 +10,7 @@ export const MIN_CATEGORY_SIZE = 3;
  */
 export const carCategoriesQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).default(50),
+  from: z.coerce.date().optional(),
 });
 
 export type CarCategoriesQueryDto = z.infer<typeof carCategoriesQuerySchema>;

--- a/src/modules/car/dto/car-categories.dto.ts
+++ b/src/modules/car/dto/car-categories.dto.ts
@@ -1,5 +1,6 @@
 import { ServiceTier, VehicleType } from "@prisma/client";
 import { z } from "zod";
+import type { CarPromotionDto } from "./car-promotion.dto";
 
 /** Minimum number of cars needed to show a category */
 export const MIN_CATEGORY_SIZE = 3;
@@ -28,6 +29,7 @@ export interface PublicCarDto {
   vehicleType: VehicleType;
   serviceTier: ServiceTier;
   images: { url: string }[];
+  promotion: CarPromotionDto | null;
 }
 
 /**

--- a/src/modules/car/dto/car-promotion.dto.ts
+++ b/src/modules/car/dto/car-promotion.dto.ts
@@ -1,0 +1,5 @@
+export interface CarPromotionDto {
+  id: string;
+  name: string | null;
+  discountValue: number;
+}

--- a/src/modules/car/dto/car-promotion.mapper.ts
+++ b/src/modules/car/dto/car-promotion.mapper.ts
@@ -1,0 +1,16 @@
+import type { ActivePromotion } from "../../promotion/promotion.interface";
+import type { CarPromotionDto } from "./car-promotion.dto";
+
+export function mapActivePromotionToCarPromotionDto(
+  promotion: ActivePromotion | null,
+): CarPromotionDto | null {
+  if (!promotion) {
+    return null;
+  }
+
+  return {
+    id: promotion.id,
+    name: promotion.name,
+    discountValue: Number(promotion.discountValue.toString()),
+  };
+}

--- a/src/modules/car/dto/car-search.dto.ts
+++ b/src/modules/car/dto/car-search.dto.ts
@@ -60,6 +60,15 @@ export const carSearchQuerySchema = z.object({
 export type CarSearchQueryDto = z.infer<typeof carSearchQuerySchema>;
 
 /**
+ * Query parameters for public car detail endpoint
+ */
+export const publicCarDetailQuerySchema = z.object({
+  from: z.coerce.date().optional(),
+});
+
+export type PublicCarDetailQueryDto = z.infer<typeof publicCarDetailQuerySchema>;
+
+/**
  * Car owner info for search results
  */
 export interface CarOwnerDto {

--- a/src/modules/car/dto/car-search.dto.ts
+++ b/src/modules/car/dto/car-search.dto.ts
@@ -1,5 +1,6 @@
 import { BookingType, ServiceTier, VehicleType } from "@prisma/client";
 import { z } from "zod";
+import type { CarPromotionDto } from "./car-promotion.dto";
 
 /**
  * Mapping of free-text queries to vehicle types
@@ -85,6 +86,7 @@ export interface SearchCarDto {
   serviceTier: ServiceTier;
   images: { url: string }[];
   owner: CarOwnerDto;
+  promotion: CarPromotionDto | null;
 }
 
 /**


### PR DESCRIPTION
Resolve and attach current promotion on car read endpoints while preserving existing rate fields, so clients can derive promo pricing without extra calls. Keep create-car write-only by avoiding enrichment in the create flow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes public and owner-facing car read responses by adding `promotion` data and introducing a new optional `from` query param that affects promotion resolution; client integrations and caching/serialization may be impacted. Logic is designed to fail open when the promotion service is unavailable, reducing outage risk but requiring careful review of response shape changes (e.g., removal of `ownerId`).
> 
> **Overview**
> **Car read APIs now return active promotion info.** Search (`GET /api/cars/search`), categories (`GET /api/cars/categories`), public car detail (`GET /api/cars/:carId`), and fleet-owner car reads (`listOwnerCars`, `getOwnerCarById`, `updateCar`) are enriched with a `promotion` field (or `null`).
> 
> Adds `CarPromotionEnrichmentService` to centralize promotion lookup/mapping via `PromotionService`, with *fail-open* behavior (logs warnings and returns `promotion: null` if lookups fail). Public endpoints now accept an optional `from` date (including a new `PublicCarDetailQueryDto`) to use as the promotion reference date, and internal `ownerId` is selected for lookup but stripped from the public response shape.
> 
> Updates DTOs/mappers and tests accordingly, and wires `PromotionModule`/`CarPromotionEnrichmentService` into `CarModule`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e4d3bf695398c91290a69680df41723a319c8d8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->