### PR TITLE
feat(booking): allow fleet owners to access booking details

### DIFF
--- a/src/modules/booking/booking-read.service.spec.ts
+++ b/src/modules/booking/booking-read.service.spec.ts
@@ -7,6 +7,36 @@ import { BookingReadService } from "./booking-read.service";
 
 describe("BookingReadService", () => {
   let service: BookingReadService;
+  const customerSessionUser = {
+    id: "user-1",
+    email: "user@example.com",
+    name: "User One",
+    emailVerified: true,
+    image: null,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    roles: ["user" as const],
+  };
+  const fleetOwnerSessionUser = {
+    id: "owner-1",
+    email: "owner@example.com",
+    name: "Owner One",
+    emailVerified: true,
+    image: null,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    roles: ["fleetOwner" as const],
+  };
+  const adminSessionUser = {
+    id: "admin-1",
+    email: "admin@example.com",
+    name: "Admin One",
+    emailVerified: true,
+    image: null,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    roles: ["admin" as const],
+  };
   const databaseServiceMock = {
     booking: {
       findMany: vi.fn(),
@@ -69,7 +99,7 @@ describe("BookingReadService", () => {
       ],
     });
 
-    const result = await service.getBookingById("booking-123", "user-1");
+    const result = await service.getBookingById("booking-123", customerSessionUser);
 
     expect(result).toEqual({
       id: "booking-123",
@@ -80,12 +110,51 @@ describe("BookingReadService", () => {
     });
   });
 
-  it("throws BookingNotFoundException when booking does not exist for user", async () => {
+  it("returns booking details for the fleet owner that owns the booked car", async () => {
+    databaseServiceMock.booking.findFirst.mockResolvedValueOnce({
+      id: "booking-123",
+      userId: "user-2",
+      status: "CONFIRMED",
+      totalAmount: { toNumber: () => 12000 },
+      car: {
+        ownerId: "owner-1",
+      },
+    });
+
+    const result = await service.getBookingById("booking-123", fleetOwnerSessionUser);
+
+    expect(result).toEqual({
+      id: "booking-123",
+      userId: "user-2",
+      status: "CONFIRMED",
+      totalAmount: 12000,
+      car: {
+        ownerId: "owner-1",
+      },
+    });
+    expect(databaseServiceMock.booking.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: "booking-123",
+          OR: [{ car: { ownerId: "owner-1" } }],
+        },
+      }),
+    );
+  });
+
+  it("throws BookingNotFoundException when booking does not exist for customer", async () => {
     databaseServiceMock.booking.findFirst.mockResolvedValueOnce(null);
 
-    await expect(service.getBookingById("missing-booking", "user-1")).rejects.toBeInstanceOf(
+    await expect(
+      service.getBookingById("missing-booking", customerSessionUser),
+    ).rejects.toBeInstanceOf(BookingNotFoundException);
+  });
+
+  it("throws BookingNotFoundException when user has no supported booking access role", async () => {
+    await expect(service.getBookingById("booking-123", adminSessionUser)).rejects.toBeInstanceOf(
       BookingNotFoundException,
     );
+    expect(databaseServiceMock.booking.findFirst).not.toHaveBeenCalled();
   });
 
   it("throws BookingFetchFailedException when list query fails unexpectedly", async () => {
@@ -99,7 +168,7 @@ describe("BookingReadService", () => {
   it("throws BookingFetchFailedException when detail query fails unexpectedly", async () => {
     databaseServiceMock.booking.findFirst.mockRejectedValueOnce(new Error("DB down"));
 
-    await expect(service.getBookingById("booking-123", "user-1")).rejects.toBeInstanceOf(
+    await expect(service.getBookingById("booking-123", customerSessionUser)).rejects.toBeInstanceOf(
       BookingFetchFailedException,
     );
   });

--- a/src/modules/booking/booking-read.service.ts
+++ b/src/modules/booking/booking-read.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { PaymentStatus } from "@prisma/client";
 import { PinoLogger } from "nestjs-pino";
+import { FLEET_OWNER, USER } from "../auth/auth.const";
 import type { AuthSession } from "../auth/guards/session.guard";
 import { DatabaseService } from "../database/database.service";
 import {
@@ -89,10 +90,25 @@ export class BookingReadService {
     }
   }
 
-  async getBookingById(bookingId: string, userId: string) {
+  async getBookingById(bookingId: string, sessionUser: AuthSession["user"]) {
     try {
+      const canAccessAsBooker = sessionUser.roles.includes(USER);
+      const canAccessAsFleetOwner = sessionUser.roles.includes(FLEET_OWNER);
+
+      if (!canAccessAsBooker && !canAccessAsFleetOwner) {
+        throw new BookingNotFoundException();
+      }
+
+      const ownershipFilters = [
+        ...(canAccessAsBooker ? [{ userId: sessionUser.id }] : []),
+        ...(canAccessAsFleetOwner ? [{ car: { ownerId: sessionUser.id } }] : []),
+      ];
+
       const booking = await this.databaseService.booking.findFirst({
-        where: { id: bookingId, userId },
+        where: {
+          id: bookingId,
+          OR: ownershipFilters,
+        },
         include: this.bookingDetailsInclude,
       });
 
@@ -109,7 +125,7 @@ export class BookingReadService {
       this.logger.error(
         {
           bookingId,
-          userId,
+          userId: sessionUser.id,
           error: error instanceof Error ? error.message : String(error),
           stack: error instanceof Error ? error.stack : undefined,
         },

--- a/src/modules/booking/booking.controller.spec.ts
+++ b/src/modules/booking/booking.controller.spec.ts
@@ -422,7 +422,25 @@ describe("BookingController", () => {
       const result = await controller.getBookingById("booking-123", mockSessionUser);
 
       expect(result).toEqual(mockBookingDetail);
-      expect(bookingReadService.getBookingById).toHaveBeenCalledWith("booking-123", "user-123");
+      expect(bookingReadService.getBookingById).toHaveBeenCalledWith(
+        "booking-123",
+        mockSessionUser,
+      );
+    });
+
+    it("forwards fleet owner session user to booking read service", async () => {
+      const fleetOwnerSessionUser = {
+        ...mockSessionUser,
+        id: "owner-123",
+        roles: ["fleetOwner" as const],
+      };
+
+      await controller.getBookingById("booking-123", fleetOwnerSessionUser);
+
+      expect(bookingReadService.getBookingById).toHaveBeenCalledWith(
+        "booking-123",
+        fleetOwnerSessionUser,
+      );
     });
 
     it("propagates BookingNotFoundException when booking does not exist", async () => {

--- a/src/modules/booking/booking.controller.ts
+++ b/src/modules/booking/booking.controller.ts
@@ -119,7 +119,7 @@ export class BookingController {
     @ZodParam("bookingId", bookingIdParamSchema) bookingId: string,
     @CurrentUser() sessionUser: AuthSession["user"],
   ) {
-    return this.bookingReadService.getBookingById(bookingId, sessionUser.id);
+    return this.bookingReadService.getBookingById(bookingId, sessionUser);
   }
 
   @Patch(":bookingId")


### PR DESCRIPTION
Allow booking details to be fetched by either the booking customer or the owner of the booked car. Add focused service and controller tests for user and fleet-owner access behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands access-control logic for booking detail reads to include fleet owners; incorrect filtering could expose other customers’ booking data if role/ownership checks are wrong.
> 
> **Overview**
> **Booking detail access is expanded beyond the booking customer.** `BookingReadService.getBookingById` now accepts the full `sessionUser` and authorizes reads for either the booking `userId` (*customer*) or `car.ownerId` (*fleet owner*), rejecting unsupported roles up-front.
> 
> The `GET /api/bookings/:bookingId` controller path is updated to pass `sessionUser` through, and tests are updated/added to cover customer access, fleet-owner access, and denial for unsupported roles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 341b88644a2cd1ac6e7975b9c8d08c60f77f2905. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->