### PR TITLE
feat(notification): add outbox-driven chauffeur assignment push delivery

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "date-fns-tz": "^3.2.0",
     "decimal.js": "^10.6.0",
     "dotenv": "^17.3.1",
+    "expo-server-sdk": "^6.1.0",
     "helmet": "^8.1.0",
     "ioredis": "^5.7.0",
     "nestjs-pino": "^4.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       dotenv:
         specifier: ^17.3.1
         version: 17.3.1
+      expo-server-sdk:
+        specifier: ^6.1.0
+        version: 6.1.0
       helmet:
         specifier: ^8.1.0
         version: 8.1.0
@@ -4034,6 +4037,9 @@ packages:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  err-code@2.0.3:
+    resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
+
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
@@ -4131,6 +4137,10 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  expo-server-sdk@6.1.0:
+    resolution: {integrity: sha512-ISuax1AQ7cpM5RAqcu8gVcoLL0ZKskJ5OLoMWmdITBe9nYjTucjdGyBq817YkIvTcj1pAUwx+9toUT7l/V7thA==}
+    engines: {node: '>=20'}
 
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
@@ -5314,6 +5324,13 @@ packages:
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
+
+  promise-limit@2.7.0:
+    resolution: {integrity: sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==}
+
+  promise-retry@2.0.1:
+    resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
+    engines: {node: '>=10'}
 
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -10458,6 +10475,8 @@ snapshots:
 
   env-paths@3.0.0: {}
 
+  err-code@2.0.3: {}
+
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
@@ -10583,6 +10602,12 @@ snapshots:
   events@3.3.0: {}
 
   expect-type@1.3.0: {}
+
+  expo-server-sdk@6.1.0:
+    dependencies:
+      promise-limit: 2.7.0
+      promise-retry: 2.0.1
+      undici: 7.24.6
 
   express@5.2.1:
     dependencies:
@@ -11783,6 +11808,13 @@ snapshots:
   process-warning@5.0.0: {}
 
   process@0.11.10: {}
+
+  promise-limit@2.7.0: {}
+
+  promise-retry@2.0.1:
+    dependencies:
+      err-code: 2.0.3
+      retry: 0.12.0
 
   prompts@2.4.2:
     dependencies:

--- a/prisma/migrations/20260502201100_add_user_push_tokens/migration.sql
+++ b/prisma/migrations/20260502201100_add_user_push_tokens/migration.sql
@@ -1,0 +1,27 @@
+-- CreateEnum
+CREATE TYPE "PushPlatform" AS ENUM ('IOS', 'ANDROID');
+
+-- CreateTable
+CREATE TABLE "UserPushToken" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "platform" "PushPlatform" NOT NULL,
+    "revokedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "UserPushToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserPushToken_token_key" ON "UserPushToken"("token");
+
+-- CreateIndex
+CREATE INDEX "UserPushToken_userId_revokedAt_idx" ON "UserPushToken"("userId", "revokedAt");
+
+-- CreateIndex
+CREATE INDEX "UserPushToken_revokedAt_idx" ON "UserPushToken"("revokedAt");
+
+-- AddForeignKey
+ALTER TABLE "UserPushToken" ADD CONSTRAINT "UserPushToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260502203400_add_notification_outbox_and_inbox/migration.sql
+++ b/prisma/migrations/20260502203400_add_notification_outbox_and_inbox/migration.sql
@@ -1,0 +1,66 @@
+-- CreateEnum
+CREATE TYPE "NotificationInboxType" AS ENUM ('CHAUFFEUR_ASSIGNED');
+
+-- CreateEnum
+CREATE TYPE "NotificationOutboxEventType" AS ENUM ('CHAUFFEUR_ASSIGNED');
+
+-- CreateEnum
+CREATE TYPE "NotificationOutboxStatus" AS ENUM ('PENDING', 'PROCESSING', 'DISPATCHED', 'FAILED', 'DEAD_LETTER');
+
+-- CreateTable
+CREATE TABLE "NotificationInbox" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "type" "NotificationInboxType" NOT NULL,
+    "title" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "payload" JSONB,
+    "readAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "NotificationInbox_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "NotificationOutboxEvent" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT,
+    "eventType" "NotificationOutboxEventType" NOT NULL,
+    "status" "NotificationOutboxStatus" NOT NULL DEFAULT 'PENDING',
+    "dedupeKey" TEXT NOT NULL,
+    "bookingId" TEXT NOT NULL,
+    "payload" JSONB,
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "nextAttemptAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastError" TEXT,
+    "processedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "NotificationOutboxEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "NotificationInbox_userId_readAt_idx" ON "NotificationInbox"("userId", "readAt");
+
+-- CreateIndex
+CREATE INDEX "NotificationInbox_createdAt_idx" ON "NotificationInbox"("createdAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "NotificationOutboxEvent_dedupeKey_key" ON "NotificationOutboxEvent"("dedupeKey");
+
+-- CreateIndex
+CREATE INDEX "NotificationOutboxEvent_status_nextAttemptAt_idx" ON "NotificationOutboxEvent"("status", "nextAttemptAt");
+
+-- CreateIndex
+CREATE INDEX "NotificationOutboxEvent_bookingId_idx" ON "NotificationOutboxEvent"("bookingId");
+
+-- CreateIndex
+CREATE INDEX "NotificationOutboxEvent_userId_idx" ON "NotificationOutboxEvent"("userId");
+
+-- AddForeignKey
+ALTER TABLE "NotificationInbox" ADD CONSTRAINT "NotificationInbox_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "NotificationOutboxEvent" ADD CONSTRAINT "NotificationOutboxEvent_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20260502203400_add_notification_outbox_and_inbox/migration.sql
+++ b/prisma/migrations/20260502203400_add_notification_outbox_and_inbox/migration.sql
@@ -64,3 +64,6 @@ ALTER TABLE "NotificationInbox" ADD CONSTRAINT "NotificationInbox_userId_fkey" F
 
 -- AddForeignKey
 ALTER TABLE "NotificationOutboxEvent" ADD CONSTRAINT "NotificationOutboxEvent_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "NotificationOutboxEvent" ADD CONSTRAINT "NotificationOutboxEvent_bookingId_fkey" FOREIGN KEY ("bookingId") REFERENCES "Booking"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260502203400_add_notification_outbox_and_inbox/migration.sql
+++ b/prisma/migrations/20260502203400_add_notification_outbox_and_inbox/migration.sql
@@ -64,6 +64,3 @@ ALTER TABLE "NotificationInbox" ADD CONSTRAINT "NotificationInbox_userId_fkey" F
 
 -- AddForeignKey
 ALTER TABLE "NotificationOutboxEvent" ADD CONSTRAINT "NotificationOutboxEvent_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "NotificationOutboxEvent" ADD CONSTRAINT "NotificationOutboxEvent_bookingId_fkey" FOREIGN KEY ("bookingId") REFERENCES "Booking"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -144,6 +144,8 @@ model NotificationOutboxEvent {
   eventType    NotificationOutboxEventType
   status       NotificationOutboxStatus @default(PENDING)
   dedupeKey    String                   @unique
+  /// Intentionally not a relation to Booking. Outbox rows must remain durable
+  /// for retry/audit purposes even if a booking is deleted.
   bookingId    String
   payload      Json?
   attempts     Int                      @default(0)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -96,6 +96,9 @@ model User {
   roles                     Role[]                     @relation("RoleToUser")
   whatsAppConversations     WhatsAppConversation[]     @relation("WhatsAppConversationLinkedUser")
   promotions                Promotion[]                @relation("OwnerPromotions")
+  pushTokens                UserPushToken[]
+  notificationInboxItems    NotificationInbox[]
+  notificationOutboxEvents  NotificationOutboxEvent[]
 
   @@index([fleetOwnerId])
   @@index([fleetOwnerStatus, hasOnboarded])
@@ -103,6 +106,57 @@ model User {
   @@index([id, email])
   @@index([referralCode])
   @@index([referredByUserId])
+}
+
+model UserPushToken {
+  id        String       @id @default(cuid())
+  userId    String
+  token     String       @unique
+  platform  PushPlatform
+  revokedAt DateTime?
+  createdAt DateTime     @default(now())
+  updatedAt DateTime     @updatedAt
+  user      User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, revokedAt])
+  @@index([revokedAt])
+}
+
+model NotificationInbox {
+  id        String               @id @default(cuid())
+  userId    String
+  type      NotificationInboxType
+  title     String
+  body      String
+  payload   Json?
+  readAt    DateTime?
+  createdAt DateTime             @default(now())
+  updatedAt DateTime             @updatedAt
+  user      User                 @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, readAt])
+  @@index([createdAt])
+}
+
+model NotificationOutboxEvent {
+  id           String                   @id @default(cuid())
+  userId       String?
+  eventType    NotificationOutboxEventType
+  status       NotificationOutboxStatus @default(PENDING)
+  dedupeKey    String                   @unique
+  bookingId    String
+  payload      Json?
+  attempts     Int                      @default(0)
+  nextAttemptAt DateTime                @default(now())
+  lastError    String?
+  processedAt  DateTime?
+  createdAt    DateTime                 @default(now())
+  updatedAt    DateTime                 @updatedAt
+  user         User?                    @relation(fields: [userId], references: [id], onDelete: SetNull)
+
+  @@index([status, nextAttemptAt])
+  @@index([bookingId])
+  @@index([userId])
 }
 
 model Role {
@@ -942,6 +996,27 @@ enum WhatsAppOutboxStatus {
   PENDING
   PROCESSING
   SENT
+  FAILED
+  DEAD_LETTER
+}
+
+enum PushPlatform {
+  IOS
+  ANDROID
+}
+
+enum NotificationInboxType {
+  CHAUFFEUR_ASSIGNED
+}
+
+enum NotificationOutboxEventType {
+  CHAUFFEUR_ASSIGNED
+}
+
+enum NotificationOutboxStatus {
+  PENDING
+  PROCESSING
+  DISPATCHED
   FAILED
   DEAD_LETTER
 }

--- a/src/config/env.config.ts
+++ b/src/config/env.config.ts
@@ -92,6 +92,7 @@ export const envSchema = z
     // Google Maps configuration (for drive time calculations)
     GOOGLE_DISTANCE_MATRIX_API_KEY: z.string().min(1, "GOOGLE_DISTANCE_MATRIX_API_KEY is required"),
     OPENAI_API_KEY: z.string().min(1, "OPENAI_API_KEY is required"),
+    EXPO_ACCESS_TOKEN: z.string().min(1, "EXPO_ACCESS_TOKEN must not be empty").optional(),
 
     // Auth configuration (optional - only required when AuthModule is used)
     SESSION_SECRET: z.string().min(32, "SESSION_SECRET must be at least 32 characters"),

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,8 @@ import { Logger as PinoLogger } from "nestjs-pino";
 import { AppModule } from "./app.module";
 import { GlobalExceptionFilter } from "./common/filters/global-exception.filter";
 import type { EnvConfig } from "./config/env.config";
-import { getDevLanOriginPatterns, isOriginAllowed } from "./modules/auth/origin-pattern";
+import { AuthService } from "./modules/auth/auth.service";
+import { isOriginAllowed } from "./modules/auth/origin-pattern";
 
 async function bootstrap() {
   const logger = new Logger("Bootstrap");
@@ -47,17 +48,12 @@ async function bootstrap() {
 
     const configService = app.get(ConfigService<EnvConfig>);
 
-    // Configure CORS for auth endpoints (if TRUSTED_ORIGINS is set).
-    // In development we extend the env-configured origins with RFC1918 LAN
-    // wildcards so that the mobile app and a web client running on the host
-    // machine's LAN IP (e.g. http://192.168.x.x:3000) aren't blocked when the
-    // IP changes between sessions. Production keeps strict, exact-origin
-    // matching.
-    const trustedOrigins = configService.get("TRUSTED_ORIGINS", { infer: true });
-    if (trustedOrigins) {
-      const nodeEnv = configService.get("NODE_ENV", { infer: true });
-      const allowedOriginPatterns = [...trustedOrigins, ...getDevLanOriginPatterns(nodeEnv)];
+    // Configure CORS for auth endpoints using AuthService's effective allow-list
+    // so CORS and Better Auth always evaluate the same origin patterns.
+    const authService = app.get(AuthService);
+    const allowedOriginPatterns = authService.getTrustedOriginPatterns();
 
+    if (allowedOriginPatterns.length > 0) {
       app.enableCors({
         origin: (origin, callback) => {
           // Non-browser callers (mobile, server-to-server, curl) don't always

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import { Logger as PinoLogger } from "nestjs-pino";
 import { AppModule } from "./app.module";
 import { GlobalExceptionFilter } from "./common/filters/global-exception.filter";
 import type { EnvConfig } from "./config/env.config";
+import { getDevLanOriginPatterns, isOriginAllowed } from "./modules/auth/origin-pattern";
 
 async function bootstrap() {
   const logger = new Logger("Bootstrap");
@@ -46,11 +47,26 @@ async function bootstrap() {
 
     const configService = app.get(ConfigService<EnvConfig>);
 
-    // Configure CORS for auth endpoints (if TRUSTED_ORIGINS is set)
+    // Configure CORS for auth endpoints (if TRUSTED_ORIGINS is set).
+    // In development we extend the env-configured origins with RFC1918 LAN
+    // wildcards so that the mobile app and a web client running on the host
+    // machine's LAN IP (e.g. http://192.168.x.x:3000) aren't blocked when the
+    // IP changes between sessions. Production keeps strict, exact-origin
+    // matching.
     const trustedOrigins = configService.get("TRUSTED_ORIGINS", { infer: true });
     if (trustedOrigins) {
+      const nodeEnv = configService.get("NODE_ENV", { infer: true });
+      const allowedOriginPatterns = [...trustedOrigins, ...getDevLanOriginPatterns(nodeEnv)];
+
       app.enableCors({
-        origin: trustedOrigins,
+        origin: (origin, callback) => {
+          // Non-browser callers (mobile, server-to-server, curl) don't always
+          // send Origin; let those through and rely on auth/CSRF for safety.
+          if (!origin) {
+            return callback(null, true);
+          }
+          callback(null, isOriginAllowed(origin, allowedOriginPatterns));
+        },
         credentials: true,
         allowedHeaders: ["Content-Type", "Authorization", "Cookie"],
         exposedHeaders: ["Set-Cookie"],

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -40,15 +40,12 @@ export class AuthService implements OnModuleInit {
   onModuleInit() {
     const sessionSecret = this.configService.get("SESSION_SECRET", { infer: true });
     const authBaseUrl = this.configService.get("AUTH_BASE_URL", { infer: true });
-    const trustedOriginsFromEnv = this.configService.get("TRUSTED_ORIGINS", { infer: true });
     const nodeEnv = this.configService.get("NODE_ENV", { infer: true });
-
-    const mergedOrigins = this.mergeTrustedOriginsWithAuthBase(trustedOriginsFromEnv, authBaseUrl);
-    const devOrigins = getDevLanOriginPatterns(nodeEnv);
-    const trustedOrigins = [...mergedOrigins, ...devOrigins];
+    const trustedOrigins = this.buildTrustedOrigins(authBaseUrl);
     this.trustedOrigins = trustedOrigins;
 
-    if (devOrigins.length > 0) {
+    if (nodeEnv === "development") {
+      const devOrigins = getDevLanOriginPatterns(nodeEnv);
       this.logger.info(
         { devOrigins },
         "Trusting LAN origins for local development (NODE_ENV=development)",
@@ -80,6 +77,10 @@ export class AuthService implements OnModuleInit {
    * CORS in sync with Better Auth's origin check.
    */
   getTrustedOriginPatterns(): readonly string[] {
+    if (this.trustedOrigins.length === 0) {
+      const authBaseUrl = this.configService.get("AUTH_BASE_URL", { infer: true });
+      this.trustedOrigins = this.buildTrustedOrigins(authBaseUrl);
+    }
     return this.trustedOrigins;
   }
 
@@ -108,6 +109,14 @@ export class AuthService implements OnModuleInit {
     }
 
     return [...trustedOrigins, authOrigin];
+  }
+
+  private buildTrustedOrigins(authBaseUrl: string): string[] {
+    const trustedOriginsFromEnv = this.configService.get("TRUSTED_ORIGINS", { infer: true });
+    const nodeEnv = this.configService.get("NODE_ENV", { infer: true });
+    const mergedOrigins = this.mergeTrustedOriginsWithAuthBase(trustedOriginsFromEnv, authBaseUrl);
+    const devOrigins = getDevLanOriginPatterns(nodeEnv);
+    return [...mergedOrigins, ...devOrigins];
   }
 
   get auth(): Auth {

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -21,6 +21,7 @@ import {
 } from "./auth.error";
 import type { RoleName, ValidateRoleForClientParams } from "./auth.interface";
 import { AuthEmailService } from "./auth-email.service";
+import { getDevLanOriginPatterns, isOriginAllowed } from "./origin-pattern";
 
 @Injectable()
 export class AuthService implements OnModuleInit {
@@ -42,8 +43,17 @@ export class AuthService implements OnModuleInit {
     const trustedOriginsFromEnv = this.configService.get("TRUSTED_ORIGINS", { infer: true });
     const nodeEnv = this.configService.get("NODE_ENV", { infer: true });
 
-    const trustedOrigins = this.mergeTrustedOriginsWithAuthBase(trustedOriginsFromEnv, authBaseUrl);
+    const mergedOrigins = this.mergeTrustedOriginsWithAuthBase(trustedOriginsFromEnv, authBaseUrl);
+    const devOrigins = getDevLanOriginPatterns(nodeEnv);
+    const trustedOrigins = [...mergedOrigins, ...devOrigins];
     this.trustedOrigins = trustedOrigins;
+
+    if (devOrigins.length > 0) {
+      this.logger.info(
+        { devOrigins },
+        "Trusting LAN origins for local development (NODE_ENV=development)",
+      );
+    }
 
     this._auth = createAuth({
       prisma: this.databaseService,
@@ -62,6 +72,15 @@ export class AuthService implements OnModuleInit {
     });
 
     this.logger.info("Auth service initialized successfully");
+  }
+
+  /**
+   * Returns the effective set of trusted origin patterns (env-configured
+   * origins plus any dev-only LAN wildcards). Used by the HTTP layer to keep
+   * CORS in sync with Better Auth's origin check.
+   */
+  getTrustedOriginPatterns(): readonly string[] {
+    return this.trustedOrigins;
   }
 
   /**
@@ -202,28 +221,16 @@ export class AuthService implements OnModuleInit {
 
   /**
    * Validates that the provided origin is in the trusted origins list.
-   * Compares the full origin (protocol://host:port) for security.
+   * Supports exact origins (protocol://host:port) and wildcard patterns
+   * (e.g. `http://192.168.*.*:*` for LAN dev). Wildcard semantics match
+   * Better Auth's `matchesOriginPattern` so this validator stays consistent
+   * with the framework-level origin check.
    *
    * @param origin - The origin header value to validate
    * @returns true if the origin is trusted, false otherwise
    */
   private isTrustedOrigin(origin: string): boolean {
-    try {
-      const originUrl = new URL(origin);
-      const originBase = originUrl.origin; // Gets protocol://host:port
-
-      return this.trustedOrigins.some((trusted) => {
-        try {
-          const trustedUrl = new URL(trusted);
-          return trustedUrl.origin === originBase;
-        } catch {
-          return false;
-        }
-      });
-    } catch {
-      // Invalid origin URL
-      return false;
-    }
+    return isOriginAllowed(origin, this.trustedOrigins);
   }
 
   /**

--- a/src/modules/auth/origin-pattern.spec.ts
+++ b/src/modules/auth/origin-pattern.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { getDevLanOriginPatterns, isOriginAllowed, originMatchesPattern } from "./origin-pattern";
+
+describe("origin-pattern", () => {
+  describe("getDevLanOriginPatterns", () => {
+    it("returns LAN wildcards only for development", () => {
+      const dev = getDevLanOriginPatterns("development");
+      expect(dev).toContain("http://192.168.*.*:*");
+      expect(dev).toContain("http://10.*.*.*:*");
+      expect(dev).toContain("http://172.*.*.*:*");
+      expect(dev).toContain("http://127.0.0.1:*");
+      expect(dev).toContain("http://localhost:*");
+    });
+
+    it("returns an empty list outside development", () => {
+      expect(getDevLanOriginPatterns("production")).toEqual([]);
+      expect(getDevLanOriginPatterns("test")).toEqual([]);
+      expect(getDevLanOriginPatterns(undefined)).toEqual([]);
+    });
+  });
+
+  describe("originMatchesPattern", () => {
+    it("matches exact origins ignoring path/trailing slash", () => {
+      expect(originMatchesPattern("https://example.com", "https://example.com/")).toBe(true);
+      expect(originMatchesPattern("https://example.com:443", "https://example.com")).toBe(true);
+      expect(originMatchesPattern("https://other.com", "https://example.com")).toBe(false);
+    });
+
+    it("rejects malformed origins", () => {
+      expect(originMatchesPattern("not-a-url", "https://example.com")).toBe(false);
+      expect(originMatchesPattern("", "https://example.com")).toBe(false);
+    });
+
+    it("supports wildcard host segments", () => {
+      expect(originMatchesPattern("http://192.168.1.105:3000", "http://192.168.*.*:*")).toBe(true);
+      expect(originMatchesPattern("http://192.168.1.105:5173", "http://192.168.*.*:*")).toBe(true);
+      expect(originMatchesPattern("http://10.0.0.5:3000", "http://10.*.*.*:*")).toBe(true);
+    });
+
+    it("rejects non-matching wildcard candidates", () => {
+      // 8.8.8.8 is a public IP and must not slip through the LAN pattern.
+      expect(originMatchesPattern("http://8.8.8.8:3000", "http://192.168.*.*:*")).toBe(false);
+      // https:// against an http:// pattern should not match.
+      expect(originMatchesPattern("https://192.168.1.5:3000", "http://192.168.*.*:*")).toBe(false);
+    });
+
+    it("does not allow patterns to match unrelated origins via leading characters", () => {
+      // The pattern is anchored — `http://evil.com/192.168.1.5:3000` must not slip past.
+      expect(originMatchesPattern("http://evil.com", "http://192.168.*.*:*")).toBe(false);
+    });
+  });
+
+  describe("isOriginAllowed", () => {
+    const patterns = ["https://app.example.com", "http://192.168.*.*:*"];
+
+    it("returns true when at least one pattern matches", () => {
+      expect(isOriginAllowed("https://app.example.com", patterns)).toBe(true);
+      expect(isOriginAllowed("http://192.168.1.105:3000", patterns)).toBe(true);
+    });
+
+    it("returns false when no pattern matches", () => {
+      expect(isOriginAllowed("https://evil.com", patterns)).toBe(false);
+      expect(isOriginAllowed("http://10.0.0.1:3000", patterns)).toBe(false);
+    });
+
+    it("returns false for an empty pattern list", () => {
+      expect(isOriginAllowed("https://example.com", [])).toBe(false);
+    });
+  });
+});

--- a/src/modules/auth/origin-pattern.ts
+++ b/src/modules/auth/origin-pattern.ts
@@ -1,0 +1,78 @@
+/**
+ * Helpers for matching request origins against an allow-list that may contain
+ * either exact origins (e.g. `https://app.example.com`) or wildcard glob
+ * patterns (e.g. `http://192.168.*.*:*`).
+ *
+ * The wildcard semantics intentionally mirror Better Auth's own
+ * `matchesOriginPattern` (see `better-auth/dist/auth/trusted-origins.mjs`):
+ *
+ *   - `*` matches any sequence of characters (including `.` and `:`).
+ *   - `?` matches exactly one character.
+ *
+ * This lets us share a single allow-list between Better Auth's origin check,
+ * NestJS-side role validation (`AuthService.isTrustedOrigin`), and the CORS
+ * middleware in `main.ts`.
+ */
+
+const RFC1918_DEV_PATTERNS = [
+  // Loopback (any port — devs use 3000, 5173, 19000, etc.)
+  "http://localhost:*",
+  "http://127.0.0.1:*",
+  // RFC1918 private ranges — only valid inside a LAN, so safe in dev.
+  // 172.* is broader than 172.16.0.0/12 but the alternative is 16 patterns
+  // and the looseness is constrained to local network reachability anyway.
+  "http://10.*.*.*:*",
+  "http://172.*.*.*:*",
+  "http://192.168.*.*:*",
+] as const;
+
+/**
+ * Returns the set of additional origin patterns that should be trusted only
+ * during local development. Returns an empty array for any non-development
+ * environment so production/preview builds remain locked down to the
+ * explicitly configured `TRUSTED_ORIGINS`.
+ */
+export function getDevLanOriginPatterns(nodeEnv: string | undefined): string[] {
+  return nodeEnv === "development" ? [...RFC1918_DEV_PATTERNS] : [];
+}
+
+/**
+ * Tests whether a candidate origin string matches a pattern. Patterns without
+ * `*` or `?` are compared as exact origins (protocol://host[:port]); patterns
+ * with wildcards are converted into a strict, anchored regex.
+ */
+export function originMatchesPattern(origin: string, pattern: string): boolean {
+  const candidate = toOrigin(origin);
+  if (!candidate) {
+    return false;
+  }
+
+  if (!pattern.includes("*") && !pattern.includes("?")) {
+    const normalizedPattern = toOrigin(pattern) ?? pattern;
+    return normalizedPattern === candidate;
+  }
+
+  const escaped = pattern.replaceAll(/[.+^${}()|[\]\\]/g, String.raw`\$&`);
+  const regexSource = escaped.replaceAll("*", ".*").replaceAll("?", ".");
+
+  try {
+    return new RegExp(`^${regexSource}$`).test(candidate);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Returns true when `origin` matches any pattern in `patterns`.
+ */
+export function isOriginAllowed(origin: string, patterns: readonly string[]): boolean {
+  return patterns.some((pattern) => originMatchesPattern(origin, pattern));
+}
+
+function toOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}

--- a/src/modules/booking/booking-read.service.ts
+++ b/src/modules/booking/booking-read.service.ts
@@ -50,7 +50,12 @@ export class BookingReadService {
         where: {
           userId,
           paymentStatus: {
-            in: [PaymentStatus.PAID, PaymentStatus.PARTIALLY_REFUNDED, PaymentStatus.REFUNDED],
+            in: [
+              PaymentStatus.PAID,
+              PaymentStatus.REFUND_PROCESSING,
+              PaymentStatus.PARTIALLY_REFUNDED,
+              PaymentStatus.REFUNDED,
+            ],
           },
         },
         include: this.bookingDetailsInclude,

--- a/src/modules/booking/booking-update.service.spec.ts
+++ b/src/modules/booking/booking-update.service.spec.ts
@@ -3,6 +3,7 @@ import { BookingStatus, ChauffeurApprovalStatus, PaymentStatus } from "@prisma/c
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mockPinoLoggerToken } from "@/testing/nest-pino-logger.mock";
 import { DatabaseService } from "../database/database.service";
+import { NotificationOutboxService } from "../notification/notification-outbox.service";
 import {
   BookingChauffeurNotFoundException,
   BookingNotFoundException,
@@ -33,6 +34,10 @@ describe("BookingUpdateService", () => {
     checkCarAvailability: vi.fn(),
   };
 
+  const notificationOutboxServiceMock = {
+    createChauffeurAssignedEvent: vi.fn(),
+  };
+
   beforeEach(async () => {
     vi.clearAllMocks();
 
@@ -41,6 +46,7 @@ describe("BookingUpdateService", () => {
         BookingUpdateService,
         { provide: DatabaseService, useValue: databaseServiceMock },
         { provide: BookingValidationService, useValue: bookingValidationServiceMock },
+        { provide: NotificationOutboxService, useValue: notificationOutboxServiceMock },
       ],
     })
       .useMocker(mockPinoLoggerToken)
@@ -245,6 +251,7 @@ describe("BookingUpdateService", () => {
             id: "booking-1",
             deletedAt: null,
             status: BookingStatus.CONFIRMED,
+            chauffeurId: null,
             car: { ownerId: "owner-1" },
           },
           data: { chauffeurId: "chauffeur-1" },
@@ -254,6 +261,11 @@ describe("BookingUpdateService", () => {
         expect.objectContaining({
           where: { id: "booking-1" },
         }),
+      );
+      expect(notificationOutboxServiceMock.createChauffeurAssignedEvent).toHaveBeenCalledWith(
+        tx,
+        result,
+        "chauffeur-1",
       );
     });
 
@@ -291,6 +303,7 @@ describe("BookingUpdateService", () => {
             id: "booking-1",
             deletedAt: null,
             status: BookingStatus.CONFIRMED,
+            chauffeurId: "chauffeur-1",
             car: { ownerId: "owner-1" },
           },
           data: { chauffeurId: "chauffeur-1" },
@@ -301,6 +314,7 @@ describe("BookingUpdateService", () => {
           where: { id: "booking-1" },
         }),
       );
+      expect(notificationOutboxServiceMock.createChauffeurAssignedEvent).not.toHaveBeenCalled();
     });
 
     it("throws when guarded write fails due to concurrent booking change", async () => {

--- a/src/modules/booking/booking-update.service.ts
+++ b/src/modules/booking/booking-update.service.ts
@@ -7,6 +7,7 @@ import {
 } from "@prisma/client";
 import { PinoLogger } from "nestjs-pino";
 import { DatabaseService } from "../database/database.service";
+import { NotificationOutboxService } from "../notification/notification-outbox.service";
 import { DAY_BOOKING_DURATION_HOURS, FULL_DAY_DURATION_HOURS } from "./booking.const";
 import {
   BookingChauffeurNotFoundException,
@@ -52,6 +53,7 @@ export class BookingUpdateService {
   constructor(
     private readonly bookingValidationService: BookingValidationService,
     private readonly databaseService: DatabaseService,
+    private readonly notificationOutboxService: NotificationOutboxService,
     private readonly logger: PinoLogger,
   ) {
     this.logger.setContext(BookingUpdateService.name);
@@ -80,7 +82,7 @@ export class BookingUpdateService {
 
   async assignChauffeur(bookingId: string, ownerId: string, chauffeurId: string) {
     try {
-      return await this.databaseService.$transaction(async (tx) => {
+      const booking = await this.databaseService.$transaction(async (tx) => {
         const booking = await tx.booking.findFirst({
           where: {
             id: bookingId,
@@ -130,6 +132,7 @@ export class BookingUpdateService {
             id: booking.id,
             deletedAt: null,
             status: BookingStatus.CONFIRMED,
+            chauffeurId: booking.chauffeurId,
             car: { ownerId },
           },
           data: { chauffeurId: chauffeur.id },
@@ -141,11 +144,22 @@ export class BookingUpdateService {
           );
         }
 
-        return tx.booking.findUniqueOrThrow({
+        const updatedBooking = await tx.booking.findUniqueOrThrow({
           where: { id: booking.id },
           include: this.bookingDetailsInclude,
         });
+        if (booking.chauffeurId !== chauffeur.id) {
+          await this.notificationOutboxService.createChauffeurAssignedEvent(
+            tx,
+            updatedBooking,
+            chauffeur.id,
+          );
+        }
+
+        return updatedBooking;
       });
+
+      return booking;
     } catch (error) {
       if (error instanceof BookingException) {
         throw error;

--- a/src/modules/booking/booking-validation.service.spec.ts
+++ b/src/modules/booking/booking-validation.service.spec.ts
@@ -407,6 +407,34 @@ describe("BookingValidationService", () => {
       expect(databaseService.booking.findMany).toHaveBeenCalled();
     });
 
+    it("should block BOOKED status when an overlapping REFUND_PROCESSING active booking exists", async () => {
+      vi.mocked(databaseService.car.findUnique).mockResolvedValueOnce(
+        createCar({
+          id: "car-123",
+          status: Status.BOOKED,
+          approvalStatus: CarApprovalStatus.APPROVED,
+        }),
+      );
+      vi.mocked(databaseService.booking.findMany).mockResolvedValueOnce([
+        createBooking({
+          id: "existing-booking-refund-processing",
+          startDate: new Date("2026-05-05T06:00:00Z"),
+          endDate: new Date("2026-05-05T18:00:00Z"),
+          bookingReference: "BK-REFUND-PROCESSING",
+          status: BookingStatus.ACTIVE,
+          paymentStatus: PaymentStatus.REFUND_PROCESSING,
+        }),
+      ]);
+
+      await expect(
+        service.checkCarAvailability({
+          carId: "car-123",
+          startDate: new Date("2026-05-05T06:00:00Z"),
+          endDate: new Date("2026-05-05T18:00:00Z"),
+        }),
+      ).rejects.toThrow(CarNotAvailableException);
+    });
+
     it("should throw CarNotAvailableException when car status is IN_SERVICE", async () => {
       vi.mocked(databaseService.car.findUnique).mockResolvedValueOnce(
         createCar({

--- a/src/modules/booking/booking-validation.service.spec.ts
+++ b/src/modules/booking/booking-validation.service.spec.ts
@@ -387,7 +387,7 @@ describe("BookingValidationService", () => {
       ).resolves.toBeUndefined();
     });
 
-    it("should throw CarNotAvailableException when car status is BOOKED", async () => {
+    it("should allow BOOKED status when there are no overlapping paid active bookings", async () => {
       vi.mocked(databaseService.car.findUnique).mockResolvedValueOnce(
         createCar({
           id: "car-123",
@@ -395,16 +395,16 @@ describe("BookingValidationService", () => {
           approvalStatus: CarApprovalStatus.APPROVED,
         }),
       );
+      vi.mocked(databaseService.booking.findMany).mockResolvedValueOnce([]);
 
       await expect(
         service.checkCarAvailability({
           carId: "car-123",
-          startDate: new Date(),
-          endDate: new Date(),
+          startDate: new Date("2026-05-05T06:00:00Z"),
+          endDate: new Date("2026-05-05T18:00:00Z"),
         }),
-      ).rejects.toThrow(CarNotAvailableException);
-
-      expect(databaseService.booking.findMany).not.toHaveBeenCalled();
+      ).resolves.toBeUndefined();
+      expect(databaseService.booking.findMany).toHaveBeenCalled();
     });
 
     it("should throw CarNotAvailableException when car status is IN_SERVICE", async () => {

--- a/src/modules/booking/booking-validation.service.spec.ts
+++ b/src/modules/booking/booking-validation.service.spec.ts
@@ -433,6 +433,17 @@ describe("BookingValidationService", () => {
           endDate: new Date("2026-05-05T18:00:00Z"),
         }),
       ).rejects.toThrow(CarNotAvailableException);
+      expect(databaseService.booking.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            carId: "car-123",
+            paymentStatus: { in: expect.arrayContaining([PaymentStatus.REFUND_PROCESSING]) },
+            status: { in: expect.arrayContaining([BookingStatus.ACTIVE]) },
+            startDate: expect.objectContaining({ lt: expect.any(Date) }),
+            endDate: expect.objectContaining({ gt: expect.any(Date) }),
+          }),
+        }),
+      );
     });
 
     it("should throw CarNotAvailableException when car status is IN_SERVICE", async () => {
@@ -560,7 +571,7 @@ describe("BookingValidationService", () => {
       );
     });
 
-    it("should only check bookings with CONFIRMED/ACTIVE status and PAID payment", async () => {
+    it("should only check bookings with CONFIRMED/ACTIVE status and paid-like payment states", async () => {
       vi.mocked(databaseService.car.findUnique).mockResolvedValueOnce(
         createCar({
           id: "car-123",
@@ -579,7 +590,9 @@ describe("BookingValidationService", () => {
       expect(databaseService.booking.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
-            paymentStatus: PaymentStatus.PAID,
+            paymentStatus: {
+              in: expect.arrayContaining([PaymentStatus.PAID, PaymentStatus.REFUND_PROCESSING]),
+            },
             status: { in: [BookingStatus.CONFIRMED, BookingStatus.ACTIVE] },
           }),
         }),

--- a/src/modules/booking/booking-validation.service.ts
+++ b/src/modules/booking/booking-validation.service.ts
@@ -186,7 +186,7 @@ export class BookingValidationService {
    *
    * A car is unavailable if there are overlapping bookings with:
    * - Status: CONFIRMED or ACTIVE
-   * - PaymentStatus: PAID
+   * - PaymentStatus: PAID or REFUND_PROCESSING
    *
    * A 2-hour buffer is applied between bookings for car preparation.
    *
@@ -247,7 +247,7 @@ export class BookingValidationService {
     const conflictingBookings = await this.databaseService.booking.findMany({
       where: {
         carId,
-        paymentStatus: PaymentStatus.PAID,
+        paymentStatus: { in: [PaymentStatus.PAID, PaymentStatus.REFUND_PROCESSING] },
         status: { in: [BookingStatus.CONFIRMED, BookingStatus.ACTIVE] },
         // Exclude current booking if this is an update
         ...(excludeBookingId && { id: { not: excludeBookingId } }),

--- a/src/modules/booking/booking-validation.service.ts
+++ b/src/modules/booking/booking-validation.service.ts
@@ -219,8 +219,9 @@ export class BookingValidationService {
       throw new CarNotAvailableException(carId, "This vehicle is not available for booking");
     }
 
-    // Check car status - only available cars can be booked
-    if (car.status !== Status.AVAILABLE) {
+    // Check hard-unavailable statuses first. BOOKED is handled by overlap checks
+    // below so cars can become bookable immediately after buffer windows.
+    if (car.status === Status.HOLD || car.status === Status.IN_SERVICE) {
       this.logger.info(
         {
           carId,
@@ -228,9 +229,7 @@ export class BookingValidationService {
         },
         "Attempt to book unavailable car",
       );
-
-      const statusMessages: Record<Exclude<Status, "AVAILABLE">, string> = {
-        [Status.BOOKED]: "This vehicle is currently booked",
+      const statusMessages: Record<"HOLD" | "IN_SERVICE", string> = {
         [Status.HOLD]: "This vehicle is temporarily unavailable",
         [Status.IN_SERVICE]: "This vehicle is currently under maintenance",
       };

--- a/src/modules/notification/dto/push-token.dto.ts
+++ b/src/modules/notification/dto/push-token.dto.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+const expoPushTokenPattern = /^(ExponentPushToken|ExpoPushToken)\[[^\]]+\]$/;
+
+export const registerPushTokenBodySchema = z.object({
+  token: z
+    .string()
+    .min(1, "Push token is required")
+    .regex(expoPushTokenPattern, "Invalid Expo push token format"),
+  platform: z.enum(["ios", "android"]),
+});
+
+export type RegisterPushTokenBodyDto = z.infer<typeof registerPushTokenBodySchema>;
+
+export const pushTokenParamSchema = z
+  .string()
+  .min(1, "Push token is required")
+  .regex(expoPushTokenPattern, "Invalid Expo push token format");

--- a/src/modules/notification/dto/push-token.dto.ts
+++ b/src/modules/notification/dto/push-token.dto.ts
@@ -16,3 +16,9 @@ export const pushTokenParamSchema = z
   .string()
   .min(1, "Push token is required")
   .regex(expoPushTokenPattern, "Invalid Expo push token format");
+
+export const revokePushTokenBodySchema = z.object({
+  token: pushTokenParamSchema,
+});
+
+export type RevokePushTokenBodyDto = z.infer<typeof revokePushTokenBodySchema>;

--- a/src/modules/notification/notification-outbox.scheduler.ts
+++ b/src/modules/notification/notification-outbox.scheduler.ts
@@ -1,0 +1,29 @@
+import { Injectable } from "@nestjs/common";
+import { Cron, CronExpression } from "@nestjs/schedule";
+import { PinoLogger } from "nestjs-pino";
+import { NotificationOutboxService } from "./notification-outbox.service";
+
+@Injectable()
+export class NotificationOutboxScheduler {
+  constructor(
+    private readonly notificationOutboxService: NotificationOutboxService,
+    private readonly logger: PinoLogger,
+  ) {
+    this.logger.setContext(NotificationOutboxScheduler.name);
+  }
+
+  @Cron(CronExpression.EVERY_5_SECONDS)
+  async processNotificationOutbox() {
+    try {
+      const processedCount = await this.notificationOutboxService.processPendingEvents();
+      if (processedCount > 0) {
+        this.logger.info({ processedCount }, "Processed pending notification outbox events");
+      }
+    } catch (error) {
+      this.logger.error(
+        { error: error instanceof Error ? error.message : String(error) },
+        "Failed to process notification outbox events",
+      );
+    }
+  }
+}

--- a/src/modules/notification/notification-outbox.service.spec.ts
+++ b/src/modules/notification/notification-outbox.service.spec.ts
@@ -1,0 +1,359 @@
+import { Test, type TestingModule } from "@nestjs/testing";
+import { NotificationOutboxEventType, NotificationOutboxStatus } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockPinoLoggerToken } from "@/testing/nest-pino-logger.mock";
+import {
+  createBooking,
+  createCar,
+  createChauffeur,
+  createOwner,
+  createUser,
+} from "../../shared/helper.fixtures";
+import type { BookingWithRelations } from "../../types";
+import { DatabaseService } from "../database/database.service";
+import { NotificationService } from "./notification.service";
+import {
+  NotificationOutboxService,
+  type NotificationOutboxTransactionClient,
+} from "./notification-outbox.service";
+
+describe("NotificationOutboxService", () => {
+  let service: NotificationOutboxService;
+
+  const databaseServiceMock = {
+    notificationOutboxEvent: {
+      findMany: vi.fn(),
+      updateMany: vi.fn(),
+      update: vi.fn(),
+    },
+  };
+
+  const notificationServiceMock = {
+    buildChauffeurAssignedJobData: vi.fn(),
+    enqueuePreparedNotification: vi.fn(),
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationOutboxService,
+        { provide: DatabaseService, useValue: databaseServiceMock },
+        { provide: NotificationService, useValue: notificationServiceMock },
+      ],
+    })
+      .useMocker(mockPinoLoggerToken)
+      .compile();
+
+    service = module.get<NotificationOutboxService>(NotificationOutboxService);
+  });
+
+  it("creates inbox and outbox records inside transaction", async () => {
+    const tx = {
+      notificationInbox: { create: vi.fn().mockResolvedValue(undefined) },
+      notificationOutboxEvent: { create: vi.fn().mockResolvedValue(undefined) },
+      userPushToken: {
+        findMany: vi.fn().mockResolvedValue([{ token: "ExponentPushToken[a]" }]),
+      },
+    } satisfies NotificationOutboxTransactionClient;
+    const booking = createBooking({
+      id: "booking-1",
+      userId: "user-1",
+      updatedAt: new Date("2026-05-02T20:00:00.000Z"),
+      user: createUser(),
+      chauffeur: createChauffeur(),
+      car: createCar({ owner: createOwner() }),
+      legs: [],
+    });
+    notificationServiceMock.buildChauffeurAssignedJobData.mockResolvedValueOnce({
+      id: "chauffeur-assigned-booking-1-1",
+      type: "chauffeur-assigned",
+      channels: ["email", "push"],
+      bookingId: "booking-1",
+      recipients: {
+        client: {
+          email: "john@example.com",
+          pushTokens: ["ExponentPushToken[a]"],
+        },
+      },
+      templateData: {
+        templateKind: "bookingStatusChange",
+        id: "booking-1",
+        bookingReference: "REF-1",
+        customerName: "John Doe",
+        ownerName: "Owner Name",
+        chauffeurName: "Chauffeur Name",
+        chauffeurPhoneNumber: "1234567890",
+        carName: "Car Name",
+        pickupLocation: "Pickup",
+        returnLocation: "Return",
+        startDate: "2024-01-01",
+        endDate: "2024-01-02",
+        totalAmount: "10000",
+        title: "been assigned a chauffeur",
+        status: "chauffeur assigned",
+        cancellationReason: "",
+        oldStatus: "confirmed",
+        newStatus: "chauffeur_assigned",
+        subject: "Your chauffeur has been assigned",
+      },
+      pushPayload: {
+        title: "Your chauffeur has been assigned",
+        body: "Your chauffeur has been assigned.",
+      },
+    });
+
+    await service.createChauffeurAssignedEvent(tx, booking, "chauffeur-1");
+
+    expect(tx.userPushToken.findMany).toHaveBeenCalledWith({
+      where: { userId: "user-1", revokedAt: null },
+      select: { token: true },
+    });
+
+    expect(tx.notificationInbox.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: "user-1",
+        }),
+      }),
+    );
+    expect(tx.notificationOutboxEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          eventType: NotificationOutboxEventType.CHAUFFEUR_ASSIGNED,
+          bookingId: "booking-1",
+          status: NotificationOutboxStatus.PENDING,
+          payload: expect.objectContaining({
+            schemaVersion: 1,
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("dispatches pending outbox event and marks it dispatched", async () => {
+    databaseServiceMock.notificationOutboxEvent.findMany.mockResolvedValueOnce([
+      {
+        id: "evt-1",
+        bookingId: "booking-1",
+        eventType: NotificationOutboxEventType.CHAUFFEUR_ASSIGNED,
+        status: NotificationOutboxStatus.PENDING,
+        attempts: 0,
+        nextAttemptAt: new Date(Date.now() - 1000),
+        payload: {
+          schemaVersion: 1,
+          notificationJobData: {
+            id: "chauffeur-assigned-booking-1-1",
+            type: "chauffeur-assigned",
+            channels: ["email"],
+            bookingId: "booking-1",
+            recipients: { client: { email: "john@example.com" } },
+            templateData: {
+              templateKind: "bookingStatusChange",
+              id: "booking-1",
+              bookingReference: "REF-1",
+              customerName: "John Doe",
+              ownerName: "Owner Name",
+              chauffeurName: "Chauffeur Name",
+              chauffeurPhoneNumber: "1234567890",
+              carName: "Car Name",
+              pickupLocation: "Pickup",
+              returnLocation: "Return",
+              startDate: "2024-01-01",
+              endDate: "2024-01-02",
+              totalAmount: "10000",
+              title: "been assigned a chauffeur",
+              status: "chauffeur assigned",
+              cancellationReason: "",
+              oldStatus: "confirmed",
+              newStatus: "chauffeur_assigned",
+              subject: "Your chauffeur has been assigned",
+            },
+          },
+        },
+      },
+    ]);
+    databaseServiceMock.notificationOutboxEvent.updateMany.mockResolvedValueOnce({ count: 1 });
+    notificationServiceMock.enqueuePreparedNotification.mockResolvedValueOnce(undefined);
+
+    const processedCount = await service.processPendingEvents();
+
+    expect(processedCount).toBe(1);
+    expect(notificationServiceMock.enqueuePreparedNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bookingId: "booking-1",
+      }),
+      expect.objectContaining({
+        jobId: "notification-outbox-evt-1",
+        removeOnComplete: { age: 24 * 60 * 60 },
+        removeOnFail: { age: 24 * 60 * 60 },
+      }),
+    );
+    expect(databaseServiceMock.notificationOutboxEvent.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "evt-1" },
+        data: expect.objectContaining({
+          status: NotificationOutboxStatus.DISPATCHED,
+        }),
+      }),
+    );
+  });
+
+  it("reclaims stale PROCESSING events without incrementing attempts", async () => {
+    databaseServiceMock.notificationOutboxEvent.findMany.mockResolvedValueOnce([
+      {
+        id: "evt-2",
+        bookingId: "booking-2",
+        eventType: NotificationOutboxEventType.CHAUFFEUR_ASSIGNED,
+        status: NotificationOutboxStatus.PROCESSING,
+        attempts: 1,
+        nextAttemptAt: new Date(Date.now() - 1000),
+        updatedAt: new Date(Date.now() - 5 * 60 * 1000),
+        payload: {
+          schemaVersion: 1,
+          notificationJobData: {
+            id: "chauffeur-assigned-booking-2-1",
+            type: "chauffeur-assigned",
+            channels: ["email"],
+            bookingId: "booking-2",
+            recipients: { client: { email: "john@example.com" } },
+            templateData: {
+              templateKind: "bookingStatusChange",
+              id: "booking-2",
+              bookingReference: "REF-2",
+              customerName: "John Doe",
+              ownerName: "Owner Name",
+              chauffeurName: "Chauffeur Name",
+              chauffeurPhoneNumber: "1234567890",
+              carName: "Car Name",
+              pickupLocation: "Pickup",
+              returnLocation: "Return",
+              startDate: "2024-01-01",
+              endDate: "2024-01-02",
+              totalAmount: "10000",
+              title: "been assigned a chauffeur",
+              status: "chauffeur assigned",
+              cancellationReason: "",
+              oldStatus: "confirmed",
+              newStatus: "chauffeur_assigned",
+              subject: "Your chauffeur has been assigned",
+            },
+          },
+        },
+      },
+    ]);
+    databaseServiceMock.notificationOutboxEvent.updateMany.mockResolvedValueOnce({ count: 1 });
+    notificationServiceMock.enqueuePreparedNotification.mockResolvedValueOnce(undefined);
+
+    const processedCount = await service.processPendingEvents();
+
+    expect(processedCount).toBe(1);
+    expect(databaseServiceMock.notificationOutboxEvent.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: "evt-2",
+          status: NotificationOutboxStatus.PROCESSING,
+        }),
+        data: { status: NotificationOutboxStatus.PROCESSING },
+      }),
+    );
+    expect(notificationServiceMock.enqueuePreparedNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bookingId: "booking-2",
+      }),
+      expect.objectContaining({
+        jobId: "notification-outbox-evt-2",
+      }),
+    );
+  });
+
+  it("marks event failed when enqueue throws", async () => {
+    databaseServiceMock.notificationOutboxEvent.findMany.mockResolvedValueOnce([
+      {
+        id: "evt-3",
+        bookingId: "booking-3",
+        eventType: NotificationOutboxEventType.CHAUFFEUR_ASSIGNED,
+        status: NotificationOutboxStatus.PENDING,
+        attempts: 0,
+        nextAttemptAt: new Date(Date.now() - 1000),
+        payload: {
+          schemaVersion: 1,
+          notificationJobData: {
+            id: "chauffeur-assigned-booking-3-1",
+            type: "chauffeur-assigned",
+            channels: ["email"],
+            bookingId: "booking-3",
+            recipients: { client: { email: "john@example.com" } },
+            templateData: {
+              templateKind: "bookingStatusChange",
+              id: "booking-3",
+              bookingReference: "REF-3",
+              customerName: "John Doe",
+              ownerName: "Owner Name",
+              chauffeurName: "Chauffeur Name",
+              chauffeurPhoneNumber: "1234567890",
+              carName: "Car Name",
+              pickupLocation: "Pickup",
+              returnLocation: "Return",
+              startDate: "2024-01-01",
+              endDate: "2024-01-02",
+              totalAmount: "10000",
+              title: "been assigned a chauffeur",
+              status: "chauffeur assigned",
+              cancellationReason: "",
+              oldStatus: "confirmed",
+              newStatus: "chauffeur_assigned",
+              subject: "Your chauffeur has been assigned",
+            },
+          },
+        },
+      },
+    ]);
+    databaseServiceMock.notificationOutboxEvent.updateMany.mockResolvedValueOnce({ count: 1 });
+    notificationServiceMock.enqueuePreparedNotification.mockRejectedValueOnce(
+      new Error("Queue unavailable"),
+    );
+
+    const processedCount = await service.processPendingEvents();
+
+    expect(processedCount).toBe(0);
+    expect(databaseServiceMock.notificationOutboxEvent.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "evt-3" },
+        data: expect.objectContaining({
+          status: NotificationOutboxStatus.FAILED,
+          lastError: "Queue unavailable",
+        }),
+      }),
+    );
+  });
+
+  it("marks malformed payload as dead letter", async () => {
+    databaseServiceMock.notificationOutboxEvent.findMany.mockResolvedValueOnce([
+      {
+        id: "evt-4",
+        bookingId: "booking-4",
+        eventType: NotificationOutboxEventType.CHAUFFEUR_ASSIGNED,
+        status: NotificationOutboxStatus.PENDING,
+        attempts: 0,
+        nextAttemptAt: new Date(Date.now() - 1000),
+        payload: { schemaVersion: 1 },
+      },
+    ]);
+    databaseServiceMock.notificationOutboxEvent.updateMany.mockResolvedValueOnce({ count: 1 });
+
+    const processedCount = await service.processPendingEvents();
+
+    expect(processedCount).toBe(1);
+    expect(databaseServiceMock.notificationOutboxEvent.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "evt-4" },
+        data: expect.objectContaining({
+          status: NotificationOutboxStatus.DEAD_LETTER,
+          lastError: "Invalid notification outbox payload",
+        }),
+      }),
+    );
+  });
+});

--- a/src/modules/notification/notification-outbox.service.ts
+++ b/src/modules/notification/notification-outbox.service.ts
@@ -1,0 +1,265 @@
+import { Injectable } from "@nestjs/common";
+import {
+  NotificationInboxType,
+  NotificationOutboxEventType,
+  NotificationOutboxStatus,
+  Prisma,
+} from "@prisma/client";
+import { PinoLogger } from "nestjs-pino";
+import type { BookingWithRelations } from "../../types";
+import { DatabaseService } from "../database/database.service";
+import { HIGH_PRIORITY_JOB_OPTIONS } from "./notification.const";
+import { NotificationJobData } from "./notification.interface";
+import { NotificationService } from "./notification.service";
+
+export type NotificationOutboxTransactionClient = {
+  notificationInbox: Pick<Prisma.TransactionClient["notificationInbox"], "create">;
+  notificationOutboxEvent: Pick<Prisma.TransactionClient["notificationOutboxEvent"], "create">;
+  userPushToken: Pick<Prisma.TransactionClient["userPushToken"], "findMany">;
+};
+
+@Injectable()
+export class NotificationOutboxService {
+  private readonly maxAttempts = 8;
+  private readonly processingStaleAfterMs = 2 * 60 * 1000;
+  /**
+   * Retain dispatched outbox-driven jobs in BullMQ for 24h so jobId-based
+   * dedup keeps protecting us if a stale PROCESSING row is reclaimed and
+   * we re-enqueue the same `notification-outbox-${eventId}` jobId.
+   */
+  private readonly dispatchedJobRetentionSeconds = 24 * 60 * 60;
+
+  constructor(
+    private readonly databaseService: DatabaseService,
+    private readonly notificationService: NotificationService,
+    private readonly logger: PinoLogger,
+  ) {
+    this.logger.setContext(NotificationOutboxService.name);
+  }
+
+  async createChauffeurAssignedEvent(
+    tx: NotificationOutboxTransactionClient,
+    booking: BookingWithRelations,
+    chauffeurId: string,
+  ): Promise<void> {
+    const dedupeKey = `chauffeur-assigned:${booking.id}:${chauffeurId}:${booking.updatedAt.toISOString()}`;
+    const inboxPayload = {
+      bookingId: booking.id,
+      chauffeurId,
+    } as const;
+    const pushTokens = booking.userId
+      ? (
+          await tx.userPushToken.findMany({
+            where: {
+              userId: booking.userId,
+              revokedAt: null,
+            },
+            select: {
+              token: true,
+            },
+          })
+        ).map((record) => record.token)
+      : [];
+    const notificationJobData = await this.notificationService.buildChauffeurAssignedJobData(
+      booking,
+      {
+        pushTokens,
+      },
+    );
+
+    if (booking.userId) {
+      await tx.notificationInbox.create({
+        data: {
+          userId: booking.userId,
+          type: NotificationInboxType.CHAUFFEUR_ASSIGNED,
+          title: "Your chauffeur has been assigned",
+          body: `Your chauffeur for ${booking.car.make} ${booking.car.model} (${booking.car.year}) has been assigned.`,
+          payload: this.toPrismaInputJsonValue(inboxPayload),
+        },
+      });
+    }
+
+    if (!notificationJobData) {
+      return;
+    }
+
+    await tx.notificationOutboxEvent.create({
+      data: {
+        userId: booking.userId ?? null,
+        eventType: NotificationOutboxEventType.CHAUFFEUR_ASSIGNED,
+        status: NotificationOutboxStatus.PENDING,
+        dedupeKey,
+        bookingId: booking.id,
+        payload: this.toPrismaInputJsonValue({
+          schemaVersion: 1,
+          notificationJobData,
+        }),
+      },
+    });
+  }
+
+  async processPendingEvents(limit = 25): Promise<number> {
+    const now = new Date();
+    const staleProcessingCutoff = new Date(now.getTime() - this.processingStaleAfterMs);
+    const candidates = await this.databaseService.notificationOutboxEvent.findMany({
+      where: {
+        eventType: NotificationOutboxEventType.CHAUFFEUR_ASSIGNED,
+        OR: [
+          {
+            status: { in: [NotificationOutboxStatus.PENDING, NotificationOutboxStatus.FAILED] },
+            nextAttemptAt: { lte: now },
+          },
+          {
+            status: NotificationOutboxStatus.PROCESSING,
+            updatedAt: { lte: staleProcessingCutoff },
+          },
+        ],
+      },
+      orderBy: { createdAt: "asc" },
+      take: limit,
+    });
+
+    let processedCount = 0;
+    for (const event of candidates) {
+      const isStaleReclaim = event.status === NotificationOutboxStatus.PROCESSING;
+      const claimed = isStaleReclaim
+        ? await this.databaseService.notificationOutboxEvent.updateMany({
+            where: {
+              id: event.id,
+              status: NotificationOutboxStatus.PROCESSING,
+              updatedAt: { lte: staleProcessingCutoff },
+            },
+            data: {
+              status: NotificationOutboxStatus.PROCESSING,
+            },
+          })
+        : await this.databaseService.notificationOutboxEvent.updateMany({
+            where: {
+              id: event.id,
+              status: { in: [NotificationOutboxStatus.PENDING, NotificationOutboxStatus.FAILED] },
+              nextAttemptAt: { lte: now },
+            },
+            data: {
+              status: NotificationOutboxStatus.PROCESSING,
+              attempts: { increment: 1 },
+            },
+          });
+      if (claimed.count === 0) {
+        continue;
+      }
+
+      const currentAttempt = isStaleReclaim ? event.attempts : event.attempts + 1;
+      try {
+        const notificationJobData = this.parseNotificationJobData(event.payload);
+        if (!notificationJobData) {
+          await this.databaseService.notificationOutboxEvent.update({
+            where: { id: event.id },
+            data: {
+              status: NotificationOutboxStatus.DEAD_LETTER,
+              lastError: "Invalid notification outbox payload",
+              processedAt: new Date(),
+            },
+          });
+          processedCount += 1;
+          continue;
+        }
+
+        await this.notificationService.enqueuePreparedNotification(notificationJobData, {
+          ...HIGH_PRIORITY_JOB_OPTIONS,
+          jobId: `notification-outbox-${event.id}`,
+          // Long retention so jobId-dedup keeps protecting us if a stale
+          // PROCESSING outbox row is reclaimed and re-enqueued.
+          removeOnComplete: { age: this.dispatchedJobRetentionSeconds },
+          removeOnFail: { age: this.dispatchedJobRetentionSeconds },
+        });
+
+        await this.databaseService.notificationOutboxEvent.update({
+          where: { id: event.id },
+          data: {
+            status: NotificationOutboxStatus.DISPATCHED,
+            processedAt: new Date(),
+            lastError: null,
+          },
+        });
+        processedCount += 1;
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        const nextAttemptAt = this.computeNextAttemptAt(currentAttempt);
+
+        await this.databaseService.notificationOutboxEvent.update({
+          where: { id: event.id },
+          data: {
+            status: this.resolveFailureStatus(currentAttempt),
+            nextAttemptAt,
+            lastError: errorMessage.slice(0, 500),
+            processedAt:
+              this.resolveFailureStatus(currentAttempt) === NotificationOutboxStatus.DEAD_LETTER
+                ? new Date()
+                : null,
+          },
+        });
+
+        this.logger.error(
+          {
+            outboxEventId: event.id,
+            bookingId: event.bookingId,
+            attempt: currentAttempt,
+            error: errorMessage,
+          },
+          "Failed processing notification outbox event",
+        );
+      }
+    }
+
+    return processedCount;
+  }
+
+  private computeNextAttemptAt(attempt: number): Date {
+    const backoffSeconds = Math.min(10 * 2 ** Math.max(0, attempt - 1), 15 * 60);
+    return new Date(Date.now() + backoffSeconds * 1000);
+  }
+
+  private resolveFailureStatus(attempt: number): NotificationOutboxStatus {
+    return attempt >= this.maxAttempts
+      ? NotificationOutboxStatus.DEAD_LETTER
+      : NotificationOutboxStatus.FAILED;
+  }
+
+  private parseNotificationJobData(payload: Prisma.JsonValue | null): NotificationJobData | null {
+    if (!this.isPlainObject(payload)) {
+      return null;
+    }
+
+    if (payload.schemaVersion !== 1) {
+      return null;
+    }
+    if (!this.isNotificationJobData(payload.notificationJobData)) {
+      return null;
+    }
+
+    return payload.notificationJobData;
+  }
+
+  private isPlainObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+  }
+
+  private isNotificationJobData(value: unknown): value is NotificationJobData {
+    if (!this.isPlainObject(value)) {
+      return false;
+    }
+
+    return (
+      typeof value.id === "string" &&
+      typeof value.type === "string" &&
+      typeof value.bookingId === "string" &&
+      Array.isArray(value.channels) &&
+      this.isPlainObject(value.recipients) &&
+      this.isPlainObject(value.templateData)
+    );
+  }
+
+  private toPrismaInputJsonValue(value: unknown): Prisma.InputJsonValue {
+    return JSON.parse(JSON.stringify(value));
+  }
+}

--- a/src/modules/notification/notification.error.ts
+++ b/src/modules/notification/notification.error.ts
@@ -1,0 +1,19 @@
+import { HttpStatus } from "@nestjs/common";
+import { AppException } from "../../common/errors/app.exception";
+
+export const NotificationErrorCode = {
+  PUSH_TOKEN_OWNERSHIP_CONFLICT: "PUSH_TOKEN_OWNERSHIP_CONFLICT",
+} as const;
+
+export class NotificationException extends AppException {}
+
+export class PushTokenOwnershipConflictException extends NotificationException {
+  constructor() {
+    super(
+      NotificationErrorCode.PUSH_TOKEN_OWNERSHIP_CONFLICT,
+      "Push token is already registered to another user",
+      HttpStatus.CONFLICT,
+      { title: "Push Token Ownership Conflict" },
+    );
+  }
+}

--- a/src/modules/notification/notification.interface.ts
+++ b/src/modules/notification/notification.interface.ts
@@ -67,13 +67,28 @@ export interface NotificationResult {
   perRecipientResults?: NotificationRecipientResult[];
 }
 
-export interface NotificationRecipientResult {
+interface NotificationRecipientResultBase {
   recipient: RecipientType;
-  email: string;
+  channel: NotificationChannel;
   success: boolean;
   messageId?: string;
   error?: string;
 }
+
+export type NotificationRecipientResult =
+  | (NotificationRecipientResultBase & {
+      channel: NotificationChannel.EMAIL;
+      email: string;
+    })
+  | (NotificationRecipientResultBase & {
+      channel: NotificationChannel.PUSH;
+      pushToken: string;
+      pushResponse?: {
+        code: string;
+        retryable: boolean;
+        message?: string;
+      };
+    });
 
 export interface QueueReviewReceivedNotificationParams {
   bookingId: string;

--- a/src/modules/notification/notification.interface.ts
+++ b/src/modules/notification/notification.interface.ts
@@ -3,6 +3,7 @@ import { RecipientType, TemplateData } from "./template-data.interface";
 export enum NotificationChannel {
   EMAIL = "email",
   WHATSAPP = "whatsapp",
+  PUSH = "push",
 }
 
 export enum NotificationType {
@@ -10,6 +11,7 @@ export enum NotificationType {
   BOOKING_REMINDER_START = "booking-reminder-start",
   BOOKING_REMINDER_END = "booking-reminder-end",
   BOOKING_CONFIRMED = "booking-confirmed",
+  CHAUFFEUR_ASSIGNED = "chauffeur-assigned",
   BOOKING_CANCELLED = "booking-cancelled",
   BOOKING_EXTENSION_CONFIRMED = "booking-extension-confirmed",
   FLEET_OWNER_NEW_BOOKING = "fleet-owner-new-booking",
@@ -33,12 +35,18 @@ export interface NotificationJobData {
   type: NotificationType;
   channels: NotificationChannel[];
   bookingId: string;
+  pushPayload?: {
+    title: string;
+    body: string;
+    data?: Record<string, string>;
+  };
   recipients: Partial<
     Record<
       RecipientType,
       {
         email?: string;
         phoneNumber?: string;
+        pushTokens?: string[];
       }
     >
   >;
@@ -49,6 +57,11 @@ export interface NotificationJobData {
 export interface NotificationResult {
   channel: NotificationChannel;
   success: boolean;
+  /**
+   * Whether channel failure should be retried by queue retry policy.
+   * Undefined defaults to retryable for backward compatibility.
+   */
+  retryable?: boolean;
   messageId?: string;
   error?: string;
   perRecipientResults?: NotificationRecipientResult[];

--- a/src/modules/notification/notification.module.ts
+++ b/src/modules/notification/notification.module.ts
@@ -3,9 +3,15 @@ import { BullBoardModule } from "@bull-board/nestjs";
 import { BullModule } from "@nestjs/bullmq";
 import { Module } from "@nestjs/common";
 import { NOTIFICATIONS_QUEUE } from "src/config/constants";
+import { AuthModule } from "../auth/auth.module";
 import { EmailModule } from "../email/email.module";
 import { NotificationProcessor } from "./notification.processor";
 import { NotificationService } from "./notification.service";
+import { NotificationOutboxScheduler } from "./notification-outbox.scheduler";
+import { NotificationOutboxService } from "./notification-outbox.service";
+import { PushService } from "./push.service";
+import { PushTokenController } from "./push-token.controller";
+import { PushTokenService } from "./push-token.service";
 import { WhatsAppService } from "./whatsapp.service";
 
 @Module({
@@ -26,9 +32,25 @@ import { WhatsAppService } from "./whatsapp.service";
       name: NOTIFICATIONS_QUEUE,
       adapter: BullMQAdapter,
     }),
+    AuthModule,
     EmailModule,
   ],
-  providers: [NotificationService, NotificationProcessor, WhatsAppService],
-  exports: [NotificationService, WhatsAppService, BullModule],
+  controllers: [PushTokenController],
+  providers: [
+    NotificationService,
+    NotificationProcessor,
+    NotificationOutboxService,
+    NotificationOutboxScheduler,
+    WhatsAppService,
+    PushService,
+    PushTokenService,
+  ],
+  exports: [
+    NotificationService,
+    NotificationOutboxService,
+    WhatsAppService,
+    PushTokenService,
+    BullModule,
+  ],
 })
 export class NotificationModule {}

--- a/src/modules/notification/notification.processor.spec.ts
+++ b/src/modules/notification/notification.processor.spec.ts
@@ -604,7 +604,7 @@ describe("NotificationProcessor", () => {
     expect(pushTokenService.revokeTokens).toHaveBeenCalledWith(["ExponentPushToken[b]"]);
   });
 
-  it("should keep PUSH channel successful when only retryable push errors exist", async () => {
+  it("should fail PUSH channel with retryable error when only retryable push errors exist", async () => {
     const job = createJob("job-12", {
       id: "notification-12",
       type: NotificationType.CHAUFFEUR_ASSIGNED,
@@ -645,23 +645,9 @@ describe("NotificationProcessor", () => {
       errors: [{ code: "MessageRateExceeded", retryable: true }],
     });
 
-    await expect(processor.process(job)).resolves.toEqual([
-      {
-        channel: NotificationChannel.PUSH,
-        success: true,
-        retryable: true,
-        messageId: undefined,
-        perRecipientResults: [
-          {
-            recipient: CLIENT_RECIPIENT_TYPE,
-            channel: NotificationChannel.PUSH,
-            pushToken: "ExponentPushToken[c]",
-            success: true,
-            messageId: "push-sent",
-          },
-        ],
-      },
-    ]);
+    await expect(processor.process(job)).rejects.toThrow(
+      "Notification channel delivery failed for notification notification-12: push",
+    );
   });
 
   it("should fail PUSH channel without retries for non-retryable errors", async () => {

--- a/src/modules/notification/notification.processor.spec.ts
+++ b/src/modules/notification/notification.processor.spec.ts
@@ -12,6 +12,8 @@ import {
   NotificationType,
 } from "./notification.interface";
 import { NotificationProcessor } from "./notification.processor";
+import { PushService } from "./push.service";
+import { PushTokenService } from "./push-token.service";
 import {
   BOOKING_REMINDER_TEMPLATE_KIND,
   BOOKING_STATUS_TEMPLATE_KIND,
@@ -23,6 +25,8 @@ describe("NotificationProcessor", () => {
   let processor: NotificationProcessor;
   let emailService: EmailService;
   let whatsAppService: WhatsAppService;
+  let pushService: PushService;
+  let pushTokenService: PushTokenService;
 
   const createJob = (
     id: string,
@@ -70,6 +74,18 @@ describe("NotificationProcessor", () => {
             sendMessage: vi.fn(),
           },
         },
+        {
+          provide: PushService,
+          useValue: {
+            sendPushNotifications: vi.fn(),
+          },
+        },
+        {
+          provide: PushTokenService,
+          useValue: {
+            revokeTokens: vi.fn(),
+          },
+        },
       ],
     })
       .useMocker(mockPinoLoggerToken)
@@ -78,6 +94,8 @@ describe("NotificationProcessor", () => {
     processor = module.get<NotificationProcessor>(NotificationProcessor);
     emailService = module.get<EmailService>(EmailService);
     whatsAppService = module.get<WhatsAppService>(WhatsAppService);
+    pushService = module.get<PushService>(PushService);
+    pushTokenService = module.get<PushTokenService>(PushTokenService);
   });
 
   it("should process notification job with EMAIL channel successfully", async () => {
@@ -498,6 +516,218 @@ describe("NotificationProcessor", () => {
         success: true,
         messageId: "whatsapp-sent",
       },
+    ]);
+  });
+
+  it("should process PUSH channel and treat invalid tokens as non-retryable", async () => {
+    const job = createJob("job-11", {
+      id: "notification-11",
+      type: NotificationType.CHAUFFEUR_ASSIGNED,
+      channels: [NotificationChannel.PUSH],
+      bookingId: "booking-111",
+      pushPayload: {
+        title: "Your chauffeur has been assigned",
+        body: "Your chauffeur for a trip has been assigned.",
+        data: { bookingId: "booking-111", type: NotificationType.CHAUFFEUR_ASSIGNED },
+      },
+      recipients: {
+        [CLIENT_RECIPIENT_TYPE]: {
+          pushTokens: ["ExponentPushToken[a]", "ExponentPushToken[b]"],
+        },
+      },
+      templateData: {
+        templateKind: BOOKING_STATUS_TEMPLATE_KIND,
+        id: "booking-111",
+        bookingReference: "BR-111",
+        customerName: "John Doe",
+        ownerName: "Owner Name",
+        chauffeurName: "Chauffeur Name",
+        chauffeurPhoneNumber: "1234567890",
+        carName: "Car Name",
+        pickupLocation: "Pickup Location",
+        returnLocation: "Return Location",
+        startDate: "2024-01-01",
+        endDate: "2024-01-02",
+        totalAmount: "10000",
+        title: "been assigned a chauffeur",
+        status: "chauffeur assigned",
+        cancellationReason: "",
+        subject: "Your chauffeur has been assigned",
+        oldStatus: "confirmed",
+        newStatus: "chauffeur_assigned",
+      },
+    });
+
+    vi.mocked(pushService.sendPushNotifications).mockResolvedValueOnce({
+      sent: 1,
+      failed: 0,
+      invalidTokens: ["ExponentPushToken[b]"],
+    });
+
+    await expect(processor.process(job)).resolves.toEqual([
+      {
+        channel: NotificationChannel.PUSH,
+        success: true,
+        messageId: "push-sent",
+      },
+    ]);
+
+    expect(pushService.sendPushNotifications).toHaveBeenCalledWith({
+      tokens: ["ExponentPushToken[a]", "ExponentPushToken[b]"],
+      title: "Your chauffeur has been assigned",
+      body: "Your chauffeur for a trip has been assigned.",
+      data: { bookingId: "booking-111", type: NotificationType.CHAUFFEUR_ASSIGNED },
+    });
+    expect(pushTokenService.revokeTokens).toHaveBeenCalledWith(["ExponentPushToken[b]"]);
+  });
+
+  it("should fail PUSH channel when retryable push errors exist", async () => {
+    const job = createJob("job-12", {
+      id: "notification-12",
+      type: NotificationType.CHAUFFEUR_ASSIGNED,
+      channels: [NotificationChannel.PUSH],
+      bookingId: "booking-112",
+      recipients: {
+        [CLIENT_RECIPIENT_TYPE]: {
+          pushTokens: ["ExponentPushToken[c]"],
+        },
+      },
+      templateData: {
+        templateKind: BOOKING_STATUS_TEMPLATE_KIND,
+        id: "booking-112",
+        bookingReference: "BR-112",
+        customerName: "John Doe",
+        ownerName: "Owner Name",
+        chauffeurName: "Chauffeur Name",
+        chauffeurPhoneNumber: "1234567890",
+        carName: "Car Name",
+        pickupLocation: "Pickup Location",
+        returnLocation: "Return Location",
+        startDate: "2024-01-01",
+        endDate: "2024-01-02",
+        totalAmount: "10000",
+        title: "been assigned a chauffeur",
+        status: "chauffeur assigned",
+        cancellationReason: "",
+        subject: "Your chauffeur has been assigned",
+        oldStatus: "confirmed",
+        newStatus: "chauffeur_assigned",
+      },
+    });
+
+    vi.mocked(pushService.sendPushNotifications).mockResolvedValueOnce({
+      sent: 0,
+      failed: 1,
+      invalidTokens: [],
+      errors: [{ code: "MessageRateExceeded", retryable: true }],
+    });
+
+    await expect(processor.process(job)).rejects.toThrow(
+      "Notification channel delivery failed for notification notification-12: push",
+    );
+  });
+
+  it("should fail PUSH channel without retries for non-retryable errors", async () => {
+    const job = createJob("job-12b", {
+      id: "notification-12b",
+      type: NotificationType.CHAUFFEUR_ASSIGNED,
+      channels: [NotificationChannel.PUSH],
+      bookingId: "booking-112b",
+      recipients: {
+        [CLIENT_RECIPIENT_TYPE]: {
+          pushTokens: ["ExponentPushToken[d]"],
+        },
+      },
+      templateData: {
+        templateKind: BOOKING_STATUS_TEMPLATE_KIND,
+        id: "booking-112b",
+        bookingReference: "BR-112b",
+        customerName: "John Doe",
+        ownerName: "Owner Name",
+        chauffeurName: "Chauffeur Name",
+        chauffeurPhoneNumber: "1234567890",
+        carName: "Car Name",
+        pickupLocation: "Pickup Location",
+        returnLocation: "Return Location",
+        startDate: "2024-01-01",
+        endDate: "2024-01-02",
+        totalAmount: "10000",
+        title: "been assigned a chauffeur",
+        status: "chauffeur assigned",
+        cancellationReason: "",
+        subject: "Your chauffeur has been assigned",
+        oldStatus: "confirmed",
+        newStatus: "chauffeur_assigned",
+      },
+    });
+
+    vi.mocked(pushService.sendPushNotifications).mockResolvedValueOnce({
+      sent: 0,
+      failed: 1,
+      invalidTokens: [],
+      errors: [{ code: "InvalidCredentials", retryable: false }],
+    });
+
+    await expect(processor.process(job)).rejects.toThrow(
+      "Notification channel delivery failed for notification notification-12b: push",
+    );
+  });
+
+  it("should succeed PUSH channel and revoke when ALL push tokens are invalid", async () => {
+    const job = createJob("job-13", {
+      id: "notification-13",
+      type: NotificationType.CHAUFFEUR_ASSIGNED,
+      channels: [NotificationChannel.PUSH],
+      bookingId: "booking-113",
+      pushPayload: {
+        title: "t",
+        body: "b",
+        data: { bookingId: "booking-113", type: NotificationType.CHAUFFEUR_ASSIGNED },
+      },
+      recipients: {
+        [CLIENT_RECIPIENT_TYPE]: {
+          pushTokens: ["ExponentPushToken[x]", "ExponentPushToken[y]"],
+        },
+      },
+      templateData: {
+        templateKind: BOOKING_STATUS_TEMPLATE_KIND,
+        id: "booking-113",
+        bookingReference: "BR-113",
+        customerName: "John Doe",
+        ownerName: "Owner",
+        chauffeurName: "Chauffeur",
+        chauffeurPhoneNumber: "1234567890",
+        carName: "Car",
+        pickupLocation: "p",
+        returnLocation: "r",
+        startDate: "2024-01-01",
+        endDate: "2024-01-02",
+        totalAmount: "10000",
+        title: "been assigned a chauffeur",
+        status: "chauffeur assigned",
+        cancellationReason: "",
+        subject: "Your chauffeur has been assigned",
+        oldStatus: "confirmed",
+        newStatus: "chauffeur_assigned",
+      },
+    });
+
+    vi.mocked(pushService.sendPushNotifications).mockResolvedValueOnce({
+      sent: 0,
+      failed: 0,
+      invalidTokens: ["ExponentPushToken[x]", "ExponentPushToken[y]"],
+    });
+
+    await expect(processor.process(job)).resolves.toEqual([
+      {
+        channel: NotificationChannel.PUSH,
+        success: true,
+        messageId: undefined,
+      },
+    ]);
+    expect(pushTokenService.revokeTokens).toHaveBeenCalledWith([
+      "ExponentPushToken[x]",
+      "ExponentPushToken[y]",
     ]);
   });
 });

--- a/src/modules/notification/notification.processor.spec.ts
+++ b/src/modules/notification/notification.processor.spec.ts
@@ -604,7 +604,7 @@ describe("NotificationProcessor", () => {
     expect(pushTokenService.revokeTokens).toHaveBeenCalledWith(["ExponentPushToken[b]"]);
   });
 
-  it("should fail PUSH channel when retryable push errors exist", async () => {
+  it("should keep PUSH channel successful when only retryable push errors exist", async () => {
     const job = createJob("job-12", {
       id: "notification-12",
       type: NotificationType.CHAUFFEUR_ASSIGNED,
@@ -645,9 +645,23 @@ describe("NotificationProcessor", () => {
       errors: [{ code: "MessageRateExceeded", retryable: true }],
     });
 
-    await expect(processor.process(job)).rejects.toThrow(
-      "Notification channel delivery failed for notification notification-12: push",
-    );
+    await expect(processor.process(job)).resolves.toEqual([
+      {
+        channel: NotificationChannel.PUSH,
+        success: true,
+        retryable: true,
+        messageId: undefined,
+        perRecipientResults: [
+          {
+            recipient: CLIENT_RECIPIENT_TYPE,
+            channel: NotificationChannel.PUSH,
+            pushToken: "ExponentPushToken[c]",
+            success: true,
+            messageId: "push-sent",
+          },
+        ],
+      },
+    ]);
   });
 
   it("should fail PUSH channel without retries for non-retryable errors", async () => {
@@ -693,6 +707,52 @@ describe("NotificationProcessor", () => {
 
     await expect(processor.process(job)).rejects.toThrow(
       "Notification channel delivery failed for notification notification-12b: push",
+    );
+  });
+
+  it("should fail PUSH channel when blocking non-retryable errors exist even with failed=0", async () => {
+    const job = createJob("job-12c", {
+      id: "notification-12c",
+      type: NotificationType.CHAUFFEUR_ASSIGNED,
+      channels: [NotificationChannel.PUSH],
+      bookingId: "booking-112c",
+      recipients: {
+        [CLIENT_RECIPIENT_TYPE]: {
+          pushTokens: ["ExponentPushToken[e]"],
+        },
+      },
+      templateData: {
+        templateKind: BOOKING_STATUS_TEMPLATE_KIND,
+        id: "booking-112c",
+        bookingReference: "BR-112c",
+        customerName: "John Doe",
+        ownerName: "Owner Name",
+        chauffeurName: "Chauffeur Name",
+        chauffeurPhoneNumber: "1234567890",
+        carName: "Car Name",
+        pickupLocation: "Pickup Location",
+        returnLocation: "Return Location",
+        startDate: "2024-01-01",
+        endDate: "2024-01-02",
+        totalAmount: "10000",
+        title: "been assigned a chauffeur",
+        status: "chauffeur assigned",
+        cancellationReason: "",
+        subject: "Your chauffeur has been assigned",
+        oldStatus: "confirmed",
+        newStatus: "chauffeur_assigned",
+      },
+    });
+
+    vi.mocked(pushService.sendPushNotifications).mockResolvedValueOnce({
+      sent: 0,
+      failed: 0,
+      invalidTokens: [],
+      errors: [{ code: "InvalidCredentials", retryable: false }],
+    });
+
+    await expect(processor.process(job)).rejects.toThrow(
+      "Notification channel delivery failed for notification notification-12c: push",
     );
   });
 

--- a/src/modules/notification/notification.processor.spec.ts
+++ b/src/modules/notification/notification.processor.spec.ts
@@ -153,6 +153,7 @@ describe("NotificationProcessor", () => {
       perRecipientResults: [
         {
           recipient: CLIENT_RECIPIENT_TYPE,
+          channel: NotificationChannel.EMAIL,
           email: "client@example.com",
           success: true,
           messageId: "email-msg-1",
@@ -447,6 +448,7 @@ describe("NotificationProcessor", () => {
       perRecipientResults: [
         {
           recipient: FLEET_OWNER_RECIPIENT_TYPE,
+          channel: NotificationChannel.EMAIL,
           email: "owner@example.com",
           success: true,
           messageId: "email-msg-4",
@@ -569,6 +571,27 @@ describe("NotificationProcessor", () => {
         channel: NotificationChannel.PUSH,
         success: true,
         messageId: "push-sent",
+        perRecipientResults: [
+          {
+            recipient: CLIENT_RECIPIENT_TYPE,
+            channel: NotificationChannel.PUSH,
+            pushToken: "ExponentPushToken[a]",
+            success: true,
+            messageId: "push-sent",
+          },
+          {
+            recipient: CLIENT_RECIPIENT_TYPE,
+            channel: NotificationChannel.PUSH,
+            pushToken: "ExponentPushToken[b]",
+            success: false,
+            error: "Device not registered",
+            pushResponse: {
+              code: "DeviceNotRegistered",
+              retryable: false,
+              message: "Device not registered",
+            },
+          },
+        ],
       },
     ]);
 
@@ -723,6 +746,32 @@ describe("NotificationProcessor", () => {
         channel: NotificationChannel.PUSH,
         success: true,
         messageId: undefined,
+        perRecipientResults: [
+          {
+            recipient: CLIENT_RECIPIENT_TYPE,
+            channel: NotificationChannel.PUSH,
+            pushToken: "ExponentPushToken[x]",
+            success: false,
+            error: "Device not registered",
+            pushResponse: {
+              code: "DeviceNotRegistered",
+              retryable: false,
+              message: "Device not registered",
+            },
+          },
+          {
+            recipient: CLIENT_RECIPIENT_TYPE,
+            channel: NotificationChannel.PUSH,
+            pushToken: "ExponentPushToken[y]",
+            success: false,
+            error: "Device not registered",
+            pushResponse: {
+              code: "DeviceNotRegistered",
+              retryable: false,
+              message: "Device not registered",
+            },
+          },
+        ],
       },
     ]);
     expect(pushTokenService.revokeTokens).toHaveBeenCalledWith([

--- a/src/modules/notification/notification.processor.ts
+++ b/src/modules/notification/notification.processor.ts
@@ -665,24 +665,21 @@ export class NotificationProcessor extends WorkerHost {
       },
     );
 
-    const blockingErrors = deliveryErrors.filter(
-      (error) => !error.retryable && error.code !== "DeviceNotRegistered",
-    );
-    const hasDeliveryErrors = deliveryErrors.length > 0;
-    const retryable = hasDeliveryErrors
-      ? deliveryErrors.some((error) => error.retryable)
+    const actionableErrors = deliveryErrors.filter((error) => error.code !== "DeviceNotRegistered");
+    const hasActionableErrors = actionableErrors.length > 0;
+    const retryable = hasActionableErrors
+      ? actionableErrors.some((error) => error.retryable)
       : undefined;
-    const blockingErrorCodes = [...new Set(blockingErrors.map((error) => error.code))];
+    const actionableErrorCodes = [...new Set(actionableErrors.map((error) => error.code))];
 
     return {
       channel: NotificationChannel.PUSH,
-      success: blockingErrors.length === 0,
+      success: !hasActionableErrors,
       retryable,
       messageId: result.sent > 0 ? "push-sent" : undefined,
-      error:
-        blockingErrors.length > 0
-          ? `One or more push notifications failed (${blockingErrorCodes.join(", ") || "unknown"})`
-          : undefined,
+      error: hasActionableErrors
+        ? `One or more push notifications failed (${actionableErrorCodes.join(", ") || "unknown"})`
+        : undefined,
       perRecipientResults,
     };
   }

--- a/src/modules/notification/notification.processor.ts
+++ b/src/modules/notification/notification.processor.ts
@@ -254,6 +254,7 @@ export class NotificationProcessor extends WorkerHost {
 
           perRecipientResults.push({
             recipient,
+            channel: NotificationChannel.EMAIL,
             email,
             success: true,
             messageId: sendResult.data?.id,
@@ -261,6 +262,7 @@ export class NotificationProcessor extends WorkerHost {
         } catch (error) {
           perRecipientResults.push({
             recipient,
+            channel: NotificationChannel.EMAIL,
             email,
             success: false,
             error: error instanceof Error ? error.message : String(error),
@@ -523,10 +525,16 @@ export class NotificationProcessor extends WorkerHost {
     bookingId: string,
     pushPayload: NotificationJobData["pushPayload"],
   ): Promise<NotificationResult | null> {
-    const pushTokens = Object.values(recipients).flatMap(
-      (recipient) => recipient?.pushTokens ?? [],
+    const pushRecipients = Object.entries(recipients).flatMap(([recipientType, recipient]) =>
+      (recipient?.pushTokens ?? []).map((token) => ({
+        recipient: recipientType as RecipientType,
+        pushToken: token,
+      })),
     );
-    const uniqueTokens = [...new Set(pushTokens)];
+    const uniquePushRecipients = Array.from(
+      new Map(pushRecipients.map((entry) => [entry.pushToken, entry])).values(),
+    );
+    const uniqueTokens = uniquePushRecipients.map((entry) => entry.pushToken);
     if (uniqueTokens.length === 0) {
       return null;
     }
@@ -552,7 +560,19 @@ export class NotificationProcessor extends WorkerHost {
     const deliveryErrors = result.errors ?? [];
 
     if (result.invalidTokens.length > 0) {
-      await this.pushTokenService.revokeTokens(result.invalidTokens);
+      try {
+        await this.pushTokenService.revokeTokens(result.invalidTokens);
+      } catch (error) {
+        this.logger.error(
+          {
+            bookingId,
+            type,
+            invalidTokenCount: result.invalidTokens.length,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          "Failed to revoke invalid push tokens after push delivery",
+        );
+      }
     }
 
     if (deliveryErrors.length > 0) {
@@ -593,6 +613,58 @@ export class NotificationProcessor extends WorkerHost {
       );
     }
 
+    const invalidTokenSet = new Set(result.invalidTokens);
+    const tokenErrorMap = new Map(
+      deliveryErrors
+        .filter((error): error is typeof error & { token: string } => Boolean(error.token))
+        .map((error) => [error.token, error]),
+    );
+    const perRecipientResults: NotificationRecipientResult[] = uniquePushRecipients.map(
+      ({ recipient, pushToken }) => {
+        const tokenError = tokenErrorMap.get(pushToken);
+        const isInvalidToken = invalidTokenSet.has(pushToken);
+        const success = !tokenError && !isInvalidToken;
+
+        if (success) {
+          return {
+            recipient,
+            channel: NotificationChannel.PUSH,
+            pushToken,
+            success: true,
+            messageId: "push-sent",
+          };
+        }
+
+        if (tokenError) {
+          return {
+            recipient,
+            channel: NotificationChannel.PUSH,
+            pushToken,
+            success: false,
+            error: tokenError.message ?? tokenError.code,
+            pushResponse: {
+              code: tokenError.code,
+              retryable: tokenError.retryable,
+              message: tokenError.message,
+            },
+          };
+        }
+
+        return {
+          recipient,
+          channel: NotificationChannel.PUSH,
+          pushToken,
+          success: false,
+          error: "Device not registered",
+          pushResponse: {
+            code: "DeviceNotRegistered",
+            retryable: false,
+            message: "Device not registered",
+          },
+        };
+      },
+    );
+
     return {
       channel: NotificationChannel.PUSH,
       success: result.failed === 0,
@@ -604,6 +676,7 @@ export class NotificationProcessor extends WorkerHost {
               [...new Set((result.errors ?? []).map((error) => error.code))].join(", ") || "unknown"
             })`
           : undefined,
+      perRecipientResults,
     };
   }
 

--- a/src/modules/notification/notification.processor.ts
+++ b/src/modules/notification/notification.processor.ts
@@ -665,16 +665,23 @@ export class NotificationProcessor extends WorkerHost {
       },
     );
 
+    const blockingErrors = deliveryErrors.filter(
+      (error) => !error.retryable && error.code !== "DeviceNotRegistered",
+    );
+    const hasDeliveryErrors = deliveryErrors.length > 0;
+    const retryable = hasDeliveryErrors
+      ? deliveryErrors.some((error) => error.retryable)
+      : undefined;
+    const blockingErrorCodes = [...new Set(blockingErrors.map((error) => error.code))];
+
     return {
       channel: NotificationChannel.PUSH,
-      success: result.failed === 0,
-      retryable: result.failed > 0 ? deliveryErrors.some((error) => error.retryable) : undefined,
+      success: blockingErrors.length === 0,
+      retryable,
       messageId: result.sent > 0 ? "push-sent" : undefined,
       error:
-        result.failed > 0
-          ? `One or more push notifications failed (${
-              [...new Set((result.errors ?? []).map((error) => error.code))].join(", ") || "unknown"
-            })`
+        blockingErrors.length > 0
+          ? `One or more push notifications failed (${blockingErrorCodes.join(", ") || "unknown"})`
           : undefined,
       perRecipientResults,
     };

--- a/src/modules/notification/notification.processor.ts
+++ b/src/modules/notification/notification.processor.ts
@@ -1,6 +1,6 @@
 import { OnWorkerEvent, Processor, WorkerHost } from "@nestjs/bullmq";
 import { Inject } from "@nestjs/common";
-import { Job } from "bullmq";
+import { Job, UnrecoverableError } from "bullmq";
 import { PinoLogger } from "nestjs-pino";
 import { NOTIFICATIONS_QUEUE } from "../../config/constants";
 import {
@@ -29,6 +29,8 @@ import {
 } from "./notification.interface";
 import { NotificationDispatchError } from "./notification.processor.error";
 import { getSucceededChannels } from "./notification.processor.helper";
+import { PushService } from "./push.service";
+import { PushTokenService } from "./push-token.service";
 import {
   BOOKING_CANCELLED_TEMPLATE_KIND,
   BOOKING_CONFIRMED_TEMPLATE_KIND,
@@ -63,6 +65,8 @@ export class NotificationProcessor extends WorkerHost {
   constructor(
     private readonly emailService: EmailService,
     private readonly whatsAppService: WhatsAppService,
+    private readonly pushService: PushService,
+    private readonly pushTokenService: PushTokenService,
     @Inject(PinoLogger) private readonly logger: PinoLogger,
   ) {
     super();
@@ -103,7 +107,15 @@ export class NotificationProcessor extends WorkerHost {
         continue;
       }
 
-      const result = await this.processChannel(id, channel, type, recipients, templateData);
+      const result = await this.processChannel(
+        id,
+        channel,
+        type,
+        recipients,
+        templateData,
+        job.data.bookingId,
+        job.data.pushPayload,
+      );
       if (result) results.push(result);
       if (result?.success) {
         succeededChannels.add(channel);
@@ -118,12 +130,19 @@ export class NotificationProcessor extends WorkerHost {
 
     const failed = results.filter((result) => !result.success);
     if (failed.length > 0) {
-      throw new NotificationDispatchError(
+      const dispatchError = new NotificationDispatchError(
         id,
         failed.map((result) => result.channel),
         job.attemptsMade + 1,
         job.opts.attempts,
       );
+
+      if (failed.every((result) => result.retryable === false)) {
+        // Stop queue-level retries when all failed channels are non-retryable
+        // (e.g. InvalidCredentials).
+        throw new UnrecoverableError(dispatchError.message);
+      }
+      throw dispatchError;
     }
 
     return results;
@@ -135,6 +154,8 @@ export class NotificationProcessor extends WorkerHost {
     type: NotificationType,
     recipients: NotificationJobData["recipients"],
     templateData: TemplateData,
+    bookingId: string,
+    pushPayload: NotificationJobData["pushPayload"],
   ): Promise<NotificationResult | null> {
     try {
       if (channel === NotificationChannel.EMAIL) {
@@ -143,6 +164,10 @@ export class NotificationProcessor extends WorkerHost {
 
       if (channel === NotificationChannel.WHATSAPP) {
         return await this.sendWhatsAppNotification(type, recipients, templateData);
+      }
+
+      if (channel === NotificationChannel.PUSH) {
+        return await this.sendPushNotification(type, recipients, bookingId, pushPayload);
       }
 
       return null;
@@ -280,6 +305,7 @@ export class NotificationProcessor extends WorkerHost {
       case NotificationType.BOOKING_CANCELLED:
         return this.buildBookingCancelledEmailHtml(templateData, recipient);
       case NotificationType.BOOKING_STATUS_CHANGE:
+      case NotificationType.CHAUFFEUR_ASSIGNED:
         return this.buildBookingStatusEmailHtml(templateData);
       case NotificationType.BOOKING_REMINDER_START:
       case NotificationType.BOOKING_REMINDER_END:
@@ -489,6 +515,96 @@ export class NotificationProcessor extends WorkerHost {
         error: error instanceof Error ? error.message : String(error),
       };
     }
+  }
+
+  private async sendPushNotification(
+    type: NotificationType,
+    recipients: NotificationJobData["recipients"],
+    bookingId: string,
+    pushPayload: NotificationJobData["pushPayload"],
+  ): Promise<NotificationResult | null> {
+    const pushTokens = Object.values(recipients).flatMap(
+      (recipient) => recipient?.pushTokens ?? [],
+    );
+    const uniqueTokens = [...new Set(pushTokens)];
+    if (uniqueTokens.length === 0) {
+      return null;
+    }
+
+    const payload = pushPayload ?? {
+      title: "Booking update",
+      body:
+        type === NotificationType.CHAUFFEUR_ASSIGNED
+          ? "Your chauffeur has been assigned."
+          : "You have a new update for your booking.",
+      data: {
+        bookingId,
+        type,
+      },
+    };
+
+    const result = await this.pushService.sendPushNotifications({
+      tokens: uniqueTokens,
+      title: payload.title,
+      body: payload.body,
+      data: payload.data,
+    });
+    const deliveryErrors = result.errors ?? [];
+
+    if (result.invalidTokens.length > 0) {
+      await this.pushTokenService.revokeTokens(result.invalidTokens);
+    }
+
+    if (deliveryErrors.length > 0) {
+      const retryableErrors = deliveryErrors.filter((error) => error.retryable);
+      const nonRetryableErrors = deliveryErrors.filter((error) => !error.retryable);
+      const errorCodeCounts = deliveryErrors.reduce<Record<string, number>>((acc, error) => {
+        acc[error.code] = (acc[error.code] ?? 0) + 1;
+        return acc;
+      }, {});
+
+      this.logger.error(
+        {
+          bookingId,
+          type,
+          sent: result.sent,
+          failed: result.failed,
+          invalidTokenCount: result.invalidTokens.length,
+          retryableErrorCount: retryableErrors.length,
+          nonRetryableErrorCount: nonRetryableErrors.length,
+          errorCodeCounts,
+          sampleErrors: deliveryErrors.slice(0, 3),
+        },
+        "Push notification delivery returned Expo ticket errors",
+      );
+    }
+
+    // All tokens were invalid: nothing was delivered, but retrying with the
+    // same tokens won't help, so do not fail the channel. Emit a high-signal
+    // log so this is observable and alertable.
+    if (result.sent === 0 && result.failed === 0 && result.invalidTokens.length > 0) {
+      this.logger.warn(
+        {
+          bookingId,
+          type,
+          invalidTokenCount: result.invalidTokens.length,
+        },
+        "Push notification skipped: all push tokens for booking are invalid",
+      );
+    }
+
+    return {
+      channel: NotificationChannel.PUSH,
+      success: result.failed === 0,
+      retryable: result.failed > 0 ? deliveryErrors.some((error) => error.retryable) : undefined,
+      messageId: result.sent > 0 ? "push-sent" : undefined,
+      error:
+        result.failed > 0
+          ? `One or more push notifications failed (${
+              [...new Set((result.errors ?? []).map((error) => error.code))].join(", ") || "unknown"
+            })`
+          : undefined,
+    };
   }
 
   private getWhatsAppTemplateKey(

--- a/src/modules/notification/notification.service.spec.ts
+++ b/src/modules/notification/notification.service.spec.ts
@@ -330,6 +330,16 @@ describe("NotificationService", () => {
     });
 
     it("should skip chauffeur assignment notification with no customer channel", async () => {
+      const recordSkippedSpy = vi.spyOn(
+        service as unknown as {
+          recordNotificationSkippedNoChannel: (input: {
+            bookingId: string;
+            oldStatus: string;
+            newStatus: string;
+          }) => void;
+        },
+        "recordNotificationSkippedNoChannel",
+      );
       const booking = createBooking({
         status: BookingStatus.CONFIRMED,
         car: createCar({ owner: createOwner() }),
@@ -347,6 +357,11 @@ describe("NotificationService", () => {
       await service.queueChauffeurAssignedNotifications(booking);
 
       expect(mockQueue.add).not.toHaveBeenCalled();
+      expect(recordSkippedSpy).toHaveBeenCalledWith({
+        bookingId: booking.id,
+        oldStatus: booking.status,
+        newStatus: "CHAUFFEUR_ASSIGNED",
+      });
     });
   });
 });

--- a/src/modules/notification/notification.service.spec.ts
+++ b/src/modules/notification/notification.service.spec.ts
@@ -25,6 +25,7 @@ import {
   NotificationType,
 } from "./notification.interface";
 import { NotificationService } from "./notification.service";
+import { PushTokenService } from "./push-token.service";
 import {
   BOOKING_REMINDER_TEMPLATE_KIND,
   BOOKING_STATUS_TEMPLATE_KIND,
@@ -33,8 +34,14 @@ import {
 describe("NotificationService", () => {
   let service: NotificationService;
   let mockQueue: Partial<Queue<NotificationJobData>>;
+  const pushTokenServiceMock = {
+    getActiveTokensForUser: vi.fn().mockResolvedValue([]),
+  };
 
   beforeEach(async () => {
+    vi.clearAllMocks();
+    pushTokenServiceMock.getActiveTokensForUser.mockResolvedValue([]);
+
     mockQueue = {
       add: vi.fn().mockResolvedValue({ id: "job-123" }),
     };
@@ -45,6 +52,10 @@ describe("NotificationService", () => {
         {
           provide: getQueueToken(NOTIFICATIONS_QUEUE),
           useValue: mockQueue,
+        },
+        {
+          provide: PushTokenService,
+          useValue: pushTokenServiceMock,
         },
       ],
     })
@@ -246,6 +257,96 @@ describe("NotificationService", () => {
         }),
         undefined,
       );
+    });
+  });
+
+  describe("queueChauffeurAssignedNotifications", () => {
+    it("should queue chauffeur assignment notification to customer", async () => {
+      const booking = createBooking({
+        status: BookingStatus.CONFIRMED,
+        car: createCar({ owner: createOwner() }),
+        chauffeur: createChauffeur(),
+        user: createUser(),
+      });
+
+      await service.queueChauffeurAssignedNotifications(booking);
+
+      expect(mockQueue.add).toHaveBeenCalledWith(
+        SEND_NOTIFICATION_JOB_NAME,
+        expect.objectContaining({
+          type: NotificationType.CHAUFFEUR_ASSIGNED,
+          channels: [NotificationChannel.EMAIL, NotificationChannel.WHATSAPP],
+          bookingId: booking.id,
+          recipients: expect.objectContaining({
+            [CLIENT_RECIPIENT_TYPE]: expect.objectContaining({
+              email: "john@example.com",
+              phoneNumber: "1234567890",
+            }),
+          }),
+          templateData: expect.objectContaining({
+            templateKind: BOOKING_STATUS_TEMPLATE_KIND,
+            title: "been assigned a chauffeur",
+            status: "chauffeur assigned",
+            subject: "Your chauffeur has been assigned",
+          }),
+        }),
+        { priority: 1 },
+      );
+    });
+
+    it("should include PUSH channel when active push tokens exist", async () => {
+      const booking = createBooking({
+        status: BookingStatus.CONFIRMED,
+        car: createCar({ owner: createOwner() }),
+        chauffeur: createChauffeur(),
+        user: createUser(),
+      });
+      pushTokenServiceMock.getActiveTokensForUser.mockResolvedValueOnce([
+        "ExponentPushToken[abc123]",
+      ]);
+
+      await service.queueChauffeurAssignedNotifications(booking);
+
+      expect(mockQueue.add).toHaveBeenCalledWith(
+        SEND_NOTIFICATION_JOB_NAME,
+        expect.objectContaining({
+          type: NotificationType.CHAUFFEUR_ASSIGNED,
+          channels: [
+            NotificationChannel.EMAIL,
+            NotificationChannel.WHATSAPP,
+            NotificationChannel.PUSH,
+          ],
+          recipients: expect.objectContaining({
+            [CLIENT_RECIPIENT_TYPE]: expect.objectContaining({
+              pushTokens: ["ExponentPushToken[abc123]"],
+            }),
+          }),
+          pushPayload: expect.objectContaining({
+            title: "Your chauffeur has been assigned",
+          }),
+        }),
+        { priority: 1 },
+      );
+    });
+
+    it("should skip chauffeur assignment notification with no customer channel", async () => {
+      const booking = createBooking({
+        status: BookingStatus.CONFIRMED,
+        car: createCar({ owner: createOwner() }),
+        chauffeur: createChauffeur(),
+        user: null,
+        guestUser: {
+          name: "No Contact Guest",
+          email: null,
+          phoneNumber: null,
+          guestContactSource: "WEB_GUEST_FORM",
+          preferredNotificationChannel: "EMAIL_AND_WHATSAPP",
+        },
+      });
+
+      await service.queueChauffeurAssignedNotifications(booking);
+
+      expect(mockQueue.add).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/modules/notification/notification.service.ts
+++ b/src/modules/notification/notification.service.ts
@@ -117,9 +117,10 @@ export class NotificationService {
   ): Promise<NotificationJobData | null> {
     const bookingDetails = normaliseBookingDetails(booking);
     const channels = deriveNotificationChannels(bookingDetails);
+    const userId = booking.userId ?? booking.user?.id;
     const pushTokens =
       input?.pushTokens ??
-      (booking.user?.id ? await this.pushTokenService.getActiveTokensForUser(booking.user.id) : []);
+      (userId ? await this.pushTokenService.getActiveTokensForUser(userId) : []);
     if (pushTokens.length > 0) {
       channels.push(NotificationChannel.PUSH);
     }

--- a/src/modules/notification/notification.service.ts
+++ b/src/modules/notification/notification.service.ts
@@ -25,6 +25,7 @@ import {
   QueueReviewReceivedNotificationParams,
 } from "./notification.interface";
 import { deriveNotificationChannels } from "./notification-channel.helper";
+import { PushTokenService } from "./push-token.service";
 import {
   BOOKING_CANCELLED_TEMPLATE_KIND,
   BOOKING_REMINDER_TEMPLATE_KIND,
@@ -42,6 +43,7 @@ export class NotificationService {
   constructor(
     @InjectQueue(NOTIFICATIONS_QUEUE)
     private readonly notificationQueue: Queue<NotificationJobData>,
+    private readonly pushTokenService: PushTokenService,
     private readonly logger: PinoLogger,
   ) {
     this.logger.setContext(NotificationService.name);
@@ -80,6 +82,82 @@ export class NotificationService {
     await this.addJobToQueue(jobData, HIGH_PRIORITY_JOB_OPTIONS);
 
     this.logStatusChangeNotification(booking.id, oldStatus, newStatus, jobData.channels);
+  }
+
+  /**
+   * Queue a notification when a chauffeur is assigned to a booking.
+   */
+  async queueChauffeurAssignedNotifications(booking: BookingWithRelations): Promise<void> {
+    const jobData = await this.buildChauffeurAssignedJobData(booking);
+    if (!jobData) {
+      this.logger.warn(
+        { bookingId: booking.id },
+        "No customer delivery channel available for chauffeur assignment",
+      );
+      return;
+    }
+
+    await this.addJobToQueue(jobData, HIGH_PRIORITY_JOB_OPTIONS);
+    this.logger.info(
+      { bookingId: booking.id, channels: jobData.channels },
+      "Queued chauffeur assignment notification",
+    );
+  }
+
+  async enqueuePreparedNotification(
+    jobData: NotificationJobData,
+    options?: JobsOptions,
+  ): Promise<Job<NotificationJobData, NotificationResult[] | null, string>> {
+    return this.addJobToQueue(jobData, options);
+  }
+
+  async buildChauffeurAssignedJobData(
+    booking: BookingWithRelations,
+    input?: { pushTokens?: string[] },
+  ): Promise<NotificationJobData | null> {
+    const bookingDetails = normaliseBookingDetails(booking);
+    const channels = deriveNotificationChannels(bookingDetails);
+    const pushTokens =
+      input?.pushTokens ??
+      (booking.user?.id ? await this.pushTokenService.getActiveTokensForUser(booking.user.id) : []);
+    if (pushTokens.length > 0) {
+      channels.push(NotificationChannel.PUSH);
+    }
+
+    if (channels.length === 0) {
+      return null;
+    }
+
+    return {
+      id: `chauffeur-assigned-${bookingDetails.id}-${Date.now()}`,
+      type: NotificationType.CHAUFFEUR_ASSIGNED,
+      channels,
+      bookingId: bookingDetails.id,
+      recipients: {
+        [CLIENT_RECIPIENT_TYPE]: {
+          email: bookingDetails.customerEmail,
+          phoneNumber: bookingDetails.customerPhone,
+          pushTokens,
+        },
+      },
+      pushPayload: {
+        title: "Your chauffeur has been assigned",
+        body: `Your chauffeur for ${bookingDetails.carName} has been assigned.`,
+        data: {
+          bookingId: bookingDetails.id,
+          type: NotificationType.CHAUFFEUR_ASSIGNED,
+        },
+      },
+      templateData: {
+        templateKind: BOOKING_STATUS_TEMPLATE_KIND,
+        ...bookingDetails,
+        title: "been assigned a chauffeur",
+        status: "chauffeur assigned",
+        oldStatus: booking.status.toLowerCase(),
+        newStatus: "chauffeur_assigned",
+        subject: "Your chauffeur has been assigned",
+      },
+    };
   }
 
   /**

--- a/src/modules/notification/notification.service.ts
+++ b/src/modules/notification/notification.service.ts
@@ -94,6 +94,11 @@ export class NotificationService {
         { bookingId: booking.id },
         "No customer delivery channel available for chauffeur assignment",
       );
+      this.recordNotificationSkippedNoChannel({
+        bookingId: booking.id,
+        oldStatus: booking.status,
+        newStatus: "CHAUFFEUR_ASSIGNED",
+      });
       return;
     }
 

--- a/src/modules/notification/push-token.controller.spec.ts
+++ b/src/modules/notification/push-token.controller.spec.ts
@@ -56,10 +56,9 @@ describe("PushTokenController", () => {
   });
 
   it("revokes a push token for the current user", async () => {
-    const result = await controller.deletePushToken(
-      { id: "user-1" } as never,
-      "ExponentPushToken[abc123]",
-    );
+    const result = await controller.deletePushToken({ id: "user-1" } as never, {
+      token: "ExponentPushToken[abc123]",
+    });
 
     expect(pushTokenService.revokeToken).toHaveBeenCalledWith(
       "user-1",

--- a/src/modules/notification/push-token.controller.spec.ts
+++ b/src/modules/notification/push-token.controller.spec.ts
@@ -1,0 +1,70 @@
+import { Test, type TestingModule } from "@nestjs/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockPinoLoggerToken } from "@/testing/nest-pino-logger.mock";
+import { AuthService } from "../auth/auth.service";
+import { PushTokenController } from "./push-token.controller";
+import { PushTokenService } from "./push-token.service";
+
+describe("PushTokenController", () => {
+  let controller: PushTokenController;
+  let pushTokenService: PushTokenService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PushTokenController],
+      providers: [
+        {
+          provide: PushTokenService,
+          useValue: {
+            registerToken: vi.fn(),
+            revokeToken: vi.fn(),
+          },
+        },
+        {
+          provide: AuthService,
+          useValue: {
+            isInitialized: true,
+            auth: {
+              api: {
+                getSession: vi.fn().mockResolvedValue(null),
+              },
+            },
+            getUserRoles: vi.fn().mockResolvedValue(["user"]),
+          },
+        },
+      ],
+    })
+      .useMocker(mockPinoLoggerToken)
+      .compile();
+
+    controller = module.get<PushTokenController>(PushTokenController);
+    pushTokenService = module.get<PushTokenService>(PushTokenService);
+  });
+
+  it("registers a push token for the current user", async () => {
+    const result = await controller.registerPushToken({ id: "user-1" } as never, {
+      token: "ExponentPushToken[abc123]",
+      platform: "ios",
+    });
+
+    expect(pushTokenService.registerToken).toHaveBeenCalledWith(
+      "user-1",
+      "ExponentPushToken[abc123]",
+      "ios",
+    );
+    expect(result).toEqual({ success: true });
+  });
+
+  it("revokes a push token for the current user", async () => {
+    const result = await controller.deletePushToken(
+      { id: "user-1" } as never,
+      "ExponentPushToken[abc123]",
+    );
+
+    expect(pushTokenService.revokeToken).toHaveBeenCalledWith(
+      "user-1",
+      "ExponentPushToken[abc123]",
+    );
+    expect(result).toEqual({ success: true });
+  });
+});

--- a/src/modules/notification/push-token.controller.ts
+++ b/src/modules/notification/push-token.controller.ts
@@ -1,11 +1,12 @@
 import { Controller, Delete, HttpCode, HttpStatus, Post, UseGuards } from "@nestjs/common";
-import { ZodBody, ZodParam } from "../../common/decorators/zod-validation.decorator";
+import { ZodBody } from "../../common/decorators/zod-validation.decorator";
 import { CurrentUser } from "../auth/decorators/current-user.decorator";
 import { type AuthSession, SessionGuard } from "../auth/guards/session.guard";
 import {
-  pushTokenParamSchema,
   type RegisterPushTokenBodyDto,
+  type RevokePushTokenBodyDto,
   registerPushTokenBodySchema,
+  revokePushTokenBodySchema,
 } from "./dto/push-token.dto";
 import { PushTokenService } from "./push-token.service";
 
@@ -24,13 +25,13 @@ export class PushTokenController {
     return { success: true };
   }
 
-  @Delete(":token")
+  @Delete()
   @HttpCode(HttpStatus.OK)
   async deletePushToken(
     @CurrentUser() user: AuthSession["user"],
-    @ZodParam("token", pushTokenParamSchema) token: string,
+    @ZodBody(revokePushTokenBodySchema) body: RevokePushTokenBodyDto,
   ): Promise<{ success: true }> {
-    await this.pushTokenService.revokeToken(user.id, token);
+    await this.pushTokenService.revokeToken(user.id, body.token);
     return { success: true };
   }
 }

--- a/src/modules/notification/push-token.controller.ts
+++ b/src/modules/notification/push-token.controller.ts
@@ -1,0 +1,36 @@
+import { Controller, Delete, HttpCode, HttpStatus, Post, UseGuards } from "@nestjs/common";
+import { ZodBody, ZodParam } from "../../common/decorators/zod-validation.decorator";
+import { CurrentUser } from "../auth/decorators/current-user.decorator";
+import { type AuthSession, SessionGuard } from "../auth/guards/session.guard";
+import {
+  pushTokenParamSchema,
+  type RegisterPushTokenBodyDto,
+  registerPushTokenBodySchema,
+} from "./dto/push-token.dto";
+import { PushTokenService } from "./push-token.service";
+
+@Controller("api/users/me/push-tokens")
+@UseGuards(SessionGuard)
+export class PushTokenController {
+  constructor(private readonly pushTokenService: PushTokenService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.OK)
+  async registerPushToken(
+    @CurrentUser() user: AuthSession["user"],
+    @ZodBody(registerPushTokenBodySchema) body: RegisterPushTokenBodyDto,
+  ): Promise<{ success: true }> {
+    await this.pushTokenService.registerToken(user.id, body.token, body.platform);
+    return { success: true };
+  }
+
+  @Delete(":token")
+  @HttpCode(HttpStatus.OK)
+  async deletePushToken(
+    @CurrentUser() user: AuthSession["user"],
+    @ZodParam("token", pushTokenParamSchema) token: string,
+  ): Promise<{ success: true }> {
+    await this.pushTokenService.revokeToken(user.id, token);
+    return { success: true };
+  }
+}

--- a/src/modules/notification/push-token.service.spec.ts
+++ b/src/modules/notification/push-token.service.spec.ts
@@ -1,0 +1,143 @@
+import { Test, type TestingModule } from "@nestjs/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockPinoLoggerToken } from "@/testing/nest-pino-logger.mock";
+import { DatabaseService } from "../database/database.service";
+import { PushTokenOwnershipConflictException } from "./notification.error";
+import { PushTokenService } from "./push-token.service";
+
+describe("PushTokenService", () => {
+  let service: PushTokenService;
+
+  const databaseServiceMock = {
+    userPushToken: {
+      upsert: vi.fn(),
+      updateMany: vi.fn(),
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+    },
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PushTokenService,
+        {
+          provide: DatabaseService,
+          useValue: databaseServiceMock,
+        },
+      ],
+    })
+      .useMocker(mockPinoLoggerToken)
+      .compile();
+
+    service = module.get<PushTokenService>(PushTokenService);
+  });
+
+  it("registers token with upsert when token has no existing owner", async () => {
+    databaseServiceMock.userPushToken.findUnique.mockResolvedValueOnce(null);
+
+    await service.registerToken("user-1", "ExponentPushToken[abc123]", "ios");
+
+    expect(databaseServiceMock.userPushToken.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { token: "ExponentPushToken[abc123]" },
+        create: expect.objectContaining({
+          userId: "user-1",
+          token: "ExponentPushToken[abc123]",
+          platform: "IOS",
+        }),
+        update: expect.objectContaining({
+          userId: "user-1",
+          platform: "IOS",
+          revokedAt: null,
+        }),
+      }),
+    );
+  });
+
+  it("re-activates token when same owner re-registers a previously revoked token", async () => {
+    databaseServiceMock.userPushToken.findUnique.mockResolvedValueOnce({
+      userId: "user-1",
+      revokedAt: new Date(),
+    });
+
+    await service.registerToken("user-1", "ExponentPushToken[abc123]", "ios");
+
+    expect(databaseServiceMock.userPushToken.upsert).toHaveBeenCalled();
+  });
+
+  it("allows re-registering a token previously revoked by another user", async () => {
+    databaseServiceMock.userPushToken.findUnique.mockResolvedValueOnce({
+      userId: "user-2",
+      revokedAt: new Date(),
+    });
+
+    await service.registerToken("user-1", "ExponentPushToken[abc123]", "ios");
+
+    expect(databaseServiceMock.userPushToken.upsert).toHaveBeenCalled();
+  });
+
+  it("rejects ownership transfer when token is already active for another user", async () => {
+    databaseServiceMock.userPushToken.findUnique.mockResolvedValueOnce({
+      userId: "user-2",
+      revokedAt: null,
+    });
+
+    await expect(
+      service.registerToken("user-1", "ExponentPushToken[abc123]", "ios"),
+    ).rejects.toBeInstanceOf(PushTokenOwnershipConflictException);
+    expect(databaseServiceMock.userPushToken.upsert).not.toHaveBeenCalled();
+  });
+
+  it("revokes token for the current user", async () => {
+    await service.revokeToken("user-1", "ExponentPushToken[abc123]");
+
+    expect(databaseServiceMock.userPushToken.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          userId: "user-1",
+          token: "ExponentPushToken[abc123]",
+          revokedAt: null,
+        }),
+      }),
+    );
+  });
+
+  it("revokes invalid tokens in bulk", async () => {
+    await service.revokeTokens([
+      "ExponentPushToken[a]",
+      "ExponentPushToken[a]",
+      "ExponentPushToken[b]",
+    ]);
+
+    expect(databaseServiceMock.userPushToken.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          token: { in: ["ExponentPushToken[a]", "ExponentPushToken[b]"] },
+        }),
+      }),
+    );
+  });
+
+  it("returns active push tokens for a user", async () => {
+    databaseServiceMock.userPushToken.findMany.mockResolvedValueOnce([
+      { token: "ExponentPushToken[a]" },
+      { token: "ExponentPushToken[b]" },
+    ]);
+
+    const tokens = await service.getActiveTokensForUser("user-1");
+
+    expect(tokens).toEqual(["ExponentPushToken[a]", "ExponentPushToken[b]"]);
+    expect(databaseServiceMock.userPushToken.findMany).toHaveBeenCalledWith({
+      where: {
+        userId: "user-1",
+        revokedAt: null,
+      },
+      select: {
+        token: true,
+      },
+    });
+  });
+});

--- a/src/modules/notification/push-token.service.spec.ts
+++ b/src/modules/notification/push-token.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, type TestingModule } from "@nestjs/testing";
+import { Prisma } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mockPinoLoggerToken } from "@/testing/nest-pino-logger.mock";
 import { DatabaseService } from "../database/database.service";
@@ -9,8 +10,9 @@ describe("PushTokenService", () => {
   let service: PushTokenService;
 
   const databaseServiceMock = {
+    $transaction: vi.fn(),
     userPushToken: {
-      upsert: vi.fn(),
+      create: vi.fn(),
       updateMany: vi.fn(),
       findMany: vi.fn(),
       findUnique: vi.fn(),
@@ -19,6 +21,9 @@ describe("PushTokenService", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    databaseServiceMock.$transaction.mockImplementation(async (callback) =>
+      callback(databaseServiceMock),
+    );
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -35,51 +40,52 @@ describe("PushTokenService", () => {
     service = module.get<PushTokenService>(PushTokenService);
   });
 
-  it("registers token with upsert when token has no existing owner", async () => {
-    databaseServiceMock.userPushToken.findUnique.mockResolvedValueOnce(null);
+  it("registers token by creating a new ownership record when token does not exist", async () => {
+    databaseServiceMock.userPushToken.create.mockResolvedValueOnce(undefined);
 
     await service.registerToken("user-1", "ExponentPushToken[abc123]", "ios");
 
-    expect(databaseServiceMock.userPushToken.upsert).toHaveBeenCalledWith(
+    expect(databaseServiceMock.userPushToken.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { token: "ExponentPushToken[abc123]" },
-        create: expect.objectContaining({
+        data: expect.objectContaining({
           userId: "user-1",
           token: "ExponentPushToken[abc123]",
           platform: "IOS",
         }),
-        update: expect.objectContaining({
-          userId: "user-1",
-          platform: "IOS",
-          revokedAt: null,
-        }),
+      }),
+    );
+    expect(databaseServiceMock.userPushToken.updateMany).not.toHaveBeenCalled();
+    expect(databaseServiceMock.userPushToken.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("re-activates token when same owner re-registers a previously revoked token", async () => {
+    databaseServiceMock.userPushToken.create.mockRejectedValueOnce(createUniqueConstraintError());
+    databaseServiceMock.userPushToken.updateMany.mockResolvedValueOnce({ count: 1 });
+
+    await service.registerToken("user-1", "ExponentPushToken[abc123]", "ios");
+
+    expect(databaseServiceMock.userPushToken.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          token: "ExponentPushToken[abc123]",
+          OR: [{ userId: "user-1" }, { revokedAt: { not: null } }],
+        },
       }),
     );
   });
 
-  it("re-activates token when same owner re-registers a previously revoked token", async () => {
-    databaseServiceMock.userPushToken.findUnique.mockResolvedValueOnce({
-      userId: "user-1",
-      revokedAt: new Date(),
-    });
-
-    await service.registerToken("user-1", "ExponentPushToken[abc123]", "ios");
-
-    expect(databaseServiceMock.userPushToken.upsert).toHaveBeenCalled();
-  });
-
   it("allows re-registering a token previously revoked by another user", async () => {
-    databaseServiceMock.userPushToken.findUnique.mockResolvedValueOnce({
-      userId: "user-2",
-      revokedAt: new Date(),
-    });
+    databaseServiceMock.userPushToken.create.mockRejectedValueOnce(createUniqueConstraintError());
+    databaseServiceMock.userPushToken.updateMany.mockResolvedValueOnce({ count: 1 });
 
     await service.registerToken("user-1", "ExponentPushToken[abc123]", "ios");
 
-    expect(databaseServiceMock.userPushToken.upsert).toHaveBeenCalled();
+    expect(databaseServiceMock.userPushToken.updateMany).toHaveBeenCalled();
   });
 
-  it("rejects ownership transfer when token is already active for another user", async () => {
+  it("rejects ownership transfer when token becomes active for another user during concurrent registration", async () => {
+    databaseServiceMock.userPushToken.create.mockRejectedValueOnce(createUniqueConstraintError());
+    databaseServiceMock.userPushToken.updateMany.mockResolvedValueOnce({ count: 0 });
     databaseServiceMock.userPushToken.findUnique.mockResolvedValueOnce({
       userId: "user-2",
       revokedAt: null,
@@ -88,7 +94,19 @@ describe("PushTokenService", () => {
     await expect(
       service.registerToken("user-1", "ExponentPushToken[abc123]", "ios"),
     ).rejects.toBeInstanceOf(PushTokenOwnershipConflictException);
-    expect(databaseServiceMock.userPushToken.upsert).not.toHaveBeenCalled();
+    expect(databaseServiceMock.userPushToken.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          token: "ExponentPushToken[abc123]",
+          OR: [{ userId: "user-1" }, { revokedAt: { not: null } }],
+        },
+        data: {
+          userId: "user-1",
+          platform: "IOS",
+          revokedAt: null,
+        },
+      }),
+    );
   });
 
   it("revokes token for the current user", async () => {
@@ -141,3 +159,9 @@ describe("PushTokenService", () => {
     });
   });
 });
+
+function createUniqueConstraintError() {
+  return Object.assign(Object.create(Prisma.PrismaClientKnownRequestError.prototype), {
+    code: "P2002",
+  });
+}

--- a/src/modules/notification/push-token.service.ts
+++ b/src/modules/notification/push-token.service.ts
@@ -1,0 +1,100 @@
+import { Injectable } from "@nestjs/common";
+import { PushPlatform } from "@prisma/client";
+import { PinoLogger } from "nestjs-pino";
+import { DatabaseService } from "../database/database.service";
+import { PushTokenOwnershipConflictException } from "./notification.error";
+
+@Injectable()
+export class PushTokenService {
+  constructor(
+    private readonly databaseService: DatabaseService,
+    private readonly logger: PinoLogger,
+  ) {
+    this.logger.setContext(PushTokenService.name);
+  }
+
+  async registerToken(userId: string, token: string, platform: "ios" | "android"): Promise<void> {
+    const existing = await this.databaseService.userPushToken.findUnique({
+      where: { token },
+      select: { userId: true, revokedAt: true },
+    });
+
+    // Block silent ownership transfer: if the token is currently bound to a
+    // different active user, reject. Re-registration is only allowed when the
+    // existing record belongs to the same user, or has been revoked.
+    if (existing && existing.userId !== userId && existing.revokedAt === null) {
+      this.logger.warn(
+        {
+          requestingUserId: userId,
+          ownerUserId: existing.userId,
+        },
+        "Rejected push token registration owned by a different active user",
+      );
+      throw new PushTokenOwnershipConflictException();
+    }
+
+    await this.databaseService.userPushToken.upsert({
+      where: { token },
+      update: {
+        userId,
+        platform: this.toPushPlatform(platform),
+        revokedAt: null,
+      },
+      create: {
+        userId,
+        token,
+        platform: this.toPushPlatform(platform),
+      },
+    });
+  }
+
+  async revokeToken(userId: string, token: string): Promise<void> {
+    await this.databaseService.userPushToken.updateMany({
+      where: {
+        userId,
+        token,
+        revokedAt: null,
+      },
+      data: {
+        revokedAt: new Date(),
+      },
+    });
+  }
+
+  async revokeTokens(tokens: string[]): Promise<void> {
+    if (tokens.length === 0) {
+      return;
+    }
+
+    const dedupedTokens = [...new Set(tokens)];
+    await this.databaseService.userPushToken.updateMany({
+      where: {
+        token: { in: dedupedTokens },
+        revokedAt: null,
+      },
+      data: {
+        revokedAt: new Date(),
+      },
+    });
+
+    this.logger.info({ tokenCount: dedupedTokens.length }, "Revoked invalid push tokens");
+  }
+
+  async getActiveTokensForUser(userId: string): Promise<string[]> {
+    const records = await this.databaseService.userPushToken.findMany({
+      where: {
+        userId,
+        revokedAt: null,
+      },
+      select: {
+        token: true,
+      },
+    });
+
+    return records.map((record) => record.token);
+  }
+
+  private toPushPlatform(platform: "ios" | "android"): PushPlatform {
+    return platform === "ios" ? PushPlatform.IOS : PushPlatform.ANDROID;
+  }
+}

--- a/src/modules/notification/push-token.service.ts
+++ b/src/modules/notification/push-token.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@nestjs/common";
-import { PushPlatform } from "@prisma/client";
+import { Prisma, PushPlatform } from "@prisma/client";
 import { PinoLogger } from "nestjs-pino";
 import { DatabaseService } from "../database/database.service";
 import { PushTokenOwnershipConflictException } from "./notification.error";
@@ -14,37 +14,64 @@ export class PushTokenService {
   }
 
   async registerToken(userId: string, token: string, platform: "ios" | "android"): Promise<void> {
-    const existing = await this.databaseService.userPushToken.findUnique({
-      where: { token },
-      select: { userId: true, revokedAt: true },
-    });
+    await this.databaseService.$transaction(async (tx) => {
+      const pushPlatform = this.toPushPlatform(platform);
 
-    // Block silent ownership transfer: if the token is currently bound to a
-    // different active user, reject. Re-registration is only allowed when the
-    // existing record belongs to the same user, or has been revoked.
-    if (existing && existing.userId !== userId && existing.revokedAt === null) {
-      this.logger.warn(
-        {
-          requestingUserId: userId,
-          ownerUserId: existing.userId,
+      try {
+        await tx.userPushToken.create({
+          data: {
+            userId,
+            token,
+            platform: pushPlatform,
+          },
+        });
+        return;
+      } catch (error) {
+        if (!this.isUniqueConstraintError(error)) {
+          throw error;
+        }
+      }
+
+      const updateResult = await tx.userPushToken.updateMany({
+        where: {
+          token,
+          OR: [{ userId }, { revokedAt: { not: null } }],
         },
-        "Rejected push token registration owned by a different active user",
-      );
-      throw new PushTokenOwnershipConflictException();
-    }
+        data: {
+          userId,
+          platform: pushPlatform,
+          revokedAt: null,
+        },
+      });
 
-    await this.databaseService.userPushToken.upsert({
-      where: { token },
-      update: {
-        userId,
-        platform: this.toPushPlatform(platform),
-        revokedAt: null,
-      },
-      create: {
-        userId,
-        token,
-        platform: this.toPushPlatform(platform),
-      },
+      if (updateResult.count > 0) {
+        return;
+      }
+
+      const existing = await tx.userPushToken.findUnique({
+        where: { token },
+        select: { userId: true, revokedAt: true },
+      });
+
+      if (existing && existing.userId !== userId && existing.revokedAt === null) {
+        this.logger.warn(
+          {
+            requestingUserId: userId,
+            ownerUserId: existing.userId,
+          },
+          "Rejected push token registration owned by a different active user",
+        );
+        throw new PushTokenOwnershipConflictException();
+      }
+
+      // Defensive retry for transient row disappearance between write attempts.
+      await tx.userPushToken.create({
+        data: {
+          userId,
+          token,
+          platform: pushPlatform,
+        },
+      });
     });
   }
 
@@ -96,5 +123,9 @@ export class PushTokenService {
 
   private toPushPlatform(platform: "ios" | "android"): PushPlatform {
     return platform === "ios" ? PushPlatform.IOS : PushPlatform.ANDROID;
+  }
+
+  private isUniqueConstraintError(error: unknown): boolean {
+    return error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002";
   }
 }

--- a/src/modules/notification/push.interface.ts
+++ b/src/modules/notification/push.interface.ts
@@ -1,0 +1,23 @@
+export interface SendPushNotificationsInput {
+  tokens: string[];
+  title: string;
+  body: string;
+  data?: Record<string, string>;
+}
+
+export interface SendPushNotificationsResult {
+  sent: number;
+  /**
+   * Retryable failures only (invalid/unregistered tokens are excluded).
+   */
+  failed: number;
+  invalidTokens: string[];
+  errors?: PushDeliveryError[];
+}
+
+export interface PushDeliveryError {
+  code: string;
+  retryable: boolean;
+  token?: string;
+  message?: string;
+}

--- a/src/modules/notification/push.service.spec.ts
+++ b/src/modules/notification/push.service.spec.ts
@@ -13,7 +13,7 @@ const { chunkPushNotificationsMock, sendPushNotificationsAsyncMock, isExpoPushTo
 
 vi.mock("expo-server-sdk", () => ({
   Expo: class {
-    static isExpoPushToken = isExpoPushTokenMock;
+    static readonly isExpoPushToken = isExpoPushTokenMock;
     chunkPushNotifications = chunkPushNotificationsMock;
     sendPushNotificationsAsync = sendPushNotificationsAsyncMock;
   },
@@ -76,7 +76,7 @@ describe("PushService", () => {
     expect(sendPushNotificationsAsyncMock).toHaveBeenCalledTimes(1);
   });
 
-  it("ignores invalid token formats before sending", async () => {
+  it("returns invalid-format tokens as non-retryable failures", async () => {
     sendPushNotificationsAsyncMock.mockResolvedValueOnce([{ status: "ok" }]);
 
     const result = await service.sendPushNotifications({
@@ -88,9 +88,45 @@ describe("PushService", () => {
     expect(result).toEqual({
       sent: 1,
       failed: 0,
-      invalidTokens: [],
-      errors: [],
+      invalidTokens: ["invalid-token"],
+      errors: [
+        {
+          code: "INVALID_PUSH_TOKEN_FORMAT",
+          retryable: false,
+          token: "invalid-token",
+          message: "Invalid Expo push token format",
+        },
+      ],
     });
     expect(sendPushNotificationsAsyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call Expo when all tokens are invalid format", async () => {
+    const result = await service.sendPushNotifications({
+      tokens: ["bad-token-a", "bad-token-b"],
+      title: "Title",
+      body: "Body",
+    });
+
+    expect(result).toEqual({
+      sent: 0,
+      failed: 0,
+      invalidTokens: ["bad-token-a", "bad-token-b"],
+      errors: [
+        {
+          code: "INVALID_PUSH_TOKEN_FORMAT",
+          retryable: false,
+          token: "bad-token-a",
+          message: "Invalid Expo push token format",
+        },
+        {
+          code: "INVALID_PUSH_TOKEN_FORMAT",
+          retryable: false,
+          token: "bad-token-b",
+          message: "Invalid Expo push token format",
+        },
+      ],
+    });
+    expect(sendPushNotificationsAsyncMock).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/notification/push.service.spec.ts
+++ b/src/modules/notification/push.service.spec.ts
@@ -1,0 +1,96 @@
+import { ConfigService } from "@nestjs/config";
+import { Test, type TestingModule } from "@nestjs/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockPinoLoggerToken } from "@/testing/nest-pino-logger.mock";
+import { PushService } from "./push.service";
+
+const { chunkPushNotificationsMock, sendPushNotificationsAsyncMock, isExpoPushTokenMock } =
+  vi.hoisted(() => ({
+    chunkPushNotificationsMock: vi.fn(),
+    sendPushNotificationsAsyncMock: vi.fn(),
+    isExpoPushTokenMock: vi.fn(),
+  }));
+
+vi.mock("expo-server-sdk", () => ({
+  Expo: class {
+    static isExpoPushToken = isExpoPushTokenMock;
+    chunkPushNotifications = chunkPushNotificationsMock;
+    sendPushNotificationsAsync = sendPushNotificationsAsyncMock;
+  },
+}));
+
+describe("PushService", () => {
+  let service: PushService;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    isExpoPushTokenMock.mockImplementation(
+      (token: string) =>
+        token.startsWith("ExponentPushToken[") || token.startsWith("ExpoPushToken["),
+    );
+    chunkPushNotificationsMock.mockImplementation((messages) => [messages]);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PushService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: vi.fn().mockReturnValue(undefined),
+          },
+        },
+      ],
+    })
+      .useMocker(mockPinoLoggerToken)
+      .compile();
+
+    service = module.get<PushService>(PushService);
+  });
+
+  it("sends push notifications and reports invalid device tokens", async () => {
+    sendPushNotificationsAsyncMock.mockResolvedValueOnce([
+      { status: "ok" },
+      { status: "error", details: { error: "DeviceNotRegistered" } },
+    ]);
+
+    const result = await service.sendPushNotifications({
+      tokens: ["ExponentPushToken[a]", "ExponentPushToken[b]"],
+      title: "Title",
+      body: "Body",
+      data: { bookingId: "booking-1" },
+    });
+
+    expect(result).toEqual({
+      sent: 1,
+      failed: 0,
+      invalidTokens: ["ExponentPushToken[b]"],
+      errors: [
+        {
+          code: "DeviceNotRegistered",
+          retryable: false,
+          token: "ExponentPushToken[b]",
+          message: undefined,
+        },
+      ],
+    });
+    expect(sendPushNotificationsAsyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores invalid token formats before sending", async () => {
+    sendPushNotificationsAsyncMock.mockResolvedValueOnce([{ status: "ok" }]);
+
+    const result = await service.sendPushNotifications({
+      tokens: ["invalid-token", "ExponentPushToken[a]"],
+      title: "Title",
+      body: "Body",
+    });
+
+    expect(result).toEqual({
+      sent: 1,
+      failed: 0,
+      invalidTokens: [],
+      errors: [],
+    });
+    expect(sendPushNotificationsAsyncMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/modules/notification/push.service.ts
+++ b/src/modules/notification/push.service.ts
@@ -30,12 +30,9 @@ export class PushService {
   async sendPushNotifications(
     input: SendPushNotificationsInput,
   ): Promise<SendPushNotificationsResult> {
-    const uniqueTokens = [...new Set(input.tokens)].filter((token) => this.isValidPushToken(token));
-    if (uniqueTokens.length === 0) {
-      return { sent: 0, failed: 0, invalidTokens: [], errors: [] };
-    }
+    const { validTokens, invalidFormatTokens } = this.partitionTokens(input.tokens);
 
-    const messages: ExpoPushMessage[] = uniqueTokens.map((token) => ({
+    const messages: ExpoPushMessage[] = validTokens.map((token) => ({
       to: token,
       sound: "default",
       title: input.title,
@@ -45,8 +42,17 @@ export class PushService {
 
     let sent = 0;
     let failed = 0;
-    const invalidTokens = new Set<string>();
-    const errors: PushDeliveryError[] = [];
+    const invalidTokens = new Set<string>(invalidFormatTokens);
+    const errors: PushDeliveryError[] = invalidFormatTokens.map((token) => ({
+      code: "INVALID_PUSH_TOKEN_FORMAT",
+      retryable: false,
+      token,
+      message: "Invalid Expo push token format",
+    }));
+
+    if (validTokens.length === 0) {
+      return { sent, failed, invalidTokens: [...invalidTokens], errors };
+    }
 
     for (const chunk of this.expo.chunkPushNotifications(messages)) {
       let tickets: ExpoPushTicket[];
@@ -89,6 +95,25 @@ export class PushService {
     }
 
     return { sent, failed, invalidTokens: [...invalidTokens], errors };
+  }
+
+  private partitionTokens(tokens: string[]): {
+    validTokens: string[];
+    invalidFormatTokens: string[];
+  } {
+    const uniqueInputTokens = [...new Set(tokens)];
+    const validTokens: string[] = [];
+    const invalidFormatTokens: string[] = [];
+
+    for (const token of uniqueInputTokens) {
+      if (this.isValidPushToken(token)) {
+        validTokens.push(token);
+      } else {
+        invalidFormatTokens.push(token);
+      }
+    }
+
+    return { validTokens, invalidFormatTokens };
   }
 
   private processTickets(

--- a/src/modules/notification/push.service.ts
+++ b/src/modules/notification/push.service.ts
@@ -1,0 +1,156 @@
+import { Injectable } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { Expo, type ExpoPushMessage, type ExpoPushTicket } from "expo-server-sdk";
+import { PinoLogger } from "nestjs-pino";
+import { EnvConfig } from "@/config/env.config";
+
+interface SendPushNotificationsInput {
+  tokens: string[];
+  title: string;
+  body: string;
+  data?: Record<string, string>;
+}
+
+interface SendPushNotificationsResult {
+  sent: number;
+  /**
+   * Retryable failures only (invalid/unregistered tokens are excluded).
+   */
+  failed: number;
+  invalidTokens: string[];
+  errors?: PushDeliveryError[];
+}
+
+interface PushDeliveryError {
+  code: string;
+  retryable: boolean;
+  token?: string;
+  message?: string;
+}
+
+@Injectable()
+export class PushService {
+  private readonly expo: Expo;
+
+  constructor(
+    private readonly configService: ConfigService<EnvConfig>,
+    private readonly logger: PinoLogger,
+  ) {
+    this.logger.setContext(PushService.name);
+    this.expo = new Expo({
+      accessToken: this.configService.get("EXPO_ACCESS_TOKEN", { infer: true }),
+    });
+  }
+
+  isValidPushToken(token: string): boolean {
+    return Expo.isExpoPushToken(token);
+  }
+
+  async sendPushNotifications(
+    input: SendPushNotificationsInput,
+  ): Promise<SendPushNotificationsResult> {
+    const uniqueTokens = [...new Set(input.tokens)].filter((token) => this.isValidPushToken(token));
+    if (uniqueTokens.length === 0) {
+      return { sent: 0, failed: 0, invalidTokens: [], errors: [] };
+    }
+
+    const messages: ExpoPushMessage[] = uniqueTokens.map((token) => ({
+      to: token,
+      sound: "default",
+      title: input.title,
+      body: input.body,
+      data: input.data,
+    }));
+
+    let sent = 0;
+    let failed = 0;
+    const invalidTokens = new Set<string>();
+    const errors: PushDeliveryError[] = [];
+
+    for (const chunk of this.expo.chunkPushNotifications(messages)) {
+      let tickets: ExpoPushTicket[];
+      try {
+        tickets = await this.expo.sendPushNotificationsAsync(chunk);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.logger.error(
+          { tokenCount: chunk.length, error: message },
+          "Failed to send push notification chunk to Expo",
+        );
+        failed += chunk.length;
+        for (const pushMessage of chunk) {
+          if (typeof pushMessage.to !== "string") {
+            continue;
+          }
+          errors.push({
+            code: "SEND_CHUNK_FAILED",
+            retryable: true,
+            token: pushMessage.to,
+            message,
+          });
+        }
+        continue;
+      }
+      this.processTickets(
+        chunk,
+        tickets,
+        invalidTokens,
+        {
+          incrementSent: () => {
+            sent += 1;
+          },
+          incrementFailed: () => {
+            failed += 1;
+          },
+        },
+        errors,
+      );
+    }
+
+    return { sent, failed, invalidTokens: [...invalidTokens], errors };
+  }
+
+  private processTickets(
+    chunk: ExpoPushMessage[],
+    tickets: ExpoPushTicket[],
+    invalidTokens: Set<string>,
+    counters: { incrementSent: () => void; incrementFailed: () => void },
+    errors: PushDeliveryError[],
+  ): void {
+    tickets.forEach((ticket, index) => {
+      const token = chunk[index]?.to;
+      if (ticket.status === "ok") {
+        counters.incrementSent();
+        return;
+      }
+
+      const code = ticket.details?.error ?? "UNKNOWN";
+      const retryable = this.isRetryableTicketError(code);
+      const tokenValue = typeof token === "string" ? token : undefined;
+
+      if (code === "DeviceNotRegistered" && tokenValue) {
+        invalidTokens.add(tokenValue);
+      }
+
+      errors.push({
+        code,
+        retryable,
+        token: tokenValue,
+        message: ticket.message,
+      });
+
+      if (code !== "DeviceNotRegistered") {
+        counters.incrementFailed();
+      }
+    });
+  }
+
+  private isRetryableTicketError(code: string): boolean {
+    const nonRetryableErrors = new Set([
+      "DeviceNotRegistered",
+      "InvalidCredentials",
+      "MessageTooBig",
+    ]);
+    return !nonRetryableErrors.has(code);
+  }
+}

--- a/src/modules/notification/push.service.ts
+++ b/src/modules/notification/push.service.ts
@@ -3,30 +3,11 @@ import { ConfigService } from "@nestjs/config";
 import { Expo, type ExpoPushMessage, type ExpoPushTicket } from "expo-server-sdk";
 import { PinoLogger } from "nestjs-pino";
 import { EnvConfig } from "@/config/env.config";
-
-interface SendPushNotificationsInput {
-  tokens: string[];
-  title: string;
-  body: string;
-  data?: Record<string, string>;
-}
-
-interface SendPushNotificationsResult {
-  sent: number;
-  /**
-   * Retryable failures only (invalid/unregistered tokens are excluded).
-   */
-  failed: number;
-  invalidTokens: string[];
-  errors?: PushDeliveryError[];
-}
-
-interface PushDeliveryError {
-  code: string;
-  retryable: boolean;
-  token?: string;
-  message?: string;
-}
+import {
+  PushDeliveryError,
+  SendPushNotificationsInput,
+  SendPushNotificationsResult,
+} from "./push.interface";
 
 @Injectable()
 export class PushService {
@@ -139,7 +120,7 @@ export class PushService {
         message: ticket.message,
       });
 
-      if (code !== "DeviceNotRegistered") {
+      if (retryable) {
         counters.incrementFailed();
       }
     });

--- a/src/modules/notification/template-mappers/booking-status-mapper.ts
+++ b/src/modules/notification/template-mappers/booking-status-mapper.ts
@@ -5,7 +5,10 @@ import { BaseTemplateMapper } from "./base-template-mapper";
 
 export class BookingStatusMapper extends BaseTemplateMapper {
   canHandle(type: NotificationType): boolean {
-    return type === NotificationType.BOOKING_STATUS_CHANGE;
+    return (
+      type === NotificationType.BOOKING_STATUS_CHANGE ||
+      type === NotificationType.CHAUFFEUR_ASSIGNED
+    );
   }
 
   getTemplateKey(type: NotificationType, _recipientType: string): Template | null {

--- a/test/push-token.e2e-spec.ts
+++ b/test/push-token.e2e-spec.ts
@@ -1,0 +1,105 @@
+import type { INestApplication } from "@nestjs/common";
+import { Test, type TestingModule } from "@nestjs/testing";
+import request from "supertest";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
+import { AuthService } from "../src/modules/auth/auth.service";
+import { SessionGuard } from "../src/modules/auth/guards/session.guard";
+import { PushTokenController } from "../src/modules/notification/push-token.controller";
+import { PushTokenService } from "../src/modules/notification/push-token.service";
+import { mockPinoLoggerToken } from "../src/testing/nest-pino-logger.mock";
+
+describe("PushToken E2E", () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const authServiceMock = {
+      isInitialized: true,
+      auth: {
+        api: {
+          getSession: vi.fn().mockImplementation(({ headers }: { headers: Headers }) => {
+            const authHeader = headers.get("authorization");
+            if (authHeader !== "Bearer valid-session") {
+              return null;
+            }
+
+            return {
+              user: { id: "user-1", email: "john@example.com" },
+              session: {
+                id: "session-1",
+                userId: "user-1",
+                expiresAt: new Date("2030-01-01T00:00:00.000Z"),
+              },
+            };
+          }),
+        },
+      },
+      getUserRoles: vi.fn().mockResolvedValue(["user"]),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PushTokenController],
+      providers: [
+        SessionGuard,
+        {
+          provide: PushTokenService,
+          useValue: {
+            registerToken: vi.fn().mockResolvedValue(undefined),
+            revokeToken: vi.fn().mockResolvedValue(undefined),
+          },
+        },
+        {
+          provide: AuthService,
+          useValue: authServiceMock,
+        },
+      ],
+    })
+      .useMocker(mockPinoLoggerToken)
+      .compile();
+
+    app = module.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it("returns 401 for unauthenticated POST register route", async () => {
+    await request(app.getHttpServer())
+      .post("/api/users/me/push-tokens")
+      .send({
+        token: "ExponentPushToken[abc123]",
+        platform: "ios",
+      })
+      .expect(401);
+  });
+
+  it("returns 400 for authenticated POST with malformed body", async () => {
+    await request(app.getHttpServer())
+      .post("/api/users/me/push-tokens")
+      .set("Authorization", "Bearer valid-session")
+      .send({
+        platform: "ios",
+      })
+      .expect(400);
+  });
+
+  it("returns 401 for unauthenticated DELETE route", async () => {
+    await request(app.getHttpServer())
+      .delete("/api/users/me/push-tokens")
+      .send({
+        token: "ExponentPushToken[abc123]",
+      })
+      .expect(401);
+  });
+
+  it("returns 400 for authenticated DELETE with malformed body", async () => {
+    await request(app.getHttpServer())
+      .delete("/api/users/me/push-tokens")
+      .set("Authorization", "Bearer valid-session")
+      .send({
+        token: "invalid-token",
+      })
+      .expect(400);
+  });
+});


### PR DESCRIPTION
Add durable inbox and outbox notification models, token registration APIs, and Expo push processing so chauffeur assignment updates reach mobile users. Improve push error classification and stop retrying non-retryable failures.
## Summary

This PR adds durable mobile push notifications for chauffeur assignment events and hardens delivery reliability and observability.

- Adds notification persistence models and migrations:
  - `UserPushToken`
  - `NotificationInbox`
  - `NotificationOutboxEvent`
  - new enums/indexes in Prisma schema
- Adds authenticated push token APIs:
  - register token
  - revoke token
  - strict Expo token format validation
  - token ownership conflict protection
- Implements outbox-driven chauffeur assignment notification flow:
  - creates inbox/outbox records inside booking assignment transaction
  - scheduler processes pending outbox events
  - dispatches prepared notification jobs with dedupe and retry metadata
- Adds Expo push delivery channel support:
  - token dedup/filtering
  - invalid token revocation (`DeviceNotRegistered`)
  - structured error diagnostics (`errorCodeCounts`, sample errors)
  - non-retryable push failures (for example `InvalidCredentials`) now fail once via unrecoverable handling
- Extends notification contract + templates:
  - `NotificationChannel.PUSH`
  - `NotificationType.CHAUFFEUR_ASSIGNED`
  - booking status mapper updated for chauffeur assignment emails
- Improves local auth/CORS for mobile-on-LAN development:
  - shared origin pattern matching helper
  - development RFC1918 wildcard patterns
  - aligned Better Auth origin checks and Nest CORS origin checks
- Booking availability tweak:
  - allows `BOOKED` car status when no overlapping paid active bookings exist

## Why

- Ensure chauffeur assignment updates reach mobile users reliably.
- Decouple DB state change from notification dispatch using an outbox pattern.
- Reduce operational noise and wasted retries for known non-retryable push errors.
- Improve debuggability with explicit Expo ticket error classification and logs.
- Make local mobile development smoother across changing LAN IPs.

## Test Plan

- Added/updated unit tests for:
  - `notification-outbox.service`
  - `notification.processor`
  - `notification.service`
  - `push.service`
  - `push-token.service`
  - `push-token.controller`
  - `booking-update.service`
  - `booking-validation.service`
  - `auth/origin-pattern`
- Verified via test runs and pre-commit hooks:
  - `tsc --noEmit`
  - `vitest --run` (full suite passed)

## Notes

- Includes Prisma migration source files:
  - `prisma/migrations/20260502201100_add_user_push_tokens/migration.sql`
  - `prisma/migrations/20260502203400_add_notification_outbox_and_inbox/migration.sql`
- Keeps retry behavior for retryable push failures, but stops repeated attempts for non-retryable credential/config errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new notification persistence tables plus a scheduled outbox dispatcher and Expo push integration, touching booking assignment flow and queue retry semantics. Moderate risk due to new background processing, new CORS/origin matching behavior, and database migrations affecting production data.
> 
> **Overview**
> Adds an **outbox/inbox-backed notification pipeline** for chauffeur assignment: new Prisma models/migrations for `UserPushToken`, `NotificationInbox`, and `NotificationOutboxEvent`, plus an outbox worker (`NotificationOutboxService` + cron scheduler) that retries with backoff and dedupes queued jobs.
> 
> Introduces **Expo push delivery** (`expo-server-sdk`) with authenticated APIs to register/revoke tokens (`/api/users/me/push-tokens`), token ownership conflict handling, and automatic revocation of invalid tokens; expands the notification contract to include `NotificationChannel.PUSH` and `NotificationType.CHAUFFEUR_ASSIGNED`, and updates the queue processor to stop retries for non-retryable channel failures.
> 
> Ties notifications into booking operations by emitting an outbox event when `assignChauffeur` actually changes the chauffeur, adjusts booking availability/payment-state filters to treat `REFUND_PROCESSING` as paid-like, and aligns CORS origin checks with Better Auth using shared wildcard-capable origin pattern matching (including dev-only LAN patterns).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba0ea232144420821d3aa5d30f5871467d429a01. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->