### PR TITLE
feat(booking): add fleet-owner chauffeur assignment flow

### DIFF
--- a/src/modules/booking/booking-update.service.spec.ts
+++ b/src/modules/booking/booking-update.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, type TestingModule } from "@nestjs/testing";
-import { BookingStatus, PaymentStatus } from "@prisma/client";
+import { BookingStatus, ChauffeurApprovalStatus, PaymentStatus } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mockPinoLoggerToken } from "@/testing/nest-pino-logger.mock";
 import { DatabaseService } from "../database/database.service";
@@ -21,6 +21,10 @@ describe("BookingUpdateService", () => {
       findUnique: vi.fn(),
       update: vi.fn(),
     },
+    user: {
+      findFirst: vi.fn(),
+    },
+    $transaction: vi.fn(),
   };
 
   const bookingValidationServiceMock = {
@@ -176,5 +180,199 @@ describe("BookingUpdateService", () => {
 
     expect(databaseServiceMock.booking.update).not.toHaveBeenCalled();
     expect(result).toEqual({ id: "booking-1", paymentStatus: PaymentStatus.PAID });
+  });
+
+  describe("assignChauffeur", () => {
+    it("assigns approved chauffeur belonging to fleet owner", async () => {
+      const tx = {
+        booking: {
+          findFirst: vi.fn().mockResolvedValue({
+            id: "booking-1",
+            chauffeurId: null,
+            status: BookingStatus.CONFIRMED,
+          }),
+          findUnique: vi.fn(),
+          update: vi.fn().mockResolvedValue({
+            id: "booking-1",
+            chauffeurId: "chauffeur-1",
+            status: BookingStatus.CONFIRMED,
+          }),
+        },
+        user: {
+          findFirst: vi.fn().mockResolvedValue({
+            id: "chauffeur-1",
+            chauffeurApprovalStatus: ChauffeurApprovalStatus.APPROVED,
+          }),
+        },
+      };
+      databaseServiceMock.$transaction.mockImplementationOnce(
+        (callback: (trx: typeof tx) => Promise<unknown>) => callback(tx),
+      );
+
+      const result = await service.assignChauffeur("booking-1", "owner-1", "chauffeur-1");
+
+      expect(result).toEqual({
+        id: "booking-1",
+        chauffeurId: "chauffeur-1",
+        status: BookingStatus.CONFIRMED,
+      });
+      expect(tx.booking.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: "booking-1",
+          deletedAt: null,
+          car: { ownerId: "owner-1" },
+        },
+        select: {
+          id: true,
+          chauffeurId: true,
+          status: true,
+        },
+      });
+      expect(tx.user.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: "chauffeur-1",
+          fleetOwnerId: "owner-1",
+        },
+        select: {
+          id: true,
+          chauffeurApprovalStatus: true,
+        },
+      });
+      expect(tx.booking.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "booking-1" },
+          data: { chauffeurId: "chauffeur-1" },
+        }),
+      );
+    });
+
+    it("returns current booking for idempotent chauffeur assignment", async () => {
+      const tx = {
+        booking: {
+          findFirst: vi.fn().mockResolvedValue({
+            id: "booking-1",
+            chauffeurId: "chauffeur-1",
+            status: BookingStatus.CONFIRMED,
+          }),
+          findUnique: vi.fn().mockResolvedValue({
+            id: "booking-1",
+            chauffeurId: "chauffeur-1",
+          }),
+          update: vi.fn(),
+        },
+        user: {
+          findFirst: vi.fn().mockResolvedValue({
+            id: "chauffeur-1",
+            chauffeurApprovalStatus: ChauffeurApprovalStatus.APPROVED,
+          }),
+        },
+      };
+      databaseServiceMock.$transaction.mockImplementationOnce(
+        (callback: (trx: typeof tx) => Promise<unknown>) => callback(tx),
+      );
+
+      const result = await service.assignChauffeur("booking-1", "owner-1", "chauffeur-1");
+
+      expect(result).toEqual({ id: "booking-1", chauffeurId: "chauffeur-1" });
+      expect(tx.booking.update).not.toHaveBeenCalled();
+      expect(tx.booking.findUnique).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "booking-1" },
+        }),
+      );
+    });
+
+    it("throws when booking is not owned by fleet owner", async () => {
+      const tx = {
+        booking: {
+          findFirst: vi.fn().mockResolvedValue(null),
+          findUnique: vi.fn(),
+          update: vi.fn(),
+        },
+        user: { findFirst: vi.fn() },
+      };
+      databaseServiceMock.$transaction.mockImplementationOnce(
+        (callback: (trx: typeof tx) => Promise<unknown>) => callback(tx),
+      );
+
+      await expect(
+        service.assignChauffeur("booking-1", "owner-1", "chauffeur-1"),
+      ).rejects.toBeInstanceOf(BookingNotFoundException);
+    });
+
+    it("throws when booking is not in confirmed status", async () => {
+      const tx = {
+        booking: {
+          findFirst: vi.fn().mockResolvedValue({
+            id: "booking-1",
+            chauffeurId: null,
+            status: BookingStatus.ACTIVE,
+          }),
+          findUnique: vi.fn(),
+          update: vi.fn(),
+        },
+        user: { findFirst: vi.fn() },
+      };
+      databaseServiceMock.$transaction.mockImplementationOnce(
+        (callback: (trx: typeof tx) => Promise<unknown>) => callback(tx),
+      );
+
+      await expect(
+        service.assignChauffeur("booking-1", "owner-1", "chauffeur-1"),
+      ).rejects.toBeInstanceOf(BookingUpdateNotAllowedException);
+      expect(tx.user.findFirst).not.toHaveBeenCalled();
+      expect(tx.booking.update).not.toHaveBeenCalled();
+    });
+
+    it("throws when chauffeur is not found for fleet owner", async () => {
+      const tx = {
+        booking: {
+          findFirst: vi.fn().mockResolvedValue({
+            id: "booking-1",
+            chauffeurId: null,
+            status: BookingStatus.CONFIRMED,
+          }),
+          findUnique: vi.fn(),
+          update: vi.fn(),
+        },
+        user: { findFirst: vi.fn().mockResolvedValue(null) },
+      };
+      databaseServiceMock.$transaction.mockImplementationOnce(
+        (callback: (trx: typeof tx) => Promise<unknown>) => callback(tx),
+      );
+
+      await expect(
+        service.assignChauffeur("booking-1", "owner-1", "chauffeur-2"),
+      ).rejects.toBeInstanceOf(BookingNotFoundException);
+      expect(tx.booking.update).not.toHaveBeenCalled();
+    });
+
+    it("throws when chauffeur is not approved", async () => {
+      const tx = {
+        booking: {
+          findFirst: vi.fn().mockResolvedValue({
+            id: "booking-1",
+            chauffeurId: null,
+            status: BookingStatus.CONFIRMED,
+          }),
+          findUnique: vi.fn(),
+          update: vi.fn(),
+        },
+        user: {
+          findFirst: vi.fn().mockResolvedValue({
+            id: "chauffeur-2",
+            chauffeurApprovalStatus: ChauffeurApprovalStatus.PENDING,
+          }),
+        },
+      };
+      databaseServiceMock.$transaction.mockImplementationOnce(
+        (callback: (trx: typeof tx) => Promise<unknown>) => callback(tx),
+      );
+
+      await expect(
+        service.assignChauffeur("booking-1", "owner-1", "chauffeur-2"),
+      ).rejects.toBeInstanceOf(BookingUpdateNotAllowedException);
+      expect(tx.booking.update).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/modules/booking/booking-update.service.spec.ts
+++ b/src/modules/booking/booking-update.service.spec.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mockPinoLoggerToken } from "@/testing/nest-pino-logger.mock";
 import { DatabaseService } from "../database/database.service";
 import {
+  BookingChauffeurNotFoundException,
   BookingNotFoundException,
   BookingUpdateFailedException,
   BookingUpdateNotAllowedException,
@@ -343,7 +344,7 @@ describe("BookingUpdateService", () => {
 
       await expect(
         service.assignChauffeur("booking-1", "owner-1", "chauffeur-2"),
-      ).rejects.toBeInstanceOf(BookingNotFoundException);
+      ).rejects.toBeInstanceOf(BookingChauffeurNotFoundException);
       expect(tx.booking.update).not.toHaveBeenCalled();
     });
 

--- a/src/modules/booking/booking-update.service.spec.ts
+++ b/src/modules/booking/booking-update.service.spec.ts
@@ -192,8 +192,8 @@ describe("BookingUpdateService", () => {
             chauffeurId: null,
             status: BookingStatus.CONFIRMED,
           }),
-          findUnique: vi.fn(),
-          update: vi.fn().mockResolvedValue({
+          updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+          findUniqueOrThrow: vi.fn().mockResolvedValue({
             id: "booking-1",
             chauffeurId: "chauffeur-1",
             status: BookingStatus.CONFIRMED,
@@ -239,15 +239,25 @@ describe("BookingUpdateService", () => {
           chauffeurApprovalStatus: true,
         },
       });
-      expect(tx.booking.update).toHaveBeenCalledWith(
+      expect(tx.booking.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            id: "booking-1",
+            deletedAt: null,
+            status: BookingStatus.CONFIRMED,
+            car: { ownerId: "owner-1" },
+          },
+          data: { chauffeurId: "chauffeur-1" },
+        }),
+      );
+      expect(tx.booking.findUniqueOrThrow).toHaveBeenCalledWith(
         expect.objectContaining({
           where: { id: "booking-1" },
-          data: { chauffeurId: "chauffeur-1" },
         }),
       );
     });
 
-    it("returns current booking for idempotent chauffeur assignment", async () => {
+    it("returns booking details for idempotent chauffeur assignment", async () => {
       const tx = {
         booking: {
           findFirst: vi.fn().mockResolvedValue({
@@ -255,11 +265,11 @@ describe("BookingUpdateService", () => {
             chauffeurId: "chauffeur-1",
             status: BookingStatus.CONFIRMED,
           }),
-          findUnique: vi.fn().mockResolvedValue({
+          updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+          findUniqueOrThrow: vi.fn().mockResolvedValue({
             id: "booking-1",
             chauffeurId: "chauffeur-1",
           }),
-          update: vi.fn(),
         },
         user: {
           findFirst: vi.fn().mockResolvedValue({
@@ -275,20 +285,58 @@ describe("BookingUpdateService", () => {
       const result = await service.assignChauffeur("booking-1", "owner-1", "chauffeur-1");
 
       expect(result).toEqual({ id: "booking-1", chauffeurId: "chauffeur-1" });
-      expect(tx.booking.update).not.toHaveBeenCalled();
-      expect(tx.booking.findUnique).toHaveBeenCalledWith(
+      expect(tx.booking.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            id: "booking-1",
+            deletedAt: null,
+            status: BookingStatus.CONFIRMED,
+            car: { ownerId: "owner-1" },
+          },
+          data: { chauffeurId: "chauffeur-1" },
+        }),
+      );
+      expect(tx.booking.findUniqueOrThrow).toHaveBeenCalledWith(
         expect.objectContaining({
           where: { id: "booking-1" },
         }),
       );
     });
 
+    it("throws when guarded write fails due to concurrent booking change", async () => {
+      const tx = {
+        booking: {
+          findFirst: vi.fn().mockResolvedValue({
+            id: "booking-1",
+            chauffeurId: null,
+            status: BookingStatus.CONFIRMED,
+          }),
+          updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+          findUniqueOrThrow: vi.fn(),
+        },
+        user: {
+          findFirst: vi.fn().mockResolvedValue({
+            id: "chauffeur-1",
+            chauffeurApprovalStatus: ChauffeurApprovalStatus.APPROVED,
+          }),
+        },
+      };
+      databaseServiceMock.$transaction.mockImplementationOnce(
+        (callback: (trx: typeof tx) => Promise<unknown>) => callback(tx),
+      );
+
+      await expect(
+        service.assignChauffeur("booking-1", "owner-1", "chauffeur-1"),
+      ).rejects.toBeInstanceOf(BookingUpdateNotAllowedException);
+      expect(tx.booking.findUniqueOrThrow).not.toHaveBeenCalled();
+    });
+
     it("throws when booking is not owned by fleet owner", async () => {
       const tx = {
         booking: {
           findFirst: vi.fn().mockResolvedValue(null),
-          findUnique: vi.fn(),
-          update: vi.fn(),
+          updateMany: vi.fn(),
+          findUniqueOrThrow: vi.fn(),
         },
         user: { findFirst: vi.fn() },
       };
@@ -309,8 +357,8 @@ describe("BookingUpdateService", () => {
             chauffeurId: null,
             status: BookingStatus.ACTIVE,
           }),
-          findUnique: vi.fn(),
-          update: vi.fn(),
+          updateMany: vi.fn(),
+          findUniqueOrThrow: vi.fn(),
         },
         user: { findFirst: vi.fn() },
       };
@@ -322,7 +370,7 @@ describe("BookingUpdateService", () => {
         service.assignChauffeur("booking-1", "owner-1", "chauffeur-1"),
       ).rejects.toBeInstanceOf(BookingUpdateNotAllowedException);
       expect(tx.user.findFirst).not.toHaveBeenCalled();
-      expect(tx.booking.update).not.toHaveBeenCalled();
+      expect(tx.booking.updateMany).not.toHaveBeenCalled();
     });
 
     it("throws when chauffeur is not found for fleet owner", async () => {
@@ -333,8 +381,8 @@ describe("BookingUpdateService", () => {
             chauffeurId: null,
             status: BookingStatus.CONFIRMED,
           }),
-          findUnique: vi.fn(),
-          update: vi.fn(),
+          updateMany: vi.fn(),
+          findUniqueOrThrow: vi.fn(),
         },
         user: { findFirst: vi.fn().mockResolvedValue(null) },
       };
@@ -345,7 +393,7 @@ describe("BookingUpdateService", () => {
       await expect(
         service.assignChauffeur("booking-1", "owner-1", "chauffeur-2"),
       ).rejects.toBeInstanceOf(BookingChauffeurNotFoundException);
-      expect(tx.booking.update).not.toHaveBeenCalled();
+      expect(tx.booking.updateMany).not.toHaveBeenCalled();
     });
 
     it("throws when chauffeur is not approved", async () => {
@@ -356,8 +404,8 @@ describe("BookingUpdateService", () => {
             chauffeurId: null,
             status: BookingStatus.CONFIRMED,
           }),
-          findUnique: vi.fn(),
-          update: vi.fn(),
+          updateMany: vi.fn(),
+          findUniqueOrThrow: vi.fn(),
         },
         user: {
           findFirst: vi.fn().mockResolvedValue({
@@ -373,7 +421,7 @@ describe("BookingUpdateService", () => {
       await expect(
         service.assignChauffeur("booking-1", "owner-1", "chauffeur-2"),
       ).rejects.toBeInstanceOf(BookingUpdateNotAllowedException);
-      expect(tx.booking.update).not.toHaveBeenCalled();
+      expect(tx.booking.updateMany).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/modules/booking/booking-update.service.ts
+++ b/src/modules/booking/booking-update.service.ts
@@ -9,6 +9,7 @@ import { PinoLogger } from "nestjs-pino";
 import { DatabaseService } from "../database/database.service";
 import { DAY_BOOKING_DURATION_HOURS, FULL_DAY_DURATION_HOURS } from "./booking.const";
 import {
+  BookingChauffeurNotFoundException,
   BookingException,
   BookingNotFoundException,
   BookingUpdateFailedException,
@@ -115,7 +116,7 @@ export class BookingUpdateService {
         });
 
         if (!chauffeur) {
-          throw new BookingNotFoundException();
+          throw new BookingChauffeurNotFoundException();
         }
 
         if (chauffeur.chauffeurApprovalStatus !== ChauffeurApprovalStatus.APPROVED) {

--- a/src/modules/booking/booking-update.service.ts
+++ b/src/modules/booking/booking-update.service.ts
@@ -1,5 +1,10 @@
 import { Injectable } from "@nestjs/common";
-import { BookingStatus, type BookingType, PaymentStatus } from "@prisma/client";
+import {
+  BookingStatus,
+  type BookingType,
+  ChauffeurApprovalStatus,
+  PaymentStatus,
+} from "@prisma/client";
 import { PinoLogger } from "nestjs-pino";
 import { DatabaseService } from "../database/database.service";
 import { DAY_BOOKING_DURATION_HOURS, FULL_DAY_DURATION_HOURS } from "./booking.const";
@@ -67,6 +72,85 @@ export class BookingUpdateService {
           stack: error instanceof Error ? error.stack : undefined,
         },
         "Failed to update booking",
+      );
+      throw new BookingUpdateFailedException();
+    }
+  }
+
+  async assignChauffeur(bookingId: string, ownerId: string, chauffeurId: string) {
+    try {
+      return await this.databaseService.$transaction(async (tx) => {
+        const booking = await tx.booking.findFirst({
+          where: {
+            id: bookingId,
+            deletedAt: null,
+            car: { ownerId },
+          },
+          select: {
+            id: true,
+            chauffeurId: true,
+            status: true,
+          },
+        });
+
+        if (!booking) {
+          throw new BookingNotFoundException();
+        }
+
+        if (booking.status !== BookingStatus.CONFIRMED) {
+          throw new BookingUpdateNotAllowedException(
+            "Only confirmed bookings can be assigned a chauffeur",
+          );
+        }
+
+        const chauffeur = await tx.user.findFirst({
+          where: {
+            id: chauffeurId,
+            fleetOwnerId: ownerId,
+          },
+          select: {
+            id: true,
+            chauffeurApprovalStatus: true,
+          },
+        });
+
+        if (!chauffeur) {
+          throw new BookingNotFoundException();
+        }
+
+        if (chauffeur.chauffeurApprovalStatus !== ChauffeurApprovalStatus.APPROVED) {
+          throw new BookingUpdateNotAllowedException(
+            "Only approved chauffeurs can be assigned to a booking",
+          );
+        }
+
+        if (booking.chauffeurId === chauffeur.id) {
+          return tx.booking.findUnique({
+            where: { id: booking.id },
+            include: this.bookingDetailsInclude,
+          });
+        }
+
+        return tx.booking.update({
+          where: { id: booking.id },
+          data: { chauffeurId: chauffeur.id },
+          include: this.bookingDetailsInclude,
+        });
+      });
+    } catch (error) {
+      if (error instanceof BookingException) {
+        throw error;
+      }
+
+      this.logger.error(
+        {
+          bookingId,
+          ownerId,
+          chauffeurId,
+          error: error instanceof Error ? error.message : String(error),
+          stack: error instanceof Error ? error.stack : undefined,
+        },
+        "Failed to assign chauffeur to booking",
       );
       throw new BookingUpdateFailedException();
     }

--- a/src/modules/booking/booking-update.service.ts
+++ b/src/modules/booking/booking-update.service.ts
@@ -125,16 +125,24 @@ export class BookingUpdateService {
           );
         }
 
-        if (booking.chauffeurId === chauffeur.id) {
-          return tx.booking.findUnique({
-            where: { id: booking.id },
-            include: this.bookingDetailsInclude,
-          });
+        const updated = await tx.booking.updateMany({
+          where: {
+            id: booking.id,
+            deletedAt: null,
+            status: BookingStatus.CONFIRMED,
+            car: { ownerId },
+          },
+          data: { chauffeurId: chauffeur.id },
+        });
+
+        if (updated.count === 0) {
+          throw new BookingUpdateNotAllowedException(
+            "Booking changed during assignment. Please retry",
+          );
         }
 
-        return tx.booking.update({
+        return tx.booking.findUniqueOrThrow({
           where: { id: booking.id },
-          data: { chauffeurId: chauffeur.id },
           include: this.bookingDetailsInclude,
         });
       });

--- a/src/modules/booking/booking.error.ts
+++ b/src/modules/booking/booking.error.ts
@@ -15,6 +15,7 @@ export const BookingErrorCode = {
   PAYMENT_INTENT_FAILED: "PAYMENT_INTENT_FAILED",
   BOOKING_CREATION_FAILED: "BOOKING_CREATION_FAILED",
   BOOKING_NOT_FOUND: "BOOKING_NOT_FOUND",
+  BOOKING_CHAUFFEUR_NOT_FOUND: "BOOKING_CHAUFFEUR_NOT_FOUND",
   BOOKING_FETCH_FAILED: "BOOKING_FETCH_FAILED",
   BOOKING_UPDATE_FAILED: "BOOKING_UPDATE_FAILED",
   BOOKING_UPDATE_NOT_ALLOWED: "BOOKING_UPDATE_NOT_ALLOWED",
@@ -135,6 +136,17 @@ export class BookingNotFoundException extends BookingException {
       "Booking not found or you do not have access to it",
       HttpStatus.NOT_FOUND,
       { title: "Booking Not Found" },
+    );
+  }
+}
+
+export class BookingChauffeurNotFoundException extends BookingException {
+  constructor() {
+    super(
+      BookingErrorCode.BOOKING_CHAUFFEUR_NOT_FOUND,
+      "Chauffeur not found for this fleet owner",
+      HttpStatus.NOT_FOUND,
+      { title: "Chauffeur Not Found" },
     );
   }
 }

--- a/src/modules/booking/booking.module.ts
+++ b/src/modules/booking/booking.module.ts
@@ -20,6 +20,7 @@ import { BookingReadService } from "./booking-read.service";
 import { BookingUpdateService } from "./booking-update.service";
 import { BookingValidationService } from "./booking-validation.service";
 import { ExtensionConfirmationService } from "./extension-confirmation.service";
+import { FleetOwnerBookingController } from "./fleet-owner-booking.controller";
 
 @Module({
   imports: [
@@ -31,7 +32,7 @@ import { ExtensionConfirmationService } from "./extension-confirmation.service";
     MapsModule,
     PromotionModule,
   ],
-  controllers: [BookingController],
+  controllers: [BookingController, FleetOwnerBookingController],
   providers: [
     BookingConfirmationService,
     BookingLegService,

--- a/src/modules/booking/dto/assign-chauffeur.dto.ts
+++ b/src/modules/booking/dto/assign-chauffeur.dto.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const assignBookingChauffeurBodySchema = z.object({
+  chauffeurId: z.string().min(1, "Chauffeur ID is required"),
+});
+
+export type AssignBookingChauffeurBodyDto = z.infer<typeof assignBookingChauffeurBodySchema>;

--- a/src/modules/booking/fleet-owner-booking.controller.spec.ts
+++ b/src/modules/booking/fleet-owner-booking.controller.spec.ts
@@ -1,0 +1,74 @@
+import { Reflector } from "@nestjs/core";
+import { Test, type TestingModule } from "@nestjs/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockPinoLoggerToken } from "@/testing/nest-pino-logger.mock";
+import { AuthService } from "../auth/auth.service";
+import { BookingUpdateService } from "./booking-update.service";
+import { FleetOwnerBookingController } from "./fleet-owner-booking.controller";
+
+describe("FleetOwnerBookingController", () => {
+  let controller: FleetOwnerBookingController;
+  let bookingUpdateService: BookingUpdateService;
+
+  const mockFleetOwner = {
+    id: "owner-1",
+    email: "owner@example.com",
+    name: "Fleet Owner",
+    emailVerified: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    roles: ["fleetOwner" as const],
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [FleetOwnerBookingController],
+      providers: [
+        {
+          provide: BookingUpdateService,
+          useValue: {
+            assignChauffeur: vi.fn(),
+          },
+        },
+        {
+          provide: AuthService,
+          useValue: {
+            isInitialized: true,
+            auth: {
+              api: {
+                getSession: vi.fn().mockResolvedValue(null),
+              },
+            },
+            getUserRoles: vi.fn().mockResolvedValue(["fleetOwner"]),
+          },
+        },
+        Reflector,
+      ],
+    })
+      .useMocker(mockPinoLoggerToken)
+      .compile();
+
+    controller = module.get<FleetOwnerBookingController>(FleetOwnerBookingController);
+    bookingUpdateService = module.get<BookingUpdateService>(BookingUpdateService);
+  });
+
+  it("assigns a chauffeur to a booking for fleet owner", async () => {
+    vi.mocked(bookingUpdateService.assignChauffeur).mockResolvedValueOnce({
+      id: "booking-1",
+      chauffeurId: "chauffeur-1",
+    } as never);
+
+    const result = await controller.assignChauffeur(
+      "booking-1",
+      { chauffeurId: "chauffeur-1" },
+      mockFleetOwner,
+    );
+
+    expect(result).toEqual({ id: "booking-1", chauffeurId: "chauffeur-1" });
+    expect(bookingUpdateService.assignChauffeur).toHaveBeenCalledWith(
+      "booking-1",
+      "owner-1",
+      "chauffeur-1",
+    );
+  });
+});

--- a/src/modules/booking/fleet-owner-booking.controller.ts
+++ b/src/modules/booking/fleet-owner-booking.controller.ts
@@ -1,0 +1,30 @@
+import { Controller, Patch, UseGuards } from "@nestjs/common";
+import { ZodBody, ZodParam } from "../../common/decorators/zod-validation.decorator";
+import { FLEET_OWNER } from "../auth/auth.const";
+import { CurrentUser } from "../auth/decorators/current-user.decorator";
+import { Roles } from "../auth/decorators/roles.decorator";
+import { RoleGuard } from "../auth/guards/role.guard";
+import type { AuthSession } from "../auth/guards/session.guard";
+import { SessionGuard } from "../auth/guards/session.guard";
+import { BookingUpdateService } from "./booking-update.service";
+import {
+  type AssignBookingChauffeurBodyDto,
+  assignBookingChauffeurBodySchema,
+} from "./dto/assign-chauffeur.dto";
+import { bookingIdParamSchema } from "./dto/create-extension.dto";
+
+@Controller("api/fleet-owner/bookings")
+@UseGuards(SessionGuard, RoleGuard)
+@Roles(FLEET_OWNER)
+export class FleetOwnerBookingController {
+  constructor(private readonly bookingUpdateService: BookingUpdateService) {}
+
+  @Patch(":bookingId/chauffeur")
+  async assignChauffeur(
+    @ZodParam("bookingId", bookingIdParamSchema) bookingId: string,
+    @ZodBody(assignBookingChauffeurBodySchema) body: AssignBookingChauffeurBodyDto,
+    @CurrentUser() sessionUser: AuthSession["user"],
+  ) {
+    return this.bookingUpdateService.assignChauffeur(bookingId, sessionUser.id, body.chauffeurId);
+  }
+}

--- a/test/fleet-owner-bookings.e2e-spec.ts
+++ b/test/fleet-owner-bookings.e2e-spec.ts
@@ -186,5 +186,7 @@ describe("Fleet Owner Booking E2E Tests", () => {
       .send({ chauffeurId: otherOwnerChauffeur.id });
 
     expect(response.status).toBe(HttpStatus.NOT_FOUND);
+    expect(response.body.errorCode).toBe("BOOKING_CHAUFFEUR_NOT_FOUND");
+    expect(response.body.detail).toBe("Chauffeur not found for this fleet owner");
   });
 });

--- a/test/fleet-owner-bookings.e2e-spec.ts
+++ b/test/fleet-owner-bookings.e2e-spec.ts
@@ -1,0 +1,190 @@
+import { HttpStatus, type INestApplication } from "@nestjs/common";
+import { HttpAdapterHost } from "@nestjs/core";
+import { Test, type TestingModule } from "@nestjs/testing";
+import { BookingStatus, ChauffeurApprovalStatus } from "@prisma/client";
+import request from "supertest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { AppModule } from "../src/app.module";
+import { GlobalExceptionFilter } from "../src/common/filters/global-exception.filter";
+import { AuthEmailService } from "../src/modules/auth/auth-email.service";
+import { DatabaseService } from "../src/modules/database/database.service";
+import { TestDataFactory, uniqueEmail } from "./helpers";
+
+describe("Fleet Owner Booking E2E Tests", () => {
+  let app: INestApplication;
+  let databaseService: DatabaseService;
+  let factory: TestDataFactory;
+
+  let ownerId: string;
+  let ownerCookie: string;
+  let nonOwnerCookie: string;
+  let ownerCarId: string;
+  let customerId: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(AuthEmailService)
+      .useValue({ sendOTPEmail: async () => undefined })
+      .compile();
+
+    app = moduleFixture.createNestApplication({ logger: false });
+    const httpAdapterHost = app.get(HttpAdapterHost);
+    app.useGlobalFilters(new GlobalExceptionFilter(httpAdapterHost));
+    await app.init();
+
+    databaseService = app.get(DatabaseService);
+    factory = new TestDataFactory(databaseService, app);
+
+    const ownerAuth = await factory.authenticateAndGetUser(
+      uniqueEmail("fleet-booking-owner"),
+      "fleetOwner",
+      "web",
+    );
+    ownerId = ownerAuth.user.id;
+    ownerCookie = ownerAuth.cookie;
+
+    const nonOwnerAuth = await factory.authenticateAndGetUser(
+      uniqueEmail("fleet-booking-user"),
+      "user",
+    );
+    nonOwnerCookie = nonOwnerAuth.cookie;
+
+    const ownerCar = await factory.createCar(ownerId, { registrationNumber: "E2E-BOOK-001" });
+    ownerCarId = ownerCar.id;
+    customerId = (await factory.createUser({ email: uniqueEmail("fleet-booking-customer") })).id;
+  });
+
+  beforeEach(async () => {
+    await factory.clearRateLimits();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const response = await request(app.getHttpServer())
+      .patch("/api/fleet-owner/bookings/some-booking/chauffeur")
+      .send({ chauffeurId: "some-chauffeur" });
+
+    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+  });
+
+  it("returns 403 for non-fleet-owner user", async () => {
+    const booking = await factory.createBooking(customerId, ownerCarId, {
+      status: "CONFIRMED",
+      paymentStatus: "PAID",
+    });
+
+    const response = await request(app.getHttpServer())
+      .patch(`/api/fleet-owner/bookings/${booking.id}/chauffeur`)
+      .set("Cookie", nonOwnerCookie)
+      .send({ chauffeurId: "any-chauffeur-id" });
+
+    expect(response.status).toBe(HttpStatus.FORBIDDEN);
+  });
+
+  it("assigns an approved owner chauffeur to a confirmed booking", async () => {
+    const booking = await factory.createBooking(customerId, ownerCarId, {
+      status: "CONFIRMED",
+      paymentStatus: "PAID",
+    });
+    const chauffeur = await factory.createChauffeur({
+      email: uniqueEmail("fleet-booking-approved"),
+    });
+    await databaseService.user.update({
+      where: { id: chauffeur.id },
+      data: {
+        fleetOwnerId: ownerId,
+        chauffeurApprovalStatus: ChauffeurApprovalStatus.APPROVED,
+      },
+    });
+
+    const response = await request(app.getHttpServer())
+      .patch(`/api/fleet-owner/bookings/${booking.id}/chauffeur`)
+      .set("Cookie", ownerCookie)
+      .send({ chauffeurId: chauffeur.id });
+
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(response.body.id).toBe(booking.id);
+    expect(response.body.chauffeur?.id ?? response.body.chauffeurId).toBe(chauffeur.id);
+
+    const updated = await factory.getBookingById(booking.id);
+    expect(updated?.chauffeurId).toBe(chauffeur.id);
+  });
+
+  it("returns 409 when booking is not confirmed", async () => {
+    const booking = await factory.createBooking(customerId, ownerCarId, {
+      status: BookingStatus.ACTIVE,
+      paymentStatus: "PAID",
+    });
+    const chauffeur = await factory.createChauffeur({ email: uniqueEmail("fleet-booking-active") });
+    await databaseService.user.update({
+      where: { id: chauffeur.id },
+      data: {
+        fleetOwnerId: ownerId,
+        chauffeurApprovalStatus: ChauffeurApprovalStatus.APPROVED,
+      },
+    });
+
+    const response = await request(app.getHttpServer())
+      .patch(`/api/fleet-owner/bookings/${booking.id}/chauffeur`)
+      .set("Cookie", ownerCookie)
+      .send({ chauffeurId: chauffeur.id });
+
+    expect(response.status).toBe(HttpStatus.CONFLICT);
+  });
+
+  it("returns 409 when chauffeur is not approved", async () => {
+    const booking = await factory.createBooking(customerId, ownerCarId, {
+      status: "CONFIRMED",
+      paymentStatus: "PAID",
+    });
+    const chauffeur = await factory.createChauffeur({
+      email: uniqueEmail("fleet-booking-pending"),
+    });
+    await databaseService.user.update({
+      where: { id: chauffeur.id },
+      data: {
+        fleetOwnerId: ownerId,
+        chauffeurApprovalStatus: ChauffeurApprovalStatus.PENDING,
+      },
+    });
+
+    const response = await request(app.getHttpServer())
+      .patch(`/api/fleet-owner/bookings/${booking.id}/chauffeur`)
+      .set("Cookie", ownerCookie)
+      .send({ chauffeurId: chauffeur.id });
+
+    expect(response.status).toBe(HttpStatus.CONFLICT);
+  });
+
+  it("returns 404 when chauffeur belongs to another fleet owner", async () => {
+    const booking = await factory.createBooking(customerId, ownerCarId, {
+      status: "CONFIRMED",
+      paymentStatus: "PAID",
+    });
+    const otherOwner = await factory.createFleetOwner({
+      email: uniqueEmail("fleet-booking-other-owner"),
+    });
+    const otherOwnerChauffeur = await factory.createChauffeur({
+      email: uniqueEmail("fleet-booking-other-owner-chauffeur"),
+    });
+    await databaseService.user.update({
+      where: { id: otherOwnerChauffeur.id },
+      data: {
+        fleetOwnerId: otherOwner.id,
+        chauffeurApprovalStatus: ChauffeurApprovalStatus.APPROVED,
+      },
+    });
+
+    const response = await request(app.getHttpServer())
+      .patch(`/api/fleet-owner/bookings/${booking.id}/chauffeur`)
+      .set("Cookie", ownerCookie)
+      .send({ chauffeurId: otherOwnerChauffeur.id });
+
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+  });
+});


### PR DESCRIPTION
- add `PATCH /api/fleet-owner/bookings/:bookingId/chauffeur` endpoint for fleet owners to assign chauffeurs
- enforce assignment rules in `BookingUpdateService`: booking must belong to owner, be `CONFIRMED`, and chauffeur must belong to owner and be `APPROVED`
- add unit and e2e coverage for success, auth/role protection, booking state conflicts, and cross-owner chauffeur rejection

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new role-protected write endpoint and new transactional update logic on bookings/users; risk is mainly around authorization and race-condition handling during assignment.
> 
> **Overview**
> Adds `PATCH /api/fleet-owner/bookings/:bookingId/chauffeur` (guarded by `SessionGuard` + `RoleGuard` and `FLEET_OWNER`) to let fleet owners assign a chauffeur to a booking.
> 
> Implements `BookingUpdateService.assignChauffeur()` with a single DB transaction that enforces: booking belongs to the owner, booking is `CONFIRMED`, chauffeur belongs to the owner and is `APPROVED`, and uses a guarded `updateMany` to detect concurrent state changes; introduces `BOOKING_CHAUFFEUR_NOT_FOUND` via `BookingChauffeurNotFoundException`.
> 
> Adds Zod DTO validation for the request body and expands unit + e2e tests covering success, auth/role rejection, invalid booking state, non-approved/foreign chauffeurs, and concurrent update conflicts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df300ab03f40752ecc37c96988ddc34a76f433ee. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->