### PR TITLE
feat: referral signup, pricing eligibility, API summary fields, and E2E coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,9 @@
       "protobufjs": "7.5.6",
       "fast-uri": "3.1.2",
       "@protobufjs/utf8": "1.1.1",
-      "hono": "4.12.16"
+      "hono": "4.12.16",
+      "langsmith": "0.7.1",
+      "next": "16.2.6"
     },
     "ignoredBuiltDependencies": [
       "@nestjs/core",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
       "fast-xml-parser": "5.5.7",
       "follow-redirects": "1.16.0",
       "flatted": "3.4.2",
-      "kysely": "0.28.14",
+      "kysely": "0.28.17",
       "lodash": "4.17.23",
       "minimatch": "10.2.3",
       "multer": "2.1.1",
@@ -134,7 +134,9 @@
       "rollup": "4.59.0",
       "defu": "6.1.5",
       "vite": "7.3.2",
-      "protobufjs": "7.5.5",
+      "protobufjs": "7.5.6",
+      "fast-uri": "3.1.2",
+      "@protobufjs/utf8": "1.1.1",
       "hono": "4.12.16"
     },
     "ignoredBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,8 @@ overrides:
   fast-uri: 3.1.2
   '@protobufjs/utf8': 1.1.1
   hono: 4.12.16
+  langsmith: 0.7.1
+  next: 16.2.6
 
 importers:
 
@@ -122,7 +124,7 @@ importers:
         version: 1.15.2
       better-auth:
         specifier: ^1.4.18
-        version: 1.5.6(@opentelemetry/api@1.9.1)(@prisma/client@7.6.0(prisma@7.6.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(magicast@0.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(next@16.2.3(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(pg@8.20.0)(prisma@7.6.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(magicast@0.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.2.4)
+        version: 1.5.6(@opentelemetry/api@1.9.1)(@prisma/client@7.6.0(prisma@7.6.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(magicast@0.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(pg@8.20.0)(prisma@7.6.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(magicast@0.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.2.4)
       bullmq:
         specifier: ^5.63.0
         version: 5.71.1
@@ -1680,53 +1682,53 @@ packages:
       '@nestjs/core': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
       reflect-metadata: ^0.1.13 || ^0.2.0
 
-  '@next/env@16.2.3':
-    resolution: {integrity: sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==}
+  '@next/env@16.2.6':
+    resolution: {integrity: sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==}
 
-  '@next/swc-darwin-arm64@16.2.3':
-    resolution: {integrity: sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==}
+  '@next/swc-darwin-arm64@16.2.6':
+    resolution: {integrity: sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.3':
-    resolution: {integrity: sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==}
+  '@next/swc-darwin-x64@16.2.6':
+    resolution: {integrity: sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.2.3':
-    resolution: {integrity: sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==}
+  '@next/swc-linux-arm64-gnu@16.2.6':
+    resolution: {integrity: sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@16.2.3':
-    resolution: {integrity: sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==}
+  '@next/swc-linux-arm64-musl@16.2.6':
+    resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@16.2.3':
-    resolution: {integrity: sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==}
+  '@next/swc-linux-x64-gnu@16.2.6':
+    resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@16.2.3':
-    resolution: {integrity: sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==}
+  '@next/swc-linux-x64-musl@16.2.6':
+    resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@16.2.3':
-    resolution: {integrity: sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==}
+  '@next/swc-win32-arm64-msvc@16.2.6':
+    resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.3':
-    resolution: {integrity: sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==}
+  '@next/swc-win32-x64-msvc@16.2.6':
+    resolution: {integrity: sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -3079,9 +3081,6 @@ packages:
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
 
-  '@types/uuid@10.0.0':
-    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
-
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -3416,7 +3415,7 @@ packages:
       drizzle-orm: '>=0.41.0'
       mongodb: ^6.0.0 || ^7.0.0
       mysql2: ^3.0.0
-      next: ^14.0.0 || ^15.0.0 || ^16.0.0
+      next: 16.2.6
       pg: ^8.0.0
       prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
       react: ^18.0.0 || ^19.0.0
@@ -3731,9 +3730,6 @@ packages:
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
-
-  console-table-printer@2.15.0:
-    resolution: {integrity: sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==}
 
   content-disposition@1.0.1:
     resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
@@ -4696,8 +4692,8 @@ packages:
     resolution: {integrity: sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==}
     engines: {node: '>=20.0.0'}
 
-  langsmith@0.5.15:
-    resolution: {integrity: sha512-S20JnYmIgqGBjA/WEn12ZZJjqd03O5wd8K9KgGBvsKXQBn0bYuFrr1w20L37PpcMmX3/cftpgJ6g2y8KoEmHLw==}
+  langsmith@0.7.1:
+    resolution: {integrity: sha512-Wjk90UjNoY5cBHMlNAC/eZx5clI8jnjBOBW8uJu8+MWBtx0QesNjsUiLtjI+I3UnrpxFFpDqGXcnhBjH654Mqg==}
     peerDependencies:
       '@opentelemetry/api': '*'
       '@opentelemetry/exporter-trace-otlp-proto': '*'
@@ -5000,8 +4996,8 @@ packages:
       pino-http: ^6.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
       rxjs: ^7.1.0
 
-  next@16.2.3:
-    resolution: {integrity: sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==}
+  next@16.2.6:
+    resolution: {integrity: sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -5626,9 +5622,6 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
-
-  simple-wcswidth@1.1.2:
-    resolution: {integrity: sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==}
 
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
@@ -7544,7 +7537,7 @@ snapshots:
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.21
-      langsmith: 0.5.15(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.18.3)(zod@4.3.6))(ws@8.18.3)
+      langsmith: 0.7.1(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.18.3)(zod@4.3.6))(ws@8.18.3)
       mustache: 4.2.0
       p-queue: 6.6.2
       uuid: 11.1.0
@@ -7768,30 +7761,30 @@ snapshots:
       '@nestjs/core': 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       reflect-metadata: 0.1.14
 
-  '@next/env@16.2.3': {}
+  '@next/env@16.2.6': {}
 
-  '@next/swc-darwin-arm64@16.2.3':
+  '@next/swc-darwin-arm64@16.2.6':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.3':
+  '@next/swc-darwin-x64@16.2.6':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.3':
+  '@next/swc-linux-arm64-gnu@16.2.6':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.3':
+  '@next/swc-linux-arm64-musl@16.2.6':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.3':
+  '@next/swc-linux-x64-gnu@16.2.6':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.3':
+  '@next/swc-linux-x64-musl@16.2.6':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.3':
+  '@next/swc-win32-arm64-msvc@16.2.6':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.3':
+  '@next/swc-win32-x64-msvc@16.2.6':
     optional: true
 
   '@noble/ciphers@2.1.1': {}
@@ -8795,7 +8788,7 @@ snapshots:
   '@react-email/ui@6.0.1(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       esbuild: 0.28.0
-      next: 16.2.3(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@opentelemetry/api'
@@ -9494,8 +9487,6 @@ snapshots:
     dependencies:
       '@types/node': 20.19.37
 
-  '@types/uuid@10.0.0': {}
-
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 20.19.37
@@ -9864,7 +9855,7 @@ snapshots:
     dependencies:
       tweetnacl: 0.14.5
 
-  better-auth@1.5.6(@opentelemetry/api@1.9.1)(@prisma/client@7.6.0(prisma@7.6.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(magicast@0.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(next@16.2.3(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(pg@8.20.0)(prisma@7.6.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(magicast@0.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.2.4):
+  better-auth@1.5.6(@opentelemetry/api@1.9.1)(@prisma/client@7.6.0(prisma@7.6.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(magicast@0.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(pg@8.20.0)(prisma@7.6.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(magicast@0.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.2.4):
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0)
       '@better-auth/drizzle-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
@@ -9886,7 +9877,7 @@ snapshots:
     optionalDependencies:
       '@prisma/client': 7.6.0(prisma@7.6.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(magicast@0.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3)
       mysql2: 3.15.3
-      next: 16.2.3(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       pg: 8.20.0
       prisma: 7.6.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(magicast@0.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       react: 18.3.1
@@ -10195,10 +10186,6 @@ snapshots:
   confbox@0.2.4: {}
 
   consola@3.4.2: {}
-
-  console-table-printer@2.15.0:
-    dependencies:
-      simple-wcswidth: 1.1.2
 
   content-disposition@1.0.1: {}
 
@@ -11243,14 +11230,9 @@ snapshots:
 
   kysely@0.28.17: {}
 
-  langsmith@0.5.15(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.18.3)(zod@4.3.6))(ws@8.18.3):
+  langsmith@0.7.1(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.18.3)(zod@4.3.6))(ws@8.18.3):
     dependencies:
-      '@types/uuid': 10.0.0
-      chalk: 5.6.2
-      console-table-printer: 2.15.0
       p-queue: 6.6.2
-      semver: 7.7.4
-      uuid: 10.0.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/exporter-trace-otlp-proto': 0.215.0(@opentelemetry/api@1.9.1)
@@ -11478,9 +11460,9 @@ snapshots:
       pino-http: 11.0.0
       rxjs: 7.8.2
 
-  next@16.2.3(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@next/env': 16.2.3
+      '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.13
       caniuse-lite: 1.0.30001782
@@ -11489,14 +11471,14 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       styled-jsx: 5.1.6(react@18.3.1)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.3
-      '@next/swc-darwin-x64': 16.2.3
-      '@next/swc-linux-arm64-gnu': 16.2.3
-      '@next/swc-linux-arm64-musl': 16.2.3
-      '@next/swc-linux-x64-gnu': 16.2.3
-      '@next/swc-linux-x64-musl': 16.2.3
-      '@next/swc-win32-arm64-msvc': 16.2.3
-      '@next/swc-win32-x64-msvc': 16.2.3
+      '@next/swc-darwin-arm64': 16.2.6
+      '@next/swc-darwin-x64': 16.2.6
+      '@next/swc-linux-arm64-gnu': 16.2.6
+      '@next/swc-linux-arm64-musl': 16.2.6
+      '@next/swc-linux-x64-gnu': 16.2.6
+      '@next/swc-linux-x64-musl': 16.2.6
+      '@next/swc-win32-arm64-msvc': 16.2.6
+      '@next/swc-win32-x64-msvc': 16.2.6
       '@opentelemetry/api': 1.9.1
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -12235,8 +12217,6 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
-
-  simple-wcswidth@1.1.2: {}
 
   sirv@3.0.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   fast-xml-parser: 5.5.7
   follow-redirects: 1.16.0
   flatted: 3.4.2
-  kysely: 0.28.14
+  kysely: 0.28.17
   lodash: 4.17.23
   minimatch: 10.2.3
   multer: 2.1.1
@@ -21,7 +21,9 @@ overrides:
   rollup: 4.59.0
   defu: 6.1.5
   vite: 7.3.2
-  protobufjs: 7.5.5
+  protobufjs: 7.5.6
+  fast-uri: 3.1.2
+  '@protobufjs/utf8': 1.1.1
   hono: 4.12.16
 
 importers:
@@ -33,7 +35,7 @@ importers:
         version: 3.1020.0
       '@better-auth/prisma-adapter':
         specifier: ^1.5.3
-        version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@prisma/client@7.6.0(prisma@7.6.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(magicast@0.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3))(prisma@7.6.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(magicast@0.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))
+        version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@prisma/client@7.6.0(prisma@7.6.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(magicast@0.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3))(prisma@7.6.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(magicast@0.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))
       '@bull-board/api':
         specifier: ^6.14.0
         version: 6.20.6(@bull-board/ui@6.20.6)
@@ -529,7 +531,7 @@ packages:
       '@opentelemetry/api': ^1.9.0
       better-call: 1.3.2
       jose: ^6.1.0
-      kysely: 0.28.14
+      kysely: 0.28.17
       nanostores: ^1.0.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
@@ -550,7 +552,7 @@ packages:
     peerDependencies:
       '@better-auth/core': 1.5.6
       '@better-auth/utils': ^0.3.0
-      kysely: 0.28.14
+      kysely: 0.28.17
     peerDependenciesMeta:
       kysely:
         optional: true
@@ -2375,8 +2377,8 @@ packages:
   '@protobufjs/base64@1.1.2':
     resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
 
-  '@protobufjs/codegen@2.0.4':
-    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
 
   '@protobufjs/eventemitter@1.1.0':
     resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
@@ -2387,8 +2389,8 @@ packages:
   '@protobufjs/float@1.0.2':
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
 
-  '@protobufjs/inquire@1.1.0':
-    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+  '@protobufjs/inquire@1.1.1':
+    resolution: {integrity: sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==}
 
   '@protobufjs/path@1.1.2':
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
@@ -2396,8 +2398,8 @@ packages:
   '@protobufjs/pool@1.1.0':
     resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
 
-  '@protobufjs/utf8@1.1.0':
-    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
@@ -4182,8 +4184,8 @@ packages:
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-xml-builder@1.1.4:
     resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
@@ -4690,8 +4692,8 @@ packages:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
 
-  kysely@0.28.14:
-    resolution: {integrity: sha512-SU3lgh0rPvq7upc6vvdVrCsSMUG1h3ChvHVOY7wJ2fw4C9QEB7X3d5eyYEyULUX7UQtxZJtZXGuT6U2US72UYA==}
+  kysely@0.28.17:
+    resolution: {integrity: sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==}
     engines: {node: '>=20.0.0'}
 
   langsmith@0.5.15:
@@ -5351,8 +5353,8 @@ packages:
     resolution: {integrity: sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==}
     engines: {node: '>=18'}
 
-  protobufjs@7.5.5:
-    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
+  protobufjs@7.5.6:
+    resolution: {integrity: sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -6797,7 +6799,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)':
+  '@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0)':
     dependencies:
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
@@ -6806,43 +6808,43 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       better-call: 1.3.2(zod@4.3.6)
       jose: 6.2.2
-      kysely: 0.28.14
+      kysely: 0.28.17
       nanostores: 1.2.0
       zod: 4.3.6
 
-  '@better-auth/drizzle-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
+  '@better-auth/drizzle-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
     dependencies:
-      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
 
-  '@better-auth/kysely-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(kysely@0.28.14)':
+  '@better-auth/kysely-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(kysely@0.28.17)':
     dependencies:
-      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
     optionalDependencies:
-      kysely: 0.28.14
+      kysely: 0.28.17
 
-  '@better-auth/memory-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
+  '@better-auth/memory-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
     dependencies:
-      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
 
-  '@better-auth/mongo-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
+  '@better-auth/mongo-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
     dependencies:
-      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
 
-  '@better-auth/prisma-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@prisma/client@7.6.0(prisma@7.6.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(magicast@0.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3))(prisma@7.6.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(magicast@0.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))':
+  '@better-auth/prisma-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@prisma/client@7.6.0(prisma@7.6.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(magicast@0.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3))(prisma@7.6.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(magicast@0.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))':
     dependencies:
-      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
     optionalDependencies:
       '@prisma/client': 7.6.0(prisma@7.6.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(magicast@0.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3)
       prisma: 7.6.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(magicast@0.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
 
-  '@better-auth/telemetry@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))':
+  '@better-auth/telemetry@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))':
     dependencies:
-      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
 
@@ -7245,14 +7247,14 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.5
+      protobufjs: 7.5.6
       yargs: 17.7.2
 
   '@grpc/proto-loader@0.8.0':
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.5
+      protobufjs: 7.5.6
       yargs: 17.7.2
 
   '@hono/node-server@1.19.11(hono@4.12.16)':
@@ -8436,7 +8438,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.206.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.1.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.1.0(@opentelemetry/api@1.9.1)
-      protobufjs: 7.5.5
+      protobufjs: 7.5.6
 
   '@opentelemetry/otlp-transformer@0.215.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -8447,7 +8449,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.215.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
-      protobufjs: 7.5.5
+      protobufjs: 7.5.6
 
   '@opentelemetry/propagator-b3@2.7.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -8708,24 +8710,24 @@ snapshots:
 
   '@protobufjs/base64@1.1.2': {}
 
-  '@protobufjs/codegen@2.0.4': {}
+  '@protobufjs/codegen@2.0.5': {}
 
   '@protobufjs/eventemitter@1.1.0': {}
 
   '@protobufjs/fetch@1.1.0':
     dependencies:
       '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/inquire': 1.1.1
 
   '@protobufjs/float@1.0.2': {}
 
-  '@protobufjs/inquire@1.1.0': {}
+  '@protobufjs/inquire@1.1.1': {}
 
   '@protobufjs/path@1.1.2': {}
 
   '@protobufjs/pool@1.1.0': {}
 
-  '@protobufjs/utf8@1.1.0': {}
+  '@protobufjs/utf8@1.1.1': {}
 
   '@radix-ui/primitive@1.1.3': {}
 
@@ -9716,7 +9718,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -9864,13 +9866,13 @@ snapshots:
 
   better-auth@1.5.6(@opentelemetry/api@1.9.1)(@prisma/client@7.6.0(prisma@7.6.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(magicast@0.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(next@16.2.3(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(pg@8.20.0)(prisma@7.6.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(magicast@0.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.2.4):
     dependencies:
-      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
-      '@better-auth/drizzle-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
-      '@better-auth/kysely-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(kysely@0.28.14)
-      '@better-auth/memory-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
-      '@better-auth/mongo-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
-      '@better-auth/prisma-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@prisma/client@7.6.0(prisma@7.6.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(magicast@0.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3))(prisma@7.6.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(magicast@0.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))
-      '@better-auth/telemetry': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0)
+      '@better-auth/drizzle-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
+      '@better-auth/kysely-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(kysely@0.28.17)
+      '@better-auth/memory-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
+      '@better-auth/mongo-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
+      '@better-auth/prisma-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@prisma/client@7.6.0(prisma@7.6.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(magicast@0.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3))(prisma@7.6.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(magicast@0.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))
+      '@better-auth/telemetry': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.1.1
@@ -9878,7 +9880,7 @@ snapshots:
       better-call: 1.3.2(zod@4.3.6)
       defu: 6.1.5
       jose: 6.2.2
-      kysely: 0.28.14
+      kysely: 0.28.17
       nanostores: 1.2.0
       zod: 4.3.6
     optionalDependencies:
@@ -10369,7 +10371,7 @@ snapshots:
       '@grpc/grpc-js': 1.14.3
       '@grpc/proto-loader': 0.7.15
       docker-modem: 5.0.7
-      protobufjs: 7.5.5
+      protobufjs: 7.5.6
       tar-fs: 2.1.4
       uuid: 10.0.0
     transitivePeerDependencies:
@@ -10680,7 +10682,7 @@ snapshots:
 
   fast-sha256@1.3.0: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fast-xml-builder@1.1.4:
     dependencies:
@@ -11239,7 +11241,7 @@ snapshots:
 
   kleur@3.0.3: {}
 
-  kysely@0.28.14: {}
+  kysely@0.28.17: {}
 
   langsmith@0.5.15(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.18.3)(zod@4.3.6))(ws@8.18.3):
     dependencies:
@@ -11850,18 +11852,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  protobufjs@7.5.5:
+  protobufjs@7.5.6:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/codegen': 2.0.5
       '@protobufjs/eventemitter': 1.1.0
       '@protobufjs/fetch': 1.1.0
       '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/inquire': 1.1.1
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.0
+      '@protobufjs/utf8': 1.1.1
       '@types/node': 20.19.37
       long: 5.3.2
 

--- a/src/modules/auth/auth.config.ts
+++ b/src/modules/auth/auth.config.ts
@@ -15,6 +15,8 @@ export interface RoleValidationCallbacks {
   validateRoleForClient: (params: ValidateRoleForClientParams) => boolean;
   /** Validates that an existing user has the requested role */
   validateExistingUserRole: (email: string, role: RoleName) => Promise<boolean>;
+  /** Checks whether an email already belongs to a user */
+  isExistingUser: (email: string) => Promise<boolean>;
   /** Assigns a role to a newly created user (called from databaseHooks.user.create.after) */
   assignRoleToNewUser: (userId: string, role: RoleName) => Promise<void>;
   /** Generates and stores a referral code for a newly created user */
@@ -251,7 +253,7 @@ export function createAuth(options: AuthConfigOptions) {
           setPendingRole(email, role);
 
           const referralCode = extractReferralCode(ctx.body);
-          if (referralCode) {
+          if (referralCode && !(await roleValidation.isExistingUser(email))) {
             const attribution = await roleValidation.validateReferralCodeForSignup(
               referralCode,
               email,

--- a/src/modules/auth/auth.config.ts
+++ b/src/modules/auth/auth.config.ts
@@ -17,6 +17,18 @@ export interface RoleValidationCallbacks {
   validateExistingUserRole: (email: string, role: RoleName) => Promise<boolean>;
   /** Assigns a role to a newly created user (called from databaseHooks.user.create.after) */
   assignRoleToNewUser: (userId: string, role: RoleName) => Promise<void>;
+  /** Generates and stores a referral code for a newly created user */
+  assignReferralCodeToNewUser: (userId: string) => Promise<string>;
+  /** Validates a referral code and returns the referrer user ID for new user attribution */
+  validateReferralCodeForSignup: (
+    code: string,
+    email: string,
+  ) => Promise<{ referrerUserId: string; referralCode: string } | null>;
+  /** Assigns referral attribution to a newly created user */
+  assignReferralToNewUser: (
+    userId: string,
+    attribution: { referrerUserId: string; referralCode: string },
+  ) => Promise<void>;
   /** Gets all roles for a user (used by after hook to enrich sign-in response) */
   getUserRoles: (userId: string) => Promise<RoleName[]>;
 }
@@ -36,6 +48,10 @@ export interface RoleValidationCallbacks {
  * TTL cleanup prevents memory leaks from abandoned OTP flows.
  */
 const pendingRoles = new Map<string, { role: RoleName; timestamp: number }>();
+const pendingReferrals = new Map<
+  string,
+  { referrerUserId: string; referralCode: string; timestamp: number }
+>();
 const PENDING_ROLE_TTL_MS = 10 * 60 * 1000; // 10 minutes (matches OTP expiry)
 
 /**
@@ -48,6 +64,11 @@ function cleanupExpiredPendingRoles(): void {
       pendingRoles.delete(email);
     }
   }
+  for (const [email, entry] of pendingReferrals) {
+    if (now - entry.timestamp > PENDING_ROLE_TTL_MS) {
+      pendingReferrals.delete(email);
+    }
+  }
 }
 
 /**
@@ -56,10 +77,20 @@ function cleanupExpiredPendingRoles(): void {
  */
 function setPendingRole(email: string, role: RoleName): void {
   // Clean up old entries periodically to prevent unbounded growth
-  if (pendingRoles.size > 100) {
+  if (pendingRoles.size > 100 || pendingReferrals.size > 100) {
     cleanupExpiredPendingRoles();
   }
   pendingRoles.set(email, { role, timestamp: Date.now() });
+}
+
+function setPendingReferral(
+  email: string,
+  attribution: { referrerUserId: string; referralCode: string },
+): void {
+  if (pendingRoles.size > 100 || pendingReferrals.size > 100) {
+    cleanupExpiredPendingRoles();
+  }
+  pendingReferrals.set(email, { ...attribution, timestamp: Date.now() });
 }
 
 /**
@@ -77,6 +108,22 @@ function consumePendingRole(email: string): RoleName {
     }
   }
   return USER;
+}
+
+function consumePendingReferral(
+  email: string,
+): { referrerUserId: string; referralCode: string } | null {
+  const entry = pendingReferrals.get(email);
+  if (entry) {
+    pendingReferrals.delete(email);
+    if (Date.now() - entry.timestamp <= PENDING_ROLE_TTL_MS) {
+      return {
+        referrerUserId: entry.referrerUserId,
+        referralCode: entry.referralCode,
+      };
+    }
+  }
+  return null;
 }
 
 export interface AuthConfigOptions {
@@ -117,6 +164,14 @@ function extractEmail(body: unknown): string | undefined {
 function extractRole(body: unknown): unknown {
   if (body && typeof body === "object" && "role" in body) {
     return (body as { role: unknown }).role;
+  }
+  return undefined;
+}
+
+function extractReferralCode(body: unknown): string | undefined {
+  if (body && typeof body === "object" && "referralCode" in body) {
+    const referralCode = (body as { referralCode: unknown }).referralCode;
+    return typeof referralCode === "string" ? referralCode.trim().toUpperCase() : undefined;
   }
   return undefined;
 }
@@ -194,6 +249,20 @@ export function createAuth(options: AuthConfigOptions) {
           // This is necessary because Better Auth's email-otp plugin strips
           // custom fields (like 'role') from the request body during validation.
           setPendingRole(email, role);
+
+          const referralCode = extractReferralCode(ctx.body);
+          if (referralCode) {
+            const attribution = await roleValidation.validateReferralCodeForSignup(
+              referralCode,
+              email,
+            );
+            if (!attribution) {
+              throw new APIError("BAD_REQUEST", {
+                message: "Invalid referral code",
+              });
+            }
+            setPendingReferral(email, attribution);
+          }
         }
       })
     : undefined;
@@ -276,6 +345,12 @@ export function createAuth(options: AuthConfigOptions) {
                 // Assign the role to the newly created user
                 // Protected roles were already rejected in the before hook via validateExistingUserRole()
                 await roleValidation.assignRoleToNewUser(user.id, role);
+                await roleValidation.assignReferralCodeToNewUser(user.id);
+
+                const referralAttribution = consumePendingReferral(user.email);
+                if (referralAttribution) {
+                  await roleValidation.assignReferralToNewUser(user.id, referralAttribution);
+                }
               },
             },
           },

--- a/src/modules/auth/auth.error.ts
+++ b/src/modules/auth/auth.error.ts
@@ -8,6 +8,7 @@ export const AuthErrorCode = {
   AUTH_PROTECTED_ROLE_ASSIGNMENT_DENIED: "AUTH_PROTECTED_ROLE_ASSIGNMENT_DENIED",
   AUTH_INVALID_ROLE: "AUTH_INVALID_ROLE",
   AUTH_USER_NOT_FOUND_FOR_ROLE_ASSIGNMENT: "AUTH_USER_NOT_FOUND_FOR_ROLE_ASSIGNMENT",
+  AUTH_REFERRAL_CODE_GENERATION_FAILED: "AUTH_REFERRAL_CODE_GENERATION_FAILED",
   AUTH_ROLE_REQUIREMENT_FAILED: "AUTH_ROLE_REQUIREMENT_FAILED",
   AUTH_SESSION_NOT_FOUND: "AUTH_SESSION_NOT_FOUND",
   AUTH_INSUFFICIENT_ROLE: "AUTH_INSUFFICIENT_ROLE",
@@ -38,5 +39,11 @@ export class AuthForbiddenException extends AuthException {
 export class AuthNotFoundException extends AuthException {
   constructor(errorCode: AuthErrorCodeValue, detail: string, title: string) {
     super(errorCode, detail, HttpStatus.NOT_FOUND, { title });
+  }
+}
+
+export class AuthInternalServerException extends AuthException {
+  constructor(errorCode: AuthErrorCodeValue, detail: string, title: string) {
+    super(errorCode, detail, HttpStatus.INTERNAL_SERVER_ERROR, { title });
   }
 }

--- a/src/modules/auth/auth.service.spec.ts
+++ b/src/modules/auth/auth.service.spec.ts
@@ -1,5 +1,6 @@
 import { ConfigService } from "@nestjs/config";
 import { Test, TestingModule } from "@nestjs/testing";
+import { Prisma } from "@prisma/client";
 import { EnvConfig } from "src/config/env.config";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mockPinoLoggerToken } from "@/testing/nest-pino-logger.mock";
@@ -8,6 +9,7 @@ import { ADMIN, FLEET_OWNER, MOBILE, STAFF, USER, WEB } from "./auth.const";
 import {
   AuthErrorCode,
   type AuthErrorCodeValue,
+  AuthInternalServerException,
   AuthNotFoundException,
   AuthUnauthorizedException,
 } from "./auth.error";
@@ -31,9 +33,13 @@ describe("AuthService", () => {
   };
 
   const mockDatabaseService: {
+    $transaction?: ReturnType<typeof vi.fn>;
     user?: {
       findUnique: ReturnType<typeof vi.fn>;
       update?: ReturnType<typeof vi.fn>;
+    };
+    referralAttribution?: {
+      create: ReturnType<typeof vi.fn>;
     };
   } = {};
 
@@ -782,6 +788,128 @@ describe("AuthService", () => {
         errorCode: AuthErrorCode.AUTH_PROTECTED_ROLE_ASSIGNMENT_DENIED,
         title: "Protected Role Assignment Denied",
         detail: 'Protected role "staff" cannot be assigned to new users',
+      });
+    });
+  });
+
+  describe("referral signup attribution", () => {
+    beforeEach(async () => {
+      await setupTestModule();
+
+      mockDatabaseService.user = {
+        findUnique: vi.fn(),
+        update: vi.fn(),
+      };
+      mockDatabaseService.referralAttribution = {
+        create: vi.fn(),
+      };
+      mockDatabaseService.$transaction = vi.fn(async (callback) =>
+        callback({
+          user: mockDatabaseService.user,
+          referralAttribution: mockDatabaseService.referralAttribution,
+        }),
+      );
+    });
+
+    it("validates referral code and normalizes code casing", async () => {
+      mockDatabaseService.user.findUnique.mockResolvedValue({
+        id: "referrer-1",
+        email: "referrer@example.com",
+        referralCode: "FLOWREF1",
+      });
+
+      const result = await service.validateReferralCodeForSignup(
+        " flowref1 ",
+        "new-user@example.com",
+      );
+
+      expect(mockDatabaseService.user.findUnique).toHaveBeenCalledWith({
+        where: { referralCode: "FLOWREF1" },
+        select: { id: true, email: true, referralCode: true },
+      });
+      expect(result).toEqual({
+        referrerUserId: "referrer-1",
+        referralCode: "FLOWREF1",
+      });
+    });
+
+    it("rejects invalid and self-referral codes", async () => {
+      mockDatabaseService.user.findUnique.mockResolvedValueOnce(null);
+      await expect(
+        service.validateReferralCodeForSignup("MISSING1", "new@example.com"),
+      ).resolves.toBe(null);
+
+      mockDatabaseService.user.findUnique.mockResolvedValueOnce({
+        id: "referrer-1",
+        email: "same@example.com",
+        referralCode: "SELFREF1",
+      });
+      await expect(
+        service.validateReferralCodeForSignup("SELFREF1", "same@example.com"),
+      ).resolves.toBe(null);
+    });
+
+    it("assigns a new referral code to a newly created user", async () => {
+      mockDatabaseService.user.findUnique.mockResolvedValue({ referralCode: null });
+      mockDatabaseService.user.update.mockResolvedValue({});
+
+      const referralCode = await service.assignReferralCodeToNewUser("user-1");
+
+      expect(referralCode).toMatch(/^[A-Z2-9]{8}$/);
+      expect(mockDatabaseService.user.update).toHaveBeenCalledWith({
+        where: { id: "user-1" },
+        data: { referralCode },
+      });
+    });
+
+    it("keeps an existing referral code unchanged", async () => {
+      mockDatabaseService.user.findUnique.mockResolvedValue({ referralCode: "EXIST123" });
+
+      const referralCode = await service.assignReferralCodeToNewUser("user-1");
+
+      expect(referralCode).toBe("EXIST123");
+      expect(mockDatabaseService.user.update).not.toHaveBeenCalled();
+    });
+
+    it("throws an auth exception when referral code generation exhausts retries", async () => {
+      mockDatabaseService.user.findUnique.mockResolvedValue({ referralCode: null });
+      mockDatabaseService.user.update.mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+          code: "P2002",
+          clientVersion: "test",
+        }),
+      );
+
+      await expectProblemDetail(service.assignReferralCodeToNewUser("user-1"), {
+        errorClass: AuthInternalServerException,
+        errorCode: AuthErrorCode.AUTH_REFERRAL_CODE_GENERATION_FAILED,
+        title: "Referral Code Generation Failed",
+        detail: "Failed to generate a unique referral code. Please try again.",
+      });
+      expect(mockDatabaseService.user.update).toHaveBeenCalledTimes(5);
+    });
+
+    it("assigns referral attribution to a newly created user", async () => {
+      await service.assignReferralToNewUser("user-1", {
+        referrerUserId: "referrer-1",
+        referralCode: "FLOWREF1",
+      });
+
+      expect(mockDatabaseService.user.update).toHaveBeenCalledWith({
+        where: { id: "user-1" },
+        data: {
+          referredByUserId: "referrer-1",
+          referralAttributionSource: "LINK",
+          referralSignupAt: expect.any(Date),
+        },
+      });
+      expect(mockDatabaseService.referralAttribution.create).toHaveBeenCalledWith({
+        data: {
+          refereeUserId: "user-1",
+          referrerUserId: "referrer-1",
+          referralCode: "FLOWREF1",
+          source: "LINK",
+        },
       });
     });
   });

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -1,5 +1,7 @@
+import { randomInt } from "node:crypto";
 import { Injectable, OnModuleInit } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
+import { Prisma, ReferralAttributionSource } from "@prisma/client";
 import { PinoLogger } from "nestjs-pino";
 import type { EnvConfig } from "../../config/env.config";
 import { DatabaseService } from "../database/database.service";
@@ -15,6 +17,7 @@ import {
 } from "./auth.const";
 import {
   AuthErrorCode,
+  AuthInternalServerException,
   AuthNotFoundException,
   AuthServiceUnavailableException,
   AuthUnauthorizedException,
@@ -22,6 +25,10 @@ import {
 import type { RoleName, ValidateRoleForClientParams } from "./auth.interface";
 import { AuthEmailService } from "./auth-email.service";
 import { getDevLanOriginPatterns, isOriginAllowed } from "./origin-pattern";
+
+const REFERRAL_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+const REFERRAL_CODE_LENGTH = 8;
+const REFERRAL_CODE_GENERATION_ATTEMPTS = 5;
 
 @Injectable()
 export class AuthService implements OnModuleInit {
@@ -64,6 +71,9 @@ export class AuthService implements OnModuleInit {
         validateRoleForClient: this.validateRoleForClient.bind(this),
         validateExistingUserRole: this.validateExistingUserRole.bind(this),
         assignRoleToNewUser: this.assignRoleToNewUser.bind(this),
+        assignReferralCodeToNewUser: this.assignReferralCodeToNewUser.bind(this),
+        validateReferralCodeForSignup: this.validateReferralCodeForSignup.bind(this),
+        assignReferralToNewUser: this.assignReferralToNewUser.bind(this),
         getUserRoles: this.getUserRoles.bind(this),
       },
     });
@@ -294,6 +304,111 @@ export class AuthService implements OnModuleInit {
         "Invalid Role",
       );
     }
+  }
+
+  async assignReferralCodeToNewUser(userId: string): Promise<string> {
+    const user = await this.databaseService.user.findUnique({
+      where: { id: userId },
+      select: { referralCode: true },
+    });
+
+    if (!user) {
+      this.logger.warn({ userId }, "Cannot assign referral code: user not found");
+      throw new AuthNotFoundException(
+        AuthErrorCode.AUTH_USER_NOT_FOUND_FOR_ROLE_ASSIGNMENT,
+        "User not found for referral code assignment",
+        "User Not Found For Referral Code Assignment",
+      );
+    }
+
+    if (user.referralCode) {
+      return user.referralCode;
+    }
+
+    for (let attempt = 0; attempt < REFERRAL_CODE_GENERATION_ATTEMPTS; attempt += 1) {
+      const referralCode = this.generateReferralCode();
+
+      try {
+        await this.databaseService.user.update({
+          where: { id: userId },
+          data: { referralCode },
+        });
+        return referralCode;
+      } catch (error) {
+        if (!this.isUniqueConstraintError(error)) {
+          throw error;
+        }
+      }
+    }
+
+    throw new AuthInternalServerException(
+      AuthErrorCode.AUTH_REFERRAL_CODE_GENERATION_FAILED,
+      "Failed to generate a unique referral code. Please try again.",
+      "Referral Code Generation Failed",
+    );
+  }
+
+  private generateReferralCode(): string {
+    return Array.from({ length: REFERRAL_CODE_LENGTH }, () =>
+      REFERRAL_CODE_ALPHABET.charAt(randomInt(REFERRAL_CODE_ALPHABET.length)),
+    ).join("");
+  }
+
+  private isUniqueConstraintError(error: unknown): boolean {
+    return error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002";
+  }
+
+  async validateReferralCodeForSignup(
+    code: string,
+    email: string,
+  ): Promise<{ referrerUserId: string; referralCode: string } | null> {
+    const normalizedCode = code.trim().toUpperCase();
+    if (!normalizedCode) {
+      return null;
+    }
+
+    const referrer = await this.databaseService.user.findUnique({
+      where: { referralCode: normalizedCode },
+      select: { id: true, email: true, referralCode: true },
+    });
+
+    if (!referrer?.referralCode) {
+      return null;
+    }
+
+    if (email.trim().toLowerCase() === referrer.email.toLowerCase()) {
+      return null;
+    }
+
+    return {
+      referrerUserId: referrer.id,
+      referralCode: referrer.referralCode,
+    };
+  }
+
+  async assignReferralToNewUser(
+    userId: string,
+    attribution: { referrerUserId: string; referralCode: string },
+  ): Promise<void> {
+    await this.databaseService.$transaction(async (tx) => {
+      await tx.user.update({
+        where: { id: userId },
+        data: {
+          referredByUserId: attribution.referrerUserId,
+          referralAttributionSource: ReferralAttributionSource.LINK,
+          referralSignupAt: new Date(),
+        },
+      });
+
+      await tx.referralAttribution.create({
+        data: {
+          refereeUserId: userId,
+          referrerUserId: attribution.referrerUserId,
+          referralCode: attribution.referralCode,
+          source: ReferralAttributionSource.LINK,
+        },
+      });
+    });
   }
 
   /**

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -70,6 +70,7 @@ export class AuthService implements OnModuleInit {
       roleValidation: {
         validateRoleForClient: this.validateRoleForClient.bind(this),
         validateExistingUserRole: this.validateExistingUserRole.bind(this),
+        isExistingUser: this.isExistingUser.bind(this),
         assignRoleToNewUser: this.assignRoleToNewUser.bind(this),
         assignReferralCodeToNewUser: this.assignReferralCodeToNewUser.bind(this),
         validateReferralCodeForSignup: this.validateReferralCodeForSignup.bind(this),
@@ -275,6 +276,15 @@ export class AuthService implements OnModuleInit {
 
     // Existing user - must have the role
     return user.roles.some((r) => r.name === role);
+  }
+
+  async isExistingUser(email: string): Promise<boolean> {
+    const user = await this.databaseService.user.findUnique({
+      where: { email },
+      select: { id: true },
+    });
+
+    return Boolean(user);
   }
 
   /**

--- a/src/modules/booking/booking-creation.service.spec.ts
+++ b/src/modules/booking/booking-creation.service.spec.ts
@@ -105,7 +105,7 @@ describe("BookingCreationService", () => {
           useValue: {
             car: { findUnique: vi.fn() },
             user: { findUnique: vi.fn(), update: vi.fn() },
-            booking: { create: vi.fn(), update: vi.fn(), updateMany: vi.fn() },
+            booking: { create: vi.fn(), update: vi.fn(), updateMany: vi.fn(), findFirst: vi.fn() },
             flight: { upsert: vi.fn() },
             referralProgramConfig: { findMany: vi.fn(), findFirst: vi.fn() },
             referralReward: { create: vi.fn() },

--- a/src/modules/booking/booking-creation.service.ts
+++ b/src/modules/booking/booking-creation.service.ts
@@ -153,13 +153,7 @@ export class BookingCreationService {
       }),
     );
 
-    // Preliminary eligibility check for price calculation
-    // For authenticated users: check session data for preliminary eligibility
-    // Actual eligibility is verified inside the transaction with fresh DB query to prevent race conditions
-    const preliminaryReferralEligibility =
-      await this.eligibilityService.checkPreliminaryReferralEligibility(sessionUser);
-
-    const financials = await this.calculationService.calculateBookingCost({
+    const baseFinancials = await this.calculationService.calculateBookingCost({
       bookingType: normalizedBooking.bookingType,
       legs,
       car,
@@ -170,8 +164,32 @@ export class BookingCreationService {
       creditsToUse: normalizedBooking.useCredits
         ? new Decimal(normalizedBooking.useCredits)
         : undefined,
-      referralDiscountAmount: preliminaryReferralEligibility.discountAmount,
+      referralDiscountAmount: new Decimal(0),
     });
+
+    // Preliminary eligibility check for price calculation.
+    // Actual eligibility is verified inside the transaction with fresh DB query to prevent races.
+    const preliminaryReferralEligibility =
+      await this.eligibilityService.checkReferralEligibilityForPricing(
+        sessionUser,
+        baseFinancials.subtotalBeforeDiscounts,
+        normalizedBooking.bookingType,
+      );
+
+    const financials = preliminaryReferralEligibility.discountAmount.gt(0)
+      ? await this.calculationService.calculateBookingCost({
+          bookingType: normalizedBooking.bookingType,
+          legs,
+          car,
+          includeSecurityDetail: normalizedBooking.includeSecurityDetail,
+          requiresFullTank: normalizedBooking.requiresFullTank,
+          userCreditsBalance: undefined,
+          creditsToUse: normalizedBooking.useCredits
+            ? new Decimal(normalizedBooking.useCredits)
+            : undefined,
+          referralDiscountAmount: preliminaryReferralEligibility.discountAmount,
+        })
+      : baseFinancials;
 
     this.validationService.validatePriceMatch(
       normalizedBooking.clientTotalAmount,

--- a/src/modules/booking/booking-eligibility.service.spec.ts
+++ b/src/modules/booking/booking-eligibility.service.spec.ts
@@ -126,6 +126,7 @@ describe("BookingEligibilityService", () => {
             createUser({ referredByUserId: "referrer-1", referralDiscountUsed: false }),
           ),
       },
+      booking: { findFirst: vi.fn().mockResolvedValue(null) },
       referralProgramConfig: {
         findMany: vi.fn().mockResolvedValue([
           { key: "REFERRAL_ENABLED", value: true },

--- a/src/modules/booking/booking-eligibility.service.spec.ts
+++ b/src/modules/booking/booking-eligibility.service.spec.ts
@@ -146,6 +146,91 @@ describe("BookingEligibilityService", () => {
     });
   });
 
+  it("returns pricing eligibility when referred user meets amount and booking type rules", async () => {
+    const databaseService = {
+      user: {
+        findUnique: vi
+          .fn()
+          .mockResolvedValue(
+            createUser({ referredByUserId: "referrer-1", referralDiscountUsed: false }),
+          ),
+      },
+      booking: { findFirst: vi.fn().mockResolvedValue(null) },
+      referralProgramConfig: {
+        findMany: vi.fn().mockResolvedValue([
+          { key: "REFERRAL_ENABLED", value: true },
+          { key: "REFERRAL_DISCOUNT_AMOUNT", value: "5000" },
+          { key: "REFERRAL_MIN_BOOKING_AMOUNT", value: "20000" },
+          { key: "REFERRAL_ELIGIBLE_TYPES", value: ["DAY", "FULL_DAY"] },
+          { key: "REFERRAL_EXPIRY_DAYS", value: 30 },
+        ]),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BookingEligibilityService,
+        { provide: DatabaseService, useValue: databaseService },
+      ],
+    })
+      .useMocker(mockPinoLoggerToken)
+      .compile();
+
+    const service = module.get<BookingEligibilityService>(BookingEligibilityService);
+    const result = await service.checkReferralEligibilityForPricing(
+      { id: "user-1" } as never,
+      new Decimal(52500),
+      "DAY",
+    );
+
+    expect(result).toEqual({
+      eligible: true,
+      referrerUserId: "referrer-1",
+      discountAmount: new Decimal(5000),
+    });
+  });
+
+  it("returns ineligible for pricing when another active booking reserved the discount", async () => {
+    const databaseService = {
+      user: {
+        findUnique: vi
+          .fn()
+          .mockResolvedValue(
+            createUser({ referredByUserId: "referrer-1", referralDiscountUsed: false }),
+          ),
+      },
+      booking: { findFirst: vi.fn().mockResolvedValue({ id: "booking-1" }) },
+      referralProgramConfig: {
+        findMany: vi.fn().mockResolvedValue([
+          { key: "REFERRAL_ENABLED", value: true },
+          { key: "REFERRAL_DISCOUNT_AMOUNT", value: "5000" },
+        ]),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BookingEligibilityService,
+        { provide: DatabaseService, useValue: databaseService },
+      ],
+    })
+      .useMocker(mockPinoLoggerToken)
+      .compile();
+
+    const service = module.get<BookingEligibilityService>(BookingEligibilityService);
+    const result = await service.checkReferralEligibilityForPricing(
+      { id: "user-1" } as never,
+      new Decimal(52500),
+      "DAY",
+    );
+
+    expect(result).toEqual({
+      eligible: false,
+      referrerUserId: null,
+      discountAmount: new Decimal(0),
+    });
+  });
+
   it("increments totalReferrals when creating referral reward stats", async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [

--- a/src/modules/booking/booking-eligibility.service.spec.ts
+++ b/src/modules/booking/booking-eligibility.service.spec.ts
@@ -25,7 +25,11 @@ describe("BookingEligibilityService", () => {
       .compile();
 
     const service = module.get<BookingEligibilityService>(BookingEligibilityService);
-    const result = await service.checkPreliminaryReferralEligibility(null);
+    const result = await service.checkReferralEligibilityForPricing(
+      null,
+      new Decimal(50000),
+      "DAY",
+    );
 
     expect(result).toEqual({
       eligible: false,
@@ -43,6 +47,7 @@ describe("BookingEligibilityService", () => {
             createUser({ referredByUserId: "referrer-1", referralDiscountUsed: false }),
           ),
       },
+      booking: { findFirst: vi.fn().mockResolvedValue(null) },
       referralProgramConfig: {
         findMany: vi.fn().mockResolvedValue([
           { key: "REFERRAL_ENABLED", value: true },
@@ -61,9 +66,11 @@ describe("BookingEligibilityService", () => {
       .compile();
 
     const service = module.get<BookingEligibilityService>(BookingEligibilityService);
-    const result = await service.checkPreliminaryReferralEligibility({
-      id: "user-1",
-    } as never);
+    const result = await service.checkReferralEligibilityForPricing(
+      { id: "user-1" } as never,
+      new Decimal(25000),
+      "DAY",
+    );
 
     expect(result).toEqual({
       eligible: true,
@@ -137,7 +144,11 @@ describe("BookingEligibilityService", () => {
       .compile();
 
     const service = module.get<BookingEligibilityService>(BookingEligibilityService);
-    const result = await service.checkPreliminaryReferralEligibility({ id: "user-1" } as never);
+    const result = await service.checkReferralEligibilityForPricing(
+      { id: "user-1" } as never,
+      new Decimal(25000),
+      "DAY",
+    );
 
     expect(result).toEqual({
       eligible: false,

--- a/src/modules/booking/booking-eligibility.service.ts
+++ b/src/modules/booking/booking-eligibility.service.ts
@@ -26,28 +26,6 @@ export class BookingEligibilityService {
     return { eligible: false, referrerUserId: null, discountAmount: new Decimal(0) };
   }
 
-  async checkPreliminaryReferralEligibility(
-    sessionUser: AuthSession["user"] | null,
-  ): Promise<ReferralEligibility> {
-    if (!sessionUser) {
-      return this.getIneligibleReferralEligibility();
-    }
-
-    const user = await this.databaseService.user.findUnique({
-      where: { id: sessionUser.id },
-      select: {
-        referredByUserId: true,
-        referralDiscountUsed: true,
-      },
-    });
-
-    if (!user?.referredByUserId || user.referralDiscountUsed) {
-      return this.getIneligibleReferralEligibility();
-    }
-
-    return this.getReferralConfig(user.referredByUserId);
-  }
-
   async checkReferralEligibilityForPricing(
     sessionUser: AuthSession["user"] | null,
     bookingAmount: Decimal,
@@ -219,29 +197,6 @@ export class BookingEligibilityService {
       },
       "Created pending referral reward",
     );
-  }
-
-  private async getReferralConfig(referrerUserId: string): Promise<ReferralEligibility> {
-    const configMap = await this.getReferralConfigMap(this.databaseService.referralProgramConfig, [
-      "REFERRAL_ENABLED",
-      "REFERRAL_DISCOUNT_AMOUNT",
-    ]);
-
-    const isEnabled = this.parseEnabledConfig(configMap.REFERRAL_ENABLED);
-    const discountAmount = this.parseDecimalConfig(
-      configMap.REFERRAL_DISCOUNT_AMOUNT,
-      "REFERRAL_DISCOUNT_AMOUNT",
-    );
-
-    if (!isEnabled || discountAmount.lte(0)) {
-      return this.getIneligibleReferralEligibility();
-    }
-
-    return {
-      eligible: true,
-      referrerUserId,
-      discountAmount,
-    };
   }
 
   private async getReferralPricingConfig(): Promise<{

--- a/src/modules/booking/booking-eligibility.service.ts
+++ b/src/modules/booking/booking-eligibility.service.ts
@@ -1,5 +1,11 @@
 import { Injectable } from "@nestjs/common";
-import { Prisma, ReferralReleaseCondition, ReferralRewardStatus } from "@prisma/client";
+import {
+  BookingReferralStatus,
+  BookingStatus,
+  Prisma,
+  ReferralReleaseCondition,
+  ReferralRewardStatus,
+} from "@prisma/client";
 import Decimal from "decimal.js";
 import { PinoLogger } from "nestjs-pino";
 import type { AuthSession } from "../auth/guards/session.guard";
@@ -40,6 +46,72 @@ export class BookingEligibilityService {
     }
 
     return this.getReferralConfig(user.referredByUserId);
+  }
+
+  async checkReferralEligibilityForPricing(
+    sessionUser: AuthSession["user"] | null,
+    bookingAmount: Decimal,
+    bookingType: string,
+  ): Promise<ReferralEligibility> {
+    if (!sessionUser) {
+      return this.getIneligibleReferralEligibility();
+    }
+
+    const user = await this.databaseService.user.findUnique({
+      where: { id: sessionUser.id },
+      select: {
+        referredByUserId: true,
+        referralDiscountUsed: true,
+        referralSignupAt: true,
+      },
+    });
+
+    if (!user?.referredByUserId || user.referralDiscountUsed) {
+      return this.getIneligibleReferralEligibility();
+    }
+
+    const config = await this.getReferralPricingConfig();
+    if (!config.enabled || config.discountAmount.lte(0)) {
+      return this.getIneligibleReferralEligibility();
+    }
+
+    const existingReserved = await this.databaseService.booking.findFirst({
+      where: {
+        userId: sessionUser.id,
+        referralStatus: { in: [BookingReferralStatus.APPLIED, BookingReferralStatus.REWARDED] },
+        status: {
+          in: [BookingStatus.PENDING, BookingStatus.CONFIRMED, BookingStatus.ACTIVE],
+        },
+      },
+      select: { id: true },
+    });
+
+    if (existingReserved) {
+      return this.getIneligibleReferralEligibility();
+    }
+
+    if (bookingAmount.lt(config.minBookingAmount)) {
+      return this.getIneligibleReferralEligibility();
+    }
+
+    if (!config.eligibleTypes.includes(bookingType)) {
+      return this.getIneligibleReferralEligibility();
+    }
+
+    if (config.expiryDays > 0 && user.referralSignupAt) {
+      const expiryDate = new Date(user.referralSignupAt);
+      expiryDate.setDate(expiryDate.getDate() + config.expiryDays);
+
+      if (new Date() > expiryDate) {
+        return this.getIneligibleReferralEligibility();
+      }
+    }
+
+    return {
+      eligible: true,
+      referrerUserId: user.referredByUserId,
+      discountAmount: Decimal.min(config.discountAmount, bookingAmount),
+    };
   }
 
   async verifyAndClaimReferralDiscountInTransaction(
@@ -172,6 +244,40 @@ export class BookingEligibilityService {
     };
   }
 
+  private async getReferralPricingConfig(): Promise<{
+    enabled: boolean;
+    discountAmount: Decimal;
+    minBookingAmount: Decimal;
+    eligibleTypes: string[];
+    expiryDays: number;
+  }> {
+    const configMap = await this.getReferralConfigMap(this.databaseService.referralProgramConfig, [
+      "REFERRAL_ENABLED",
+      "REFERRAL_DISCOUNT_AMOUNT",
+      "REFERRAL_MIN_BOOKING_AMOUNT",
+      "REFERRAL_ELIGIBLE_TYPES",
+      "REFERRAL_EXPIRY_DAYS",
+    ]);
+
+    return {
+      enabled: this.parseEnabledConfig(configMap.REFERRAL_ENABLED ?? true),
+      discountAmount: this.parseDecimalConfig(
+        configMap.REFERRAL_DISCOUNT_AMOUNT ?? 10000,
+        "REFERRAL_DISCOUNT_AMOUNT",
+      ),
+      minBookingAmount: this.parseDecimalConfig(
+        configMap.REFERRAL_MIN_BOOKING_AMOUNT ?? 20000,
+        "REFERRAL_MIN_BOOKING_AMOUNT",
+      ),
+      eligibleTypes: this.parseStringArrayConfig(configMap.REFERRAL_ELIGIBLE_TYPES, [
+        "DAY",
+        "NIGHT",
+        "FULL_DAY",
+      ]),
+      expiryDays: this.parseNumberConfig(configMap.REFERRAL_EXPIRY_DAYS ?? 30, 30),
+    };
+  }
+
   private async getReferralConfigMap(
     referralProgramConfigModel: Pick<Prisma.TransactionClient["referralProgramConfig"], "findMany">,
     keys: string[],
@@ -216,6 +322,25 @@ export class BookingEligibilityService {
       `Invalid ${key} config value type`,
     );
     return new Decimal(0);
+  }
+
+  private parseNumberConfig(rawValue: unknown, fallback: number): number {
+    if (typeof rawValue === "number" && Number.isFinite(rawValue)) {
+      return rawValue;
+    }
+    if (typeof rawValue === "string") {
+      const parsed = Number(rawValue);
+      return Number.isFinite(parsed) ? parsed : fallback;
+    }
+    return fallback;
+  }
+
+  private parseStringArrayConfig(rawValue: unknown, fallback: string[]): string[] {
+    if (!Array.isArray(rawValue)) {
+      return fallback;
+    }
+    const strings = rawValue.filter((item): item is string => typeof item === "string");
+    return strings.length > 0 ? strings : fallback;
   }
 
   private parseReleaseConditionConfig(rawValue: unknown): ReferralReleaseCondition {

--- a/src/modules/booking/booking-pricing-preview.service.spec.ts
+++ b/src/modules/booking/booking-pricing-preview.service.spec.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mockPinoLoggerToken } from "@/testing/nest-pino-logger.mock";
 import type { BookingFinancials } from "./booking-calculation.interface";
 import { BookingCalculationService } from "./booking-calculation.service";
+import { BookingEligibilityService } from "./booking-eligibility.service";
 import { BookingLegService } from "./booking-leg.service";
 import { BookingPersistenceService } from "./booking-persistence.service";
 import { BookingPricingPreviewService } from "./booking-pricing-preview.service";
@@ -14,6 +15,7 @@ describe("BookingPricingPreviewService", () => {
   let bookingPersistenceService: BookingPersistenceService;
   let bookingLegService: BookingLegService;
   let bookingCalculationService: BookingCalculationService;
+  let bookingEligibilityService: BookingEligibilityService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -37,6 +39,12 @@ describe("BookingPricingPreviewService", () => {
             calculateBookingCost: vi.fn(),
           },
         },
+        {
+          provide: BookingEligibilityService,
+          useValue: {
+            checkReferralEligibilityForPricing: vi.fn(),
+          },
+        },
       ],
     })
       .useMocker(mockPinoLoggerToken)
@@ -46,6 +54,12 @@ describe("BookingPricingPreviewService", () => {
     bookingPersistenceService = module.get<BookingPersistenceService>(BookingPersistenceService);
     bookingLegService = module.get<BookingLegService>(BookingLegService);
     bookingCalculationService = module.get<BookingCalculationService>(BookingCalculationService);
+    bookingEligibilityService = module.get<BookingEligibilityService>(BookingEligibilityService);
+    vi.mocked(bookingEligibilityService.checkReferralEligibilityForPricing).mockResolvedValue({
+      eligible: false,
+      referrerUserId: null,
+      discountAmount: new Decimal(0),
+    });
   });
 
   it("returns PARTIAL coverage and promo/standard segments", async () => {
@@ -159,6 +173,9 @@ describe("BookingPricingPreviewService", () => {
     });
     expect(result.compareAtBaseTotal).toBe(150000);
     expect(result.baseTotal).toBe(140000);
+    expect(result.referralDiscountAmount).toBe(0);
+    expect(result.creditsUsed).toBe(0);
+    expect(result.subtotalAfterDiscounts).toBe(147000);
     expect(result.savingsAmount).toBeGreaterThan(0);
   });
 
@@ -237,5 +254,109 @@ describe("BookingPricingPreviewService", () => {
       unitPrice: 60000,
       total: 60000,
     });
+  });
+
+  it("applies authenticated user's referral discount to the preview total", async () => {
+    vi.mocked(bookingPersistenceService.fetchCarWithPricing).mockResolvedValue({
+      id: "car-1",
+      ownerId: "owner-1",
+      dayRate: 50000,
+      nightRate: 45000,
+      fullDayRate: 80000,
+      airportPickupRate: 60000,
+      fuelUpgradeRate: 0,
+      pricingIncludesFuel: false,
+    });
+    vi.mocked(bookingLegService.generateLegs).mockReturnValue([
+      {
+        legDate: new Date("2026-05-01T00:00:00.000Z"),
+        legStartTime: new Date("2026-05-01T09:00:00.000Z"),
+        legEndTime: new Date("2026-05-01T21:00:00.000Z"),
+      },
+    ]);
+
+    const baseFinancials: BookingFinancials = {
+      legPrices: [
+        {
+          legDate: new Date("2026-05-01T00:00:00.000Z"),
+          price: new Decimal(50000),
+          basePrice: new Decimal(50000),
+          promotion: null,
+        },
+      ],
+      numberOfLegs: 1,
+      netTotal: new Decimal(50000),
+      compareAtNetTotal: new Decimal(50000),
+      appliedPromotion: null,
+      securityDetailCost: new Decimal(0),
+      fuelUpgradeCost: new Decimal(0),
+      netTotalWithAddons: new Decimal(50000),
+      platformFeeBase: new Decimal(50000),
+      platformCustomerServiceFeeRatePercent: new Decimal(5),
+      platformCustomerServiceFeeAmount: new Decimal(2500),
+      subtotalBeforeDiscounts: new Decimal(52500),
+      referralDiscountAmount: new Decimal(0),
+      creditsUsed: new Decimal(0),
+      subtotalAfterDiscounts: new Decimal(52500),
+      vatRatePercent: new Decimal(7.5),
+      vatAmount: new Decimal(3937.5),
+      totalAmount: new Decimal(56437.5),
+      platformFleetOwnerCommissionRatePercent: new Decimal(5),
+      platformFleetOwnerCommissionAmount: new Decimal(2500),
+      fleetOwnerPayoutAmountNet: new Decimal(47500),
+    };
+    const discountedFinancials: BookingFinancials = {
+      ...baseFinancials,
+      referralDiscountAmount: new Decimal(5000),
+      subtotalAfterDiscounts: new Decimal(47500),
+      vatAmount: new Decimal(3562.5),
+      totalAmount: new Decimal(51062.5),
+    };
+    vi.mocked(bookingCalculationService.calculateBookingCost)
+      .mockResolvedValueOnce(baseFinancials)
+      .mockResolvedValueOnce(discountedFinancials);
+    vi.mocked(bookingEligibilityService.checkReferralEligibilityForPricing).mockResolvedValue({
+      eligible: true,
+      referrerUserId: "referrer-1",
+      discountAmount: new Decimal(5000),
+    });
+
+    const sessionUser = {
+      id: "user-1",
+      email: "user@example.com",
+      name: "User",
+      emailVerified: true,
+      image: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      roles: ["user" as const],
+    };
+
+    const result = await service.preview(
+      {
+        carId: "car-1",
+        bookingType: BookingType.DAY,
+        startDate: new Date("2026-05-01T00:00:00.000Z"),
+        endDate: new Date("2026-05-01T23:59:00.000Z"),
+        pickupTime: "9:00 AM",
+        includeSecurityDetail: false,
+        requiresFullTank: false,
+      },
+      sessionUser,
+    );
+
+    expect(bookingEligibilityService.checkReferralEligibilityForPricing).toHaveBeenCalledWith(
+      sessionUser,
+      new Decimal(52500),
+      BookingType.DAY,
+    );
+    expect(bookingCalculationService.calculateBookingCost).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        referralDiscountAmount: new Decimal(5000),
+      }),
+    );
+    expect(result.referralDiscountAmount).toBe(5000);
+    expect(result.subtotalAfterDiscounts).toBe(47500);
+    expect(result.totalAmount).toBe(51062.5);
   });
 });

--- a/src/modules/booking/booking-pricing-preview.service.ts
+++ b/src/modules/booking/booking-pricing-preview.service.ts
@@ -2,8 +2,10 @@ import { Injectable } from "@nestjs/common";
 import Decimal from "decimal.js";
 import { PinoLogger } from "nestjs-pino";
 import { normalizeBookingTimeWindow } from "../../shared/booking-time-window.helper";
+import type { AuthSession } from "../auth/guards/session.guard";
 import type { BookingFinancials, LegPrice } from "./booking-calculation.interface";
 import { BookingCalculationService } from "./booking-calculation.service";
+import { BookingEligibilityService } from "./booking-eligibility.service";
 import { BookingLegService } from "./booking-leg.service";
 import { buildLegGenerationInput } from "./booking-leg-input.builder";
 import { BookingPersistenceService } from "./booking-persistence.service";
@@ -24,12 +26,16 @@ export class BookingPricingPreviewService {
     private readonly bookingPersistenceService: BookingPersistenceService,
     private readonly bookingLegService: BookingLegService,
     private readonly bookingCalculationService: BookingCalculationService,
+    private readonly bookingEligibilityService: BookingEligibilityService,
     private readonly logger: PinoLogger,
   ) {
     this.logger.setContext(BookingPricingPreviewService.name);
   }
 
-  async preview(input: PricingPreviewBodyDto): Promise<BookingPricingPreviewResponseDto> {
+  async preview(
+    input: PricingPreviewBodyDto,
+    sessionUser: AuthSession["user"] | null = null,
+  ): Promise<BookingPricingPreviewResponseDto> {
     this.logger.debug(
       {
         carId: input.carId,
@@ -69,7 +75,7 @@ export class BookingPricingPreviewService {
       }),
     );
 
-    const financials = await this.bookingCalculationService.calculateBookingCost({
+    const baseFinancials = await this.bookingCalculationService.calculateBookingCost({
       bookingType: input.bookingType,
       legs,
       car,
@@ -79,6 +85,25 @@ export class BookingPricingPreviewService {
       creditsToUse: new Decimal(0),
       referralDiscountAmount: new Decimal(0),
     });
+    const referralEligibility =
+      await this.bookingEligibilityService.checkReferralEligibilityForPricing(
+        sessionUser,
+        baseFinancials.subtotalBeforeDiscounts,
+        input.bookingType,
+      );
+
+    const financials = referralEligibility.discountAmount.gt(0)
+      ? await this.bookingCalculationService.calculateBookingCost({
+          bookingType: input.bookingType,
+          legs,
+          car,
+          includeSecurityDetail: input.includeSecurityDetail,
+          requiresFullTank: input.requiresFullTank,
+          userCreditsBalance: new Decimal(0),
+          creditsToUse: new Decimal(0),
+          referralDiscountAmount: referralEligibility.discountAmount,
+        })
+      : baseFinancials;
 
     const response = this.mapPreviewResponse(financials);
     this.logger.debug(
@@ -132,6 +157,9 @@ export class BookingPricingPreviewService {
       compareAtPlatformFeeAmount: compareAtPlatformFeeAmount.toNumber(),
       subtotalBeforeDiscounts: financials.subtotalBeforeDiscounts.toNumber(),
       compareAtSubtotalBeforeDiscounts: compareAtSubtotalBeforeDiscounts.toNumber(),
+      referralDiscountAmount: financials.referralDiscountAmount.toNumber(),
+      creditsUsed: financials.creditsUsed.toNumber(),
+      subtotalAfterDiscounts: financials.subtotalAfterDiscounts.toNumber(),
       vatRatePercent: financials.vatRatePercent.toNumber(),
       vatAmount: financials.vatAmount.toNumber(),
       compareAtVatAmount: compareAtVatAmount.toNumber(),
@@ -142,10 +170,20 @@ export class BookingPricingPreviewService {
   }
 
   private computeCoverage(legPrices: LegPrice[]): PricingPreviewDiscountCoverage {
-    if (legPrices.length === 0) return "NONE";
+    if (legPrices.length === 0) {
+      return "NONE";
+    }
+
     const discountedUnits = legPrices.filter((leg) => leg.promotion !== null).length;
-    if (discountedUnits === 0) return "NONE";
-    if (discountedUnits === legPrices.length) return "FULL";
+
+    if (discountedUnits === 0) {
+      return "NONE";
+    }
+
+    if (discountedUnits === legPrices.length) {
+      return "FULL";
+    }
+
     return "PARTIAL";
   }
 

--- a/src/modules/booking/booking.controller.spec.ts
+++ b/src/modules/booking/booking.controller.spec.ts
@@ -68,6 +68,9 @@ describe("BookingController", () => {
     compareAtPlatformFeeAmount: 7500,
     subtotalBeforeDiscounts: 147000,
     compareAtSubtotalBeforeDiscounts: 157500,
+    referralDiscountAmount: 0,
+    creditsUsed: 0,
+    subtotalAfterDiscounts: 147000,
     vatRatePercent: 7.5,
     vatAmount: 11025,
     compareAtVatAmount: 11812.5,
@@ -391,10 +394,10 @@ describe("BookingController", () => {
         requiresFullTank: false,
       };
 
-      const result = await controller.getPricingPreview(body);
+      const result = await controller.getPricingPreview(body, null);
 
       expect(result).toEqual(mockPricingPreviewResponse);
-      expect(bookingPricingPreviewService.preview).toHaveBeenCalledWith(body);
+      expect(bookingPricingPreviewService.preview).toHaveBeenCalledWith(body, null);
     });
   });
 

--- a/src/modules/booking/booking.controller.ts
+++ b/src/modules/booking/booking.controller.ts
@@ -94,8 +94,12 @@ export class BookingController {
 
   @Post("pricing-preview")
   @HttpCode(HttpStatus.OK)
-  async getPricingPreview(@ZodBody(pricingPreviewBodySchema) body: PricingPreviewBodyDto) {
-    return this.bookingPricingPreviewService.preview(body);
+  @UseGuards(OptionalSessionGuard)
+  async getPricingPreview(
+    @ZodBody(pricingPreviewBodySchema) body: PricingPreviewBodyDto,
+    @CurrentUser() sessionUser: AuthSession["user"] | null,
+  ) {
+    return this.bookingPricingPreviewService.preview(body, sessionUser);
   }
 
   @Get()

--- a/src/modules/booking/dto/pricing-preview.dto.ts
+++ b/src/modules/booking/dto/pricing-preview.dto.ts
@@ -59,6 +59,9 @@ export interface BookingPricingPreviewResponseDto {
   compareAtPlatformFeeAmount: number;
   subtotalBeforeDiscounts: number;
   compareAtSubtotalBeforeDiscounts: number;
+  referralDiscountAmount: number;
+  creditsUsed: number;
+  subtotalAfterDiscounts: number;
   vatRatePercent: number;
   vatAmount: number;
   compareAtVatAmount: number;

--- a/src/modules/referral/referral-api.service.spec.ts
+++ b/src/modules/referral/referral-api.service.spec.ts
@@ -147,6 +147,8 @@ describe("ReferralApiService", () => {
 
     expect(result.referralCode).toBe("ABCDEFGH");
     expect(result.shareLink).toBe("http://localhost:3000/auth?ref=ABCDEFGH");
+    expect(result.programEnabled).toBe(true);
+    expect(result.discountAmount).toBe(10000);
     expect(result.stats.totalRewardsGranted).toBe(2500);
     expect(result.stats.totalEarned).toBe(2500);
     expect(result.stats.totalUsed).toBe(500);

--- a/src/modules/referral/referral-api.service.ts
+++ b/src/modules/referral/referral-api.service.ts
@@ -184,6 +184,8 @@ export class ReferralApiService {
     return {
       referralCode: referralInfo.referralCode,
       shareLink,
+      programEnabled: config.REFERRAL_ENABLED,
+      discountAmount: config.REFERRAL_DISCOUNT_AMOUNT,
       hasUsedDiscount: referralInfo.referralDiscountUsed,
       referredBy: referralInfo.referredByUserId,
       signupDate: referralInfo.referralSignupAt,

--- a/src/modules/referral/referral.controller.spec.ts
+++ b/src/modules/referral/referral.controller.spec.ts
@@ -147,6 +147,8 @@ describe("ReferralController", () => {
     const result = await controller.getCurrentUserReferralInfo(createMockAuthUser(), request);
 
     expect(result.referralCode).toBe("ABCDEFGH");
+    expect(result.programEnabled).toBe(true);
+    expect(result.discountAmount).toBe(10000);
     expect(referralService.getCurrentUserReferralInfo).toHaveBeenCalledWith("user-1", request);
   });
 });

--- a/src/modules/referral/referral.controller.spec.ts
+++ b/src/modules/referral/referral.controller.spec.ts
@@ -119,6 +119,8 @@ describe("ReferralController", () => {
     vi.mocked(referralService.getCurrentUserReferralInfo).mockResolvedValue({
       referralCode: "ABCDEFGH",
       shareLink: "http://localhost:3000/auth?ref=ABCDEFGH",
+      programEnabled: true,
+      discountAmount: 10000,
       hasUsedDiscount: false,
       referredBy: null,
       signupDate: null,

--- a/src/modules/referral/referral.interface.ts
+++ b/src/modules/referral/referral.interface.ts
@@ -29,6 +29,8 @@ export interface ReferralStatsResponse {
 export interface ReferralUserSummaryResponse {
   referralCode: string | null;
   shareLink: string | null;
+  programEnabled: boolean;
+  discountAmount: number;
   hasUsedDiscount: boolean;
   referredBy: string | null;
   signupDate: Date | null;

--- a/src/modules/referral/referral.service.spec.ts
+++ b/src/modules/referral/referral.service.spec.ts
@@ -130,6 +130,8 @@ describe("ReferralService", () => {
     vi.mocked(referralApiService.getUserReferralSummary).mockResolvedValue({
       referralCode: "ABCDEFGH",
       shareLink: "http://localhost:3000/auth?ref=ABCDEFGH",
+      programEnabled: true,
+      discountAmount: 10000,
       hasUsedDiscount: false,
       referredBy: null,
       signupDate: null,
@@ -163,6 +165,8 @@ describe("ReferralService", () => {
       .mockResolvedValueOnce({
         referralCode: "FIRST",
         shareLink: "http://localhost:3000/auth?ref=FIRST",
+        programEnabled: true,
+        discountAmount: 10000,
         hasUsedDiscount: false,
         referredBy: null,
         signupDate: null,
@@ -182,6 +186,8 @@ describe("ReferralService", () => {
       .mockResolvedValueOnce({
         referralCode: "SECOND",
         shareLink: "http://localhost:3000/auth?ref=SECOND",
+        programEnabled: true,
+        discountAmount: 10000,
         hasUsedDiscount: false,
         referredBy: null,
         signupDate: null,
@@ -217,6 +223,8 @@ describe("ReferralService", () => {
     vi.mocked(referralApiService.getUserReferralSummary).mockImplementation(async (userId) => ({
       referralCode: userId,
       shareLink: `http://localhost:3000/auth?ref=${userId}`,
+      programEnabled: true,
+      discountAmount: 10000,
       hasUsedDiscount: false,
       referredBy: null,
       signupDate: null,

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -147,6 +147,64 @@ describe("Auth E2E Tests", () => {
       const cookies = verifyResponse.headers["set-cookie"];
       expect(cookies).toBeDefined();
     });
+
+    it("should allow existing users to log in when a stale self-referral code is present", async () => {
+      const testEmail = uniqueEmail("self-referral-login");
+
+      await request(app.getHttpServer())
+        .post("/api/auth/email-otp/send-verification-otp")
+        .set("X-Client-Type", "mobile")
+        .send({ email: testEmail, type: "sign-in" });
+
+      const signupVerification = await databaseService.verification.findFirst({
+        where: { identifier: `sign-in-otp-${testEmail}` },
+        orderBy: { createdAt: "desc" },
+      });
+      const signupOtp = signupVerification?.value.split(":")[0];
+
+      const signupResponse = await request(app.getHttpServer())
+        .post("/api/auth/sign-in/email-otp")
+        .set("X-Client-Type", "mobile")
+        .send({ email: testEmail, otp: signupOtp });
+
+      expect(signupResponse.status).toBe(HttpStatus.OK);
+
+      const existingUser = await databaseService.user.findUnique({
+        where: { email: testEmail },
+        select: { referralCode: true },
+      });
+      const selfReferralCode = existingUser?.referralCode;
+      expect(selfReferralCode).toEqual(expect.any(String));
+
+      const sendLoginOtpResponse = await request(app.getHttpServer())
+        .post("/api/auth/email-otp/send-verification-otp")
+        .set("X-Client-Type", "mobile")
+        .send({
+          email: testEmail,
+          type: "sign-in",
+          referralCode: selfReferralCode,
+        });
+
+      expect(sendLoginOtpResponse.status).toBe(HttpStatus.OK);
+
+      const loginVerification = await databaseService.verification.findFirst({
+        where: { identifier: `sign-in-otp-${testEmail}` },
+        orderBy: { createdAt: "desc" },
+      });
+      const loginOtp = loginVerification?.value.split(":")[0];
+
+      const loginResponse = await request(app.getHttpServer())
+        .post("/api/auth/sign-in/email-otp")
+        .set("X-Client-Type", "mobile")
+        .send({
+          email: testEmail,
+          otp: loginOtp,
+          referralCode: selfReferralCode,
+        });
+
+      expect(loginResponse.status).toBe(HttpStatus.OK);
+      expect(loginResponse.body.user.email).toBe(testEmail);
+    });
   });
 
   describe("Authenticated session flow", () => {

--- a/test/booking-flow.e2e-spec.ts
+++ b/test/booking-flow.e2e-spec.ts
@@ -17,6 +17,13 @@ import { TestDataFactory, uniqueEmail } from "./helpers";
 const ONE_DAY_MS = 86400000;
 const TWELVE_HOURS_MS = 43200000;
 
+type SameLocationCreateBookingDto = Extract<CreateBookingDto, { sameLocation: true }>;
+type ExpectedReferralBooking = {
+  referrerUserId: string;
+  discountAmount: number;
+  totalAmount: number;
+};
+
 /**
  * End-to-end test for the full booking flow:
  * Auth (OTP signup) → Create Booking → Flutterwave Webhook → Booking Confirmed
@@ -92,8 +99,13 @@ describe("Booking Flow E2E", () => {
    * 1. Creates a booking → asserts PENDING state
    * 2. Sends Flutterwave webhook → asserts CONFIRMED state
    */
-  async function runBookingFlow(cookie: string, testCarId: string): Promise<{ bookingId: string }> {
-    const bookingPayload: CreateBookingDto = {
+  async function runBookingFlow(
+    cookie: string,
+    testCarId: string,
+    overrides: Partial<SameLocationCreateBookingDto> = {},
+    expectedReferral?: ExpectedReferralBooking,
+  ): Promise<{ bookingId: string }> {
+    const bookingPayload: SameLocationCreateBookingDto = {
       carId: testCarId,
       startDate: new Date(Date.now() + ONE_DAY_MS * 2),
       endDate: new Date(Date.now() + ONE_DAY_MS * 2 + TWELVE_HOURS_MS),
@@ -104,6 +116,7 @@ describe("Booking Flow E2E", () => {
       includeSecurityDetail: false,
       requiresFullTank: false,
       useCredits: 0,
+      ...overrides,
     };
 
     const bookingResponse = await request(app.getHttpServer())
@@ -119,7 +132,9 @@ describe("Booking Flow E2E", () => {
     const { bookingId } = bookingResponse.body;
 
     const pendingBooking = await factory.getBookingById(bookingId);
+
     if (!pendingBooking) throw new Error("Booking not found after creation");
+
     expect(pendingBooking.status).toBe("PENDING");
     expect(pendingBooking.paymentStatus).toBe("UNPAID");
 
@@ -181,16 +196,29 @@ describe("Booking Flow E2E", () => {
     expect(confirmedBooking.status).toBe("CONFIRMED");
     expect(confirmedBooking.paymentStatus).toBe("PAID");
 
+    if (expectedReferral) {
+      expect(confirmedBooking.referralReferrerUserId).toBe(expectedReferral.referrerUserId);
+      expect(confirmedBooking.referralDiscountAmount.toNumber()).toBe(
+        expectedReferral.discountAmount,
+      );
+      expect(confirmedBooking.referralStatus).toBe("APPLIED");
+      expect(confirmedBooking.totalAmount.toNumber()).toBe(expectedReferral.totalAmount);
+    }
+
     // Payment should be SUCCESSFUL
     const successfulPayment = await factory.getPaymentByBookingId(bookingId);
+
     if (!successfulPayment) throw new Error("Payment not found after webhook");
+
     expect(successfulPayment.status).toBe("SUCCESSFUL");
     expect(successfulPayment.flutterwaveTransactionId).toBe(String(flwTransactionId));
     expect(successfulPayment.amountCharged?.toNumber()).toBe(expectedAmount);
 
     // Car should be BOOKED
     const bookedCar = await factory.getCarById(testCarId);
+
     if (!bookedCar) throw new Error("Car not found after webhook");
+
     expect(bookedCar.status).toBe("BOOKED");
 
     return { bookingId };
@@ -303,15 +331,100 @@ describe("Booking Flow E2E", () => {
     { clientType: "mobile", label: "Mobile client" },
     { clientType: "web", label: "Web client" },
   ])("$label - full booking flow", ({ clientType }) => {
-    it("should authenticate, create booking, process payment webhook, and confirm booking", async () => {
+    it("should authenticate referrer and referee, apply referral discount, process payment webhook, and confirm booking", async () => {
       // Create a fresh car for this test (avoids status conflicts between tests)
       const car = await factory.createCar(fleetOwnerId);
 
-      // Authenticate via the appropriate client type
-      const email = uniqueEmail(`flow-${clientType}`);
-      const { cookie } = await factory.authenticateAndGetUser(email, "user", clientType);
+      // User A signs up first and is auto-assigned a referral code
+      const { user: userA } = await factory.authenticateAndGetUser(
+        uniqueEmail(`referrer-flow-${clientType}`),
+        "user",
+        clientType,
+      );
 
-      await runBookingFlow(cookie, car.id);
+      // User B signs up using User A's referral code
+      const { cookie, user: userB } = await factory.authenticateAndGetUser(
+        uniqueEmail(`referred-flow-${clientType}`),
+        "user",
+        clientType,
+        { referralCode: userA.referralCode },
+      );
+      expect(userB.referredByUserId).toBe(userA.id);
+
+      await factory.enableReferralProgram();
+
+      // 20% car-specific promotion covering the booking window
+      await factory.createPromotion(fleetOwnerId, { carId: car.id, discountValue: 20 });
+
+      // Pin start to 9 AM local so the 12-hour DAY booking falls within a single
+      // calendar day (1 leg) regardless of when the test runs. DAY bookings
+      // generate one leg per calendar day, so a window crossing midnight would
+      // produce 2 legs and double the expected price.
+      const startDate = new Date(Date.now() + ONE_DAY_MS * 2);
+      startDate.setHours(9, 0, 0, 0);
+      const endDate = new Date(startDate.getTime() + TWELVE_HOURS_MS);
+
+      // Pricing preview should reflect both the promotion and the referral discount.
+      // Math (1 DAY leg @ dayRate 50,000, 10% platform fee, 7.5% VAT):
+      //   compare-at: 50,000 + 5,000 fee = 55,000 subtotal → +4,125 VAT → 59,125
+      //   after 20% promo: 40,000 + 4,000 fee = 44,000 subtotal
+      //   after referral: 44,000 − 10,000 = 34,000 → +2,550 VAT → 36,550 total
+      //   savings: 59,125 − 36,550 = 22,575
+      const previewResponse = await request(app.getHttpServer())
+        .post("/api/bookings/pricing-preview")
+        .set("Cookie", cookie)
+        .send({
+          carId: car.id,
+          bookingType: "DAY",
+          startDate: startDate.toISOString(),
+          endDate: endDate.toISOString(),
+          pickupTime: "9:00 AM",
+          includeSecurityDetail: false,
+          requiresFullTank: false,
+        });
+      expect(previewResponse.status).toBe(HttpStatus.OK);
+
+      // Per-leg base (after promo) and compare-at (before promo)
+      expect(previewResponse.body.baseTotal).toBe(40000);
+      expect(previewResponse.body.compareAtBaseTotal).toBe(50000);
+
+      // Platform fee (10% of leg net)
+      expect(previewResponse.body.platformFeeAmount).toBe(4000);
+      expect(previewResponse.body.compareAtPlatformFeeAmount).toBe(5000);
+
+      // Subtotal before referral discount (after promotion)
+      expect(previewResponse.body.subtotalBeforeDiscounts).toBe(44000);
+      expect(previewResponse.body.compareAtSubtotalBeforeDiscounts).toBe(55000);
+
+      // Referral discount applied
+      expect(previewResponse.body.referralDiscountAmount).toBe(10000);
+      expect(previewResponse.body.subtotalAfterDiscounts).toBe(34000);
+
+      // VAT (7.5%) on subtotalAfterDiscounts vs compareAtSubtotalBeforeDiscounts
+      expect(previewResponse.body.vatAmount).toBe(2550);
+      expect(previewResponse.body.compareAtVatAmount).toBe(4125);
+
+      // Final totals + combined savings (promo + referral, including their VAT impact)
+      expect(previewResponse.body.totalAmount).toBe(36550);
+      expect(previewResponse.body.compareAtTotalAmount).toBe(59125);
+      expect(previewResponse.body.savingsAmount).toBe(22575);
+      expect(previewResponse.body.discountCoverage).toBe("FULL");
+
+      // Booking creation + payment webhook must persist the same discount and total
+      await runBookingFlow(
+        cookie,
+        car.id,
+        {
+          startDate,
+          endDate,
+          clientTotalAmount: String(previewResponse.body.totalAmount),
+        },
+        {
+          referrerUserId: userA.id,
+          discountAmount: 10000,
+          totalAmount: 36550,
+        },
+      );
     });
 
     it("should initialize extension payment, process webhook, and activate extension", async () => {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,6 +1,8 @@
 import type { INestApplication } from "@nestjs/common";
-import type { PayoutTransactionStatus, Prisma, PrismaClient } from "@prisma/client";
+import type { Prisma, PrismaClient, ReferralAttributionSource } from "@prisma/client";
 import request from "supertest";
+
+const ONE_DAY_MS = 86400000;
 
 // ============================================================================
 // Test Data Factory Types (using Prisma UncheckedCreateInput for direct FK usage)
@@ -24,9 +26,29 @@ export type CreatePayoutTransactionOptions = Partial<Prisma.PayoutTransactionUnc
 
 export type CreateReviewOptions = Partial<Prisma.ReviewUncheckedCreateInput>;
 
+export type CreatePromotionOptions = Partial<Prisma.PromotionUncheckedCreateInput>;
+
 export type AuthRole = "user" | "fleetOwner" | "admin";
 
 export type ClientTypeOption = "mobile" | "web";
+
+export interface AuthenticateOptions {
+  referralCode?: string;
+}
+
+export interface TestUser {
+  id: string;
+  email: string;
+  name: string | null;
+  referralCode: string | null;
+  referredByUserId: string | null;
+  referralAttributionSource: ReferralAttributionSource | null;
+  referralSignupAt: Date | null;
+}
+
+export interface AuthenticatedTestUser extends TestUser {
+  referralCode: string;
+}
 
 /**
  * Maps auth roles to their corresponding web client referer paths.
@@ -119,6 +141,7 @@ export class TestDataFactory {
     email: string,
     role: AuthRole = "user",
     clientType: ClientTypeOption = "mobile",
+    options: AuthenticateOptions = {},
   ): Promise<string> {
     if (!this.app) {
       throw new Error("TestDataFactory requires app instance for authentication methods");
@@ -133,7 +156,7 @@ export class TestDataFactory {
     await request(this.app.getHttpServer())
       .post("/api/auth/email-otp/send-verification-otp")
       .set(authHeaders)
-      .send({ email, type: "sign-in", role });
+      .send({ email, type: "sign-in", role, referralCode: options.referralCode });
 
     // Get OTP from database
     const verification = await this.prisma.verification.findFirst({
@@ -151,7 +174,7 @@ export class TestDataFactory {
     const verifyResponse = await request(this.app.getHttpServer())
       .post("/api/auth/sign-in/email-otp")
       .set(authHeaders)
-      .send({ email, otp, role });
+      .send({ email, otp, role, referralCode: options.referralCode });
 
     const cookies = verifyResponse.headers["set-cookie"];
 
@@ -165,12 +188,18 @@ export class TestDataFactory {
   /**
    * Get user by email.
    */
-  async getUserByEmail(
-    email: string,
-  ): Promise<{ id: string; email: string; name: string | null } | null> {
+  async getUserByEmail(email: string): Promise<TestUser | null> {
     return this.prisma.user.findUnique({
       where: { email },
-      select: { id: true, email: true, name: true },
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        referralCode: true,
+        referredByUserId: true,
+        referralAttributionSource: true,
+        referralSignupAt: true,
+      },
     });
   }
 
@@ -182,13 +211,18 @@ export class TestDataFactory {
     email: string,
     role: AuthRole = "user",
     clientType: ClientTypeOption = "mobile",
-  ): Promise<{ cookie: string; user: { id: string; email: string; name: string | null } }> {
-    const cookie = await this.authenticateAndGetCookie(email, role, clientType);
+    options: AuthenticateOptions = {},
+  ): Promise<{ cookie: string; user: AuthenticatedTestUser }> {
+    const cookie = await this.authenticateAndGetCookie(email, role, clientType, options);
     const user = await this.getUserByEmail(email);
     if (!user) {
       throw new Error(`User not found after authentication: ${email}`);
     }
-    return { cookie, user };
+    const referralCode = user.referralCode;
+    if (!referralCode) {
+      throw new Error(`User did not receive a referral code after authentication: ${email}`);
+    }
+    return { cookie, user: { ...user, referralCode } };
   }
 
   /**
@@ -198,7 +232,7 @@ export class TestDataFactory {
    */
   async createAuthenticatedAdmin(email: string): Promise<{
     cookie: string;
-    user: { id: string; email: string; name: string | null };
+    user: AuthenticatedTestUser;
   }> {
     const { cookie, user } = await this.authenticateAndGetUser(email, "user");
     await this.assignRole(user.id, "admin");
@@ -447,7 +481,7 @@ export class TestDataFactory {
         carRating: options.carRating ?? 5,
         chauffeurRating: options.chauffeurRating ?? 5,
         serviceRating: options.serviceRating ?? 5,
-        comment: options.comment === undefined ? "Great experience" : options.comment,
+        comment: options.comment ?? "Great experience",
         isVisible: options.isVisible ?? true,
         moderatedAt: options.moderatedAt,
         moderatedBy: options.moderatedBy,
@@ -524,7 +558,7 @@ export class TestDataFactory {
         extensionId: options.extensionId,
         amountToPay: options.amountToPay ?? 45000,
         currency: options.currency ?? "NGN",
-        status: (options.status ?? "PROCESSING") as PayoutTransactionStatus,
+        status: options.status ?? "PROCESSING",
         payoutProviderReference:
           options.payoutProviderReference ??
           `payout-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
@@ -634,6 +668,65 @@ export class TestDataFactory {
           },
         ],
         skipDuplicates: true,
+      }),
+    ]);
+  }
+
+  /**
+   * Create a promotion for a fleet owner (optionally scoped to a single car).
+   * Defaults to a 20% discount active in a wide window around "now" so it
+   * overlaps booking windows created by tests without ceremony.
+   */
+  async createPromotion(
+    ownerId: string,
+    options: Omit<CreatePromotionOptions, "ownerId"> = {},
+  ): Promise<{ id: string }> {
+    const promotion = await this.prisma.promotion.create({
+      data: {
+        ownerId,
+        carId: options.carId ?? null,
+        name: options.name ?? "Test Promotion",
+        discountValue: options.discountValue ?? 20,
+        startDate: options.startDate ?? new Date(Date.now() - ONE_DAY_MS),
+        endDate: options.endDate ?? new Date(Date.now() + 30 * ONE_DAY_MS),
+        isActive: options.isActive ?? true,
+      },
+      select: { id: true },
+    });
+    return promotion;
+  }
+
+  /**
+   * Enable the referral program with deterministic config for E2E tests.
+   * Idempotent via upsert — safe to call multiple times.
+   * Sets: enabled, 10000 discount, 20000 min booking, DAY/NIGHT/FULL_DAY eligible, 30 day expiry.
+   */
+  async enableReferralProgram(): Promise<void> {
+    await Promise.all([
+      this.prisma.referralProgramConfig.upsert({
+        where: { key: "REFERRAL_ENABLED" },
+        create: { key: "REFERRAL_ENABLED", value: true },
+        update: { value: true },
+      }),
+      this.prisma.referralProgramConfig.upsert({
+        where: { key: "REFERRAL_DISCOUNT_AMOUNT" },
+        create: { key: "REFERRAL_DISCOUNT_AMOUNT", value: 10000 },
+        update: { value: 10000 },
+      }),
+      this.prisma.referralProgramConfig.upsert({
+        where: { key: "REFERRAL_MIN_BOOKING_AMOUNT" },
+        create: { key: "REFERRAL_MIN_BOOKING_AMOUNT", value: 20000 },
+        update: { value: 20000 },
+      }),
+      this.prisma.referralProgramConfig.upsert({
+        where: { key: "REFERRAL_ELIGIBLE_TYPES" },
+        create: { key: "REFERRAL_ELIGIBLE_TYPES", value: ["DAY", "NIGHT", "FULL_DAY"] },
+        update: { value: ["DAY", "NIGHT", "FULL_DAY"] },
+      }),
+      this.prisma.referralProgramConfig.upsert({
+        where: { key: "REFERRAL_EXPIRY_DAYS" },
+        create: { key: "REFERRAL_EXPIRY_DAYS", value: 30 },
+        update: { value: 30 },
       }),
     ]);
   }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -46,10 +46,6 @@ export interface TestUser {
   referralSignupAt: Date | null;
 }
 
-export interface AuthenticatedTestUser extends TestUser {
-  referralCode: string;
-}
-
 /**
  * Maps auth roles to their corresponding web client referer paths.
  */
@@ -153,10 +149,17 @@ export class TestDataFactory {
     const authHeaders = this.getAuthHeaders(clientType, role);
 
     // Send OTP
-    await request(this.app.getHttpServer())
+    const sendOtpResponse = await request(this.app.getHttpServer())
       .post("/api/auth/email-otp/send-verification-otp")
       .set(authHeaders)
       .send({ email, type: "sign-in", role, referralCode: options.referralCode });
+
+    if (sendOtpResponse.status < 200 || sendOtpResponse.status >= 300) {
+      const bodyPreview = JSON.stringify(sendOtpResponse.body);
+      throw new Error(
+        `send-verification-otp failed for ${email}: status ${sendOtpResponse.status}, body: ${bodyPreview}`,
+      );
+    }
 
     // Get OTP from database
     const verification = await this.prisma.verification.findFirst({
@@ -175,6 +178,13 @@ export class TestDataFactory {
       .post("/api/auth/sign-in/email-otp")
       .set(authHeaders)
       .send({ email, otp, role, referralCode: options.referralCode });
+
+    if (verifyResponse.status < 200 || verifyResponse.status >= 300) {
+      const bodyPreview = JSON.stringify(verifyResponse.body);
+      throw new Error(
+        `sign-in/email-otp failed for ${email}: status ${verifyResponse.status}, body: ${bodyPreview}`,
+      );
+    }
 
     const cookies = verifyResponse.headers["set-cookie"];
 
@@ -212,17 +222,13 @@ export class TestDataFactory {
     role: AuthRole = "user",
     clientType: ClientTypeOption = "mobile",
     options: AuthenticateOptions = {},
-  ): Promise<{ cookie: string; user: AuthenticatedTestUser }> {
+  ): Promise<{ cookie: string; user: TestUser }> {
     const cookie = await this.authenticateAndGetCookie(email, role, clientType, options);
     const user = await this.getUserByEmail(email);
     if (!user) {
       throw new Error(`User not found after authentication: ${email}`);
     }
-    const referralCode = user.referralCode;
-    if (!referralCode) {
-      throw new Error(`User did not receive a referral code after authentication: ${email}`);
-    }
-    return { cookie, user: { ...user, referralCode } };
+    return { cookie, user };
   }
 
   /**
@@ -232,7 +238,7 @@ export class TestDataFactory {
    */
   async createAuthenticatedAdmin(email: string): Promise<{
     cookie: string;
-    user: AuthenticatedTestUser;
+    user: TestUser;
   }> {
     const { cookie, user } = await this.authenticateAndGetUser(email, "user");
     await this.assignRole(user.id, "admin");

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -696,6 +696,7 @@ export class TestDataFactory {
         startDate: options.startDate ?? new Date(Date.now() - ONE_DAY_MS),
         endDate: options.endDate ?? new Date(Date.now() + 30 * ONE_DAY_MS),
         isActive: options.isActive ?? true,
+        ...options,
       },
       select: { id: true },
     });


### PR DESCRIPTION
## Summary
End-to-end referral signup via OTP, booking and preview pricing that use the same referral rules (subtotal-based, type/min/expiry/reservation checks), richer referral summary for clients, and a strengthened booking E2E that asserts the full price ladder including promotions.

## Commits
| Commit | Area |
|--------|------|
| `feat(auth): validate referral codes and attribute signups on OTP flow` | Auth |
| `feat(booking): align referral discount with pricing subtotal rules` | Booking |
| `feat(referral): expose program flag and discount amount in user summary` | Referral API |
| `test(e2e): cover referral pricing with promotions and factory helpers` | Tests |

## Auth
- Parse `referralCode` from the email-OTP request body and validate it before signup (invalid code → `BAD_REQUEST`).
- Store pending referral attribution keyed by email with the same TTL cleanup pattern as pending roles.
- On user creation: assign referral code to new users; consume pending referral and persist referrer attribution when present.
- New error surface: `AUTH_REFERRAL_CODE_GENERATION_FAILED`, `AuthInternalServerException`.
- Unit tests extended in `auth.service.spec.ts`.

## Booking
- **`BookingEligibilityService`**: `checkReferralEligibilityForPricing(sessionUser, bookingAmount, bookingType)` — enabled program, min amount, eligible booking types, signup expiry, no prior discount use, and no existing booking that already **reserved** the discount (`APPLIED` / `REWARDED` on `PENDING` / `CONFIRMED` / `ACTIVE`).
- **`BookingCreationService`**: compute base cost with no referral, run pricing eligibility on `subtotalBeforeDiscounts`, then optionally recalculate with the referral discount (matches preview semantics).
- **`BookingPricingPreviewService`**: same two-pass pattern; enriched preview response (compare-at / savings where applicable).
- **`BookingController`**: pass session into pricing preview so logged-in users get referral-aware previews.
- **`pricing-preview.dto`**: DTO updates as needed for the new fields.
- Specs updated/added for eligibility, preview, creation mocks (`booking.findFirst` on prisma mock where needed).

## Referral
- **`ReferralUserSummaryResponse`**: `programEnabled`, `discountAmount`.
- **`ReferralApiService.getUserReferralSummary`**: populate from loaded program config.
- Controller/service specs updated for the new fields.

## Tests (E2E + helpers)
- **`TestDataFactory`**: `enableReferralProgram()` (deterministic upserts), `createPromotion()` for car-scoped promos.
- **`booking-flow.e2e-spec.ts`**: referral program enabled, 20% car promotion, deterministic DAY window (9 AM local, single leg), strict assertions on preview (`baseTotal`, `compareAt*`, platform fee, subtotals, VAT, `totalAmount`, `savingsAmount`, `discountCoverage`) then full booking + webhook with matching totals.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth signup hooks and booking pricing/referral eligibility logic; incorrect validation or edge cases could mis-attribute referrals or misprice bookings, but changes are scoped and well-covered by unit/E2E tests.
> 
> **Overview**
> Implements **referral-aware OTP signup** by accepting `referralCode` in auth requests, validating it for *new* users only, caching pending attribution alongside pending roles, and on user creation generating a unique referral code plus persisting referral attribution (with new `AUTH_REFERRAL_CODE_GENERATION_FAILED` and `AuthInternalServerException`).
> 
> Updates **booking referral discount application** to use a two-pass pricing flow (compute base totals, then reprice only if eligible) and centralizes pricing eligibility in `BookingEligibilityService.checkReferralEligibilityForPricing` (program enabled, min subtotal, eligible types, expiry window, and no existing booking reserving the discount).
> 
> Enhances **pricing preview and referral APIs** by making `/bookings/pricing-preview` session-aware (optional guard), returning additional totals (`referralDiscountAmount`, `creditsUsed`, `subtotalAfterDiscounts`), and extending referral user summary responses with `programEnabled` and `discountAmount`; adds/updates unit and E2E tests plus bumps pinned dependency overrides (e.g., `kysely`, `protobufjs`, `langsmith`, `next`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caa3d1ed92e011c95112a963d1d191df7499535b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->