### PR TITLE
fix(notification): make push token registration idempotent

### DIFF
--- a/src/modules/notification/push-token.service.spec.ts
+++ b/src/modules/notification/push-token.service.spec.ts
@@ -9,16 +9,24 @@ describe("PushTokenService", () => {
   let service: PushTokenService;
 
   const databaseServiceMock = {
+    $transaction: vi.fn(),
     userPushToken: {
       upsert: vi.fn(),
       findMany: vi.fn(),
       findUnique: vi.fn(),
       updateMany: vi.fn(),
+      $executeRaw: vi.fn(),
     },
   };
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    databaseServiceMock.$transaction.mockImplementation(async (callback) =>
+      callback({
+        $executeRaw: databaseServiceMock.userPushToken.$executeRaw,
+        userPushToken: databaseServiceMock.userPushToken,
+      }),
+    );
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -41,6 +49,8 @@ describe("PushTokenService", () => {
 
     await service.registerToken("user-1", "ExponentPushToken[abc123]", "ios");
 
+    expect(databaseServiceMock.$transaction).toHaveBeenCalledTimes(1);
+    expect(databaseServiceMock.userPushToken.$executeRaw).toHaveBeenCalledTimes(1);
     expect(databaseServiceMock.userPushToken.findUnique).toHaveBeenCalledWith({
       where: { token: "ExponentPushToken[abc123]" },
       select: { userId: true, revokedAt: true },

--- a/src/modules/notification/push-token.service.spec.ts
+++ b/src/modules/notification/push-token.service.spec.ts
@@ -1,5 +1,4 @@
 import { Test, type TestingModule } from "@nestjs/testing";
-import { Prisma } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mockPinoLoggerToken } from "@/testing/nest-pino-logger.mock";
 import { DatabaseService } from "../database/database.service";
@@ -10,20 +9,16 @@ describe("PushTokenService", () => {
   let service: PushTokenService;
 
   const databaseServiceMock = {
-    $transaction: vi.fn(),
     userPushToken: {
-      create: vi.fn(),
-      updateMany: vi.fn(),
+      upsert: vi.fn(),
       findMany: vi.fn(),
       findUnique: vi.fn(),
+      updateMany: vi.fn(),
     },
   };
 
   beforeEach(async () => {
     vi.clearAllMocks();
-    databaseServiceMock.$transaction.mockImplementation(async (callback) =>
-      callback(databaseServiceMock),
-    );
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -40,52 +35,66 @@ describe("PushTokenService", () => {
     service = module.get<PushTokenService>(PushTokenService);
   });
 
-  it("registers token by creating a new ownership record when token does not exist", async () => {
-    databaseServiceMock.userPushToken.create.mockResolvedValueOnce(undefined);
+  it("registers token by creating or updating through idempotent upsert", async () => {
+    databaseServiceMock.userPushToken.findUnique.mockResolvedValueOnce(null);
+    databaseServiceMock.userPushToken.upsert.mockResolvedValueOnce(undefined);
 
     await service.registerToken("user-1", "ExponentPushToken[abc123]", "ios");
 
-    expect(databaseServiceMock.userPushToken.create).toHaveBeenCalledWith(
+    expect(databaseServiceMock.userPushToken.findUnique).toHaveBeenCalledWith({
+      where: { token: "ExponentPushToken[abc123]" },
+      select: { userId: true, revokedAt: true },
+    });
+    expect(databaseServiceMock.userPushToken.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({
+        where: { token: "ExponentPushToken[abc123]" },
+        create: expect.objectContaining({
           userId: "user-1",
           token: "ExponentPushToken[abc123]",
           platform: "IOS",
         }),
+        update: expect.objectContaining({
+          userId: "user-1",
+          platform: "IOS",
+          revokedAt: null,
+        }),
       }),
     );
-    expect(databaseServiceMock.userPushToken.updateMany).not.toHaveBeenCalled();
-    expect(databaseServiceMock.userPushToken.findUnique).not.toHaveBeenCalled();
   });
 
-  it("re-activates token when same owner re-registers a previously revoked token", async () => {
-    databaseServiceMock.userPushToken.create.mockRejectedValueOnce(createUniqueConstraintError());
-    databaseServiceMock.userPushToken.updateMany.mockResolvedValueOnce({ count: 1 });
+  it("re-activates token for same owner with upsert", async () => {
+    databaseServiceMock.userPushToken.findUnique.mockResolvedValueOnce({
+      userId: "user-1",
+      revokedAt: new Date("2025-01-01T00:00:00.000Z"),
+    });
+    databaseServiceMock.userPushToken.upsert.mockResolvedValueOnce(undefined);
 
     await service.registerToken("user-1", "ExponentPushToken[abc123]", "ios");
 
-    expect(databaseServiceMock.userPushToken.updateMany).toHaveBeenCalledWith(
+    expect(databaseServiceMock.userPushToken.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: {
-          token: "ExponentPushToken[abc123]",
-          OR: [{ userId: "user-1" }, { revokedAt: { not: null } }],
-        },
+        update: expect.objectContaining({
+          userId: "user-1",
+          platform: "IOS",
+          revokedAt: null,
+        }),
       }),
     );
   });
 
   it("allows re-registering a token previously revoked by another user", async () => {
-    databaseServiceMock.userPushToken.create.mockRejectedValueOnce(createUniqueConstraintError());
-    databaseServiceMock.userPushToken.updateMany.mockResolvedValueOnce({ count: 1 });
+    databaseServiceMock.userPushToken.findUnique.mockResolvedValueOnce({
+      userId: "user-2",
+      revokedAt: new Date("2025-01-01T00:00:00.000Z"),
+    });
+    databaseServiceMock.userPushToken.upsert.mockResolvedValueOnce(undefined);
 
     await service.registerToken("user-1", "ExponentPushToken[abc123]", "ios");
 
-    expect(databaseServiceMock.userPushToken.updateMany).toHaveBeenCalled();
+    expect(databaseServiceMock.userPushToken.upsert).toHaveBeenCalled();
   });
 
-  it("rejects ownership transfer when token becomes active for another user during concurrent registration", async () => {
-    databaseServiceMock.userPushToken.create.mockRejectedValueOnce(createUniqueConstraintError());
-    databaseServiceMock.userPushToken.updateMany.mockResolvedValueOnce({ count: 0 });
+  it("rejects ownership transfer when token is actively owned by another user", async () => {
     databaseServiceMock.userPushToken.findUnique.mockResolvedValueOnce({
       userId: "user-2",
       revokedAt: null,
@@ -94,19 +103,7 @@ describe("PushTokenService", () => {
     await expect(
       service.registerToken("user-1", "ExponentPushToken[abc123]", "ios"),
     ).rejects.toBeInstanceOf(PushTokenOwnershipConflictException);
-    expect(databaseServiceMock.userPushToken.updateMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: {
-          token: "ExponentPushToken[abc123]",
-          OR: [{ userId: "user-1" }, { revokedAt: { not: null } }],
-        },
-        data: {
-          userId: "user-1",
-          platform: "IOS",
-          revokedAt: null,
-        },
-      }),
-    );
+    expect(databaseServiceMock.userPushToken.upsert).not.toHaveBeenCalled();
   });
 
   it("revokes token for the current user", async () => {
@@ -159,9 +156,3 @@ describe("PushTokenService", () => {
     });
   });
 });
-
-function createUniqueConstraintError() {
-  return Object.assign(Object.create(Prisma.PrismaClientKnownRequestError.prototype), {
-    code: "P2002",
-  });
-}

--- a/src/modules/notification/push-token.service.ts
+++ b/src/modules/notification/push-token.service.ts
@@ -15,34 +15,39 @@ export class PushTokenService {
 
   async registerToken(userId: string, token: string, platform: "ios" | "android"): Promise<void> {
     const pushPlatform = this.toPushPlatform(platform);
-    const existing = await this.databaseService.userPushToken.findUnique({
-      where: { token },
-      select: { userId: true, revokedAt: true },
-    });
+    await this.databaseService.$transaction(async (tx) => {
+      // Serialize concurrent registrations for the same token to avoid ownership races.
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${token}))`;
 
-    if (existing && existing.userId !== userId && existing.revokedAt === null) {
-      this.logger.warn(
-        {
-          requestingUserId: userId,
-          ownerUserId: existing.userId,
+      const existing = await tx.userPushToken.findUnique({
+        where: { token },
+        select: { userId: true, revokedAt: true },
+      });
+
+      if (existing && existing.userId !== userId && existing.revokedAt === null) {
+        this.logger.warn(
+          {
+            requestingUserId: userId,
+            ownerUserId: existing.userId,
+          },
+          "Rejected push token registration owned by a different active user",
+        );
+        throw new PushTokenOwnershipConflictException();
+      }
+
+      await tx.userPushToken.upsert({
+        where: { token },
+        create: {
+          userId,
+          token,
+          platform: pushPlatform,
         },
-        "Rejected push token registration owned by a different active user",
-      );
-      throw new PushTokenOwnershipConflictException();
-    }
-
-    await this.databaseService.userPushToken.upsert({
-      where: { token },
-      create: {
-        userId,
-        token,
-        platform: pushPlatform,
-      },
-      update: {
-        userId,
-        platform: pushPlatform,
-        revokedAt: null,
-      },
+        update: {
+          userId,
+          platform: pushPlatform,
+          revokedAt: null,
+        },
+      });
     });
   }
 

--- a/src/modules/notification/push-token.service.ts
+++ b/src/modules/notification/push-token.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@nestjs/common";
-import { Prisma, PushPlatform } from "@prisma/client";
+import { PushPlatform } from "@prisma/client";
 import { PinoLogger } from "nestjs-pino";
 import { DatabaseService } from "../database/database.service";
 import { PushTokenOwnershipConflictException } from "./notification.error";
@@ -14,64 +14,35 @@ export class PushTokenService {
   }
 
   async registerToken(userId: string, token: string, platform: "ios" | "android"): Promise<void> {
-    await this.databaseService.$transaction(async (tx) => {
-      const pushPlatform = this.toPushPlatform(platform);
+    const pushPlatform = this.toPushPlatform(platform);
+    const existing = await this.databaseService.userPushToken.findUnique({
+      where: { token },
+      select: { userId: true, revokedAt: true },
+    });
 
-      try {
-        await tx.userPushToken.create({
-          data: {
-            userId,
-            token,
-            platform: pushPlatform,
-          },
-        });
-        return;
-      } catch (error) {
-        if (!this.isUniqueConstraintError(error)) {
-          throw error;
-        }
-      }
-
-      const updateResult = await tx.userPushToken.updateMany({
-        where: {
-          token,
-          OR: [{ userId }, { revokedAt: { not: null } }],
+    if (existing && existing.userId !== userId && existing.revokedAt === null) {
+      this.logger.warn(
+        {
+          requestingUserId: userId,
+          ownerUserId: existing.userId,
         },
-        data: {
-          userId,
-          platform: pushPlatform,
-          revokedAt: null,
-        },
-      });
+        "Rejected push token registration owned by a different active user",
+      );
+      throw new PushTokenOwnershipConflictException();
+    }
 
-      if (updateResult.count > 0) {
-        return;
-      }
-
-      const existing = await tx.userPushToken.findUnique({
-        where: { token },
-        select: { userId: true, revokedAt: true },
-      });
-
-      if (existing && existing.userId !== userId && existing.revokedAt === null) {
-        this.logger.warn(
-          {
-            requestingUserId: userId,
-            ownerUserId: existing.userId,
-          },
-          "Rejected push token registration owned by a different active user",
-        );
-        throw new PushTokenOwnershipConflictException();
-      }
-
-      // Defensive retry for transient row disappearance between write attempts.
-      await tx.userPushToken.create({
-        data: {
-          userId,
-          token,
-          platform: pushPlatform,
-        },
-      });
+    await this.databaseService.userPushToken.upsert({
+      where: { token },
+      create: {
+        userId,
+        token,
+        platform: pushPlatform,
+      },
+      update: {
+        userId,
+        platform: pushPlatform,
+        revokedAt: null,
+      },
     });
   }
 
@@ -123,9 +94,5 @@ export class PushTokenService {
 
   private toPushPlatform(platform: "ios" | "android"): PushPlatform {
     return platform === "ios" ? PushPlatform.IOS : PushPlatform.ANDROID;
-  }
-
-  private isUniqueConstraintError(error: unknown): boolean {
-    return error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002";
   }
 }

--- a/test/push-token.e2e-spec.ts
+++ b/test/push-token.e2e-spec.ts
@@ -4,14 +4,24 @@ import request from "supertest";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { AuthService } from "../src/modules/auth/auth.service";
 import { SessionGuard } from "../src/modules/auth/guards/session.guard";
+import { PushTokenOwnershipConflictException } from "../src/modules/notification/notification.error";
 import { PushTokenController } from "../src/modules/notification/push-token.controller";
 import { PushTokenService } from "../src/modules/notification/push-token.service";
 import { mockPinoLoggerToken } from "../src/testing/nest-pino-logger.mock";
 
 describe("PushToken E2E", () => {
   let app: INestApplication;
+  let pushTokenServiceMock: {
+    registerToken: ReturnType<typeof vi.fn>;
+    revokeToken: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(async () => {
+    pushTokenServiceMock = {
+      registerToken: vi.fn().mockResolvedValue(undefined),
+      revokeToken: vi.fn().mockResolvedValue(undefined),
+    };
+
     const authServiceMock = {
       isInitialized: true,
       auth: {
@@ -42,10 +52,7 @@ describe("PushToken E2E", () => {
         SessionGuard,
         {
           provide: PushTokenService,
-          useValue: {
-            registerToken: vi.fn().mockResolvedValue(undefined),
-            revokeToken: vi.fn().mockResolvedValue(undefined),
-          },
+          useValue: pushTokenServiceMock,
         },
         {
           provide: AuthService,
@@ -82,6 +89,21 @@ describe("PushToken E2E", () => {
         platform: "ios",
       })
       .expect(400);
+  });
+
+  it("returns 409 when push token is actively owned by another user", async () => {
+    pushTokenServiceMock.registerToken.mockRejectedValueOnce(
+      new PushTokenOwnershipConflictException(),
+    );
+
+    await request(app.getHttpServer())
+      .post("/api/users/me/push-tokens")
+      .set("Authorization", "Bearer valid-session")
+      .send({
+        token: "ExponentPushToken[abc123]",
+        platform: "ios",
+      })
+      .expect(409);
   });
 
   it("returns 401 for unauthenticated DELETE route", async () => {


### PR DESCRIPTION
Prevent duplicate-token login failures by replacing exception-based writes with an ownership check and upsert, plus tests for conflict and re-registration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes push-token registration write semantics and introduces a PostgreSQL advisory lock via `$executeRaw`, which could affect concurrency behavior and database portability if misused.
> 
> **Overview**
> Push token registration is refactored to be **idempotent and race-resistant**: it now takes an advisory transaction lock per token, checks for an existing active owner, and then uses a single `upsert` to (re)activate or create the token record instead of relying on unique-constraint exceptions and `updateMany`.
> 
> Unit tests are updated to validate the new transaction/lock + `upsert` flow and ownership-conflict behavior, and an E2E test is added to assert the API returns `409` when `PushTokenOwnershipConflictException` is raised.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 207ea37ec2fadbbaf5cd47f64b14e557a0e95699. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->