### PR TITLE
fix(referral): reserve discount until payment succeeds

### DIFF
--- a/prisma/migrations/20260515221500_add_reserved_booking_referral_status/migration.sql
+++ b/prisma/migrations/20260515221500_add_reserved_booking_referral_status/migration.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "BookingReferralStatus" ADD VALUE 'RESERVED';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -945,6 +945,7 @@ enum ReferralReleaseCondition {
 
 enum BookingReferralStatus {
   NONE
+  RESERVED
   APPLIED
   REWARDED
   REVERSED

--- a/src/modules/booking/booking-confirmation.service.spec.ts
+++ b/src/modules/booking/booking-confirmation.service.spec.ts
@@ -2,7 +2,13 @@ import { getQueueToken } from "@nestjs/bullmq";
 import { EventEmitter2, EventEmitterReadinessWatcher } from "@nestjs/event-emitter";
 import { Test, TestingModule } from "@nestjs/testing";
 import type { Payment } from "@prisma/client";
-import { BookingStatus, PaymentAttemptStatus, PaymentStatus, Status } from "@prisma/client";
+import {
+  BookingReferralStatus,
+  BookingStatus,
+  PaymentAttemptStatus,
+  PaymentStatus,
+  Status,
+} from "@prisma/client";
 import type { Job, Queue } from "bullmq";
 import Decimal from "decimal.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -91,9 +97,14 @@ describe("BookingConfirmationService", () => {
         {
           provide: DatabaseService,
           useValue: {
+            $transaction: vi.fn(async (callback) => callback(databaseService)),
             booking: {
               findUnique: vi.fn(),
+              update: vi.fn(),
               updateMany: vi.fn(),
+            },
+            user: {
+              update: vi.fn(),
             },
             car: {
               update: vi.fn(),
@@ -202,6 +213,45 @@ describe("BookingConfirmationService", () => {
         }),
         { priority: 1 },
       );
+    });
+
+    it("should mark reserved referral discount as used after successful payment", async () => {
+      const mockPayment = createMockPayment({
+        id: "payment-123",
+        bookingId: "booking-123",
+      });
+      const mockBooking = createMockBookingWithRelations({
+        id: "booking-123",
+        userId: "user-123",
+        referralReferrerUserId: "referrer-123",
+        referralStatus: BookingReferralStatus.RESERVED,
+        status: BookingStatus.CONFIRMED,
+        paymentStatus: PaymentStatus.PAID,
+      });
+
+      vi.mocked(databaseService.booking.updateMany).mockResolvedValueOnce({ count: 1 });
+      vi.mocked(databaseService.booking.findUnique).mockResolvedValueOnce(mockBooking);
+      vi.mocked(databaseService.booking.update).mockResolvedValueOnce({
+        ...mockBooking,
+        referralStatus: BookingReferralStatus.APPLIED,
+      });
+      vi.mocked(databaseService.user.update).mockResolvedValueOnce(
+        createUser({ id: "user-123", referralDiscountUsed: true }),
+      );
+      vi.mocked(databaseService.car.update).mockResolvedValueOnce(mockBooking.car);
+      vi.mocked(notificationQueue.add).mockResolvedValue(createMockJob());
+
+      const result = await service.confirmFromPayment(mockPayment);
+
+      expect(result).toBe(true);
+      expect(databaseService.user.update).toHaveBeenCalledWith({
+        where: { id: "user-123" },
+        data: { referralDiscountUsed: true },
+      });
+      expect(databaseService.booking.update).toHaveBeenCalledWith({
+        where: { id: "booking-123" },
+        data: { referralStatus: BookingReferralStatus.APPLIED },
+      });
     });
 
     it("should return false when payment has no bookingId", async () => {

--- a/src/modules/booking/booking-confirmation.service.ts
+++ b/src/modules/booking/booking-confirmation.service.ts
@@ -1,7 +1,13 @@
 import { InjectQueue } from "@nestjs/bullmq";
 import { Injectable } from "@nestjs/common";
 import { EventEmitter2, EventEmitterReadinessWatcher } from "@nestjs/event-emitter";
-import { BookingStatus, type Payment, PaymentStatus, Status } from "@prisma/client";
+import {
+  BookingReferralStatus,
+  BookingStatus,
+  type Payment,
+  PaymentStatus,
+  Status,
+} from "@prisma/client";
 import { Queue } from "bullmq";
 import { PinoLogger } from "nestjs-pino";
 import { NOTIFICATIONS_QUEUE } from "../../config/constants";
@@ -65,18 +71,56 @@ export class BookingConfirmationService {
       return false;
     }
 
-    // Atomic conditional update - only updates if booking exists and is still PENDING
-    // This prevents TOCTOU race conditions where status could change between read and update
-    const updateResult = await this.databaseService.booking.updateMany({
-      where: { id: bookingId, status: BookingStatus.PENDING },
-      data: {
-        status: BookingStatus.CONFIRMED,
-        paymentStatus: PaymentStatus.PAID,
-      },
+    const updatedBooking = await this.databaseService.$transaction(async (tx) => {
+      // Atomic conditional update - only updates if booking exists and is still PENDING.
+      // This prevents TOCTOU race conditions where status could change between read and update.
+      const updateResult = await tx.booking.updateMany({
+        where: { id: bookingId, status: BookingStatus.PENDING },
+        data: {
+          status: BookingStatus.CONFIRMED,
+          paymentStatus: PaymentStatus.PAID,
+        },
+      });
+
+      if (updateResult.count === 0) {
+        return null;
+      }
+
+      const booking = await tx.booking.findUnique({
+        where: { id: bookingId },
+        include: {
+          chauffeur: true,
+          user: true,
+          car: { include: { owner: true } },
+          legs: { include: { extensions: true } },
+        },
+      });
+
+      if (
+        booking?.referralStatus === BookingReferralStatus.RESERVED &&
+        booking.userId &&
+        booking.referralReferrerUserId
+      ) {
+        await tx.user.update({
+          where: { id: booking.userId },
+          data: { referralDiscountUsed: true },
+        });
+        await tx.booking.update({
+          where: { id: booking.id },
+          data: { referralStatus: BookingReferralStatus.APPLIED },
+        });
+
+        return {
+          ...booking,
+          referralStatus: BookingReferralStatus.APPLIED,
+        };
+      }
+
+      return booking;
     });
 
     // If no records were updated, booking doesn't exist or is not in PENDING status
-    if (updateResult.count === 0) {
+    if (!updatedBooking) {
       this.logger.info(
         {
           bookingId,
@@ -84,30 +128,6 @@ export class BookingConfirmationService {
           txRef,
         },
         "Booking not found or not in PENDING status, skipping confirmation",
-      );
-      return false;
-    }
-
-    // Fetch the updated booking with relations for notification
-    const updatedBooking = await this.databaseService.booking.findUnique({
-      where: { id: bookingId },
-      include: {
-        chauffeur: true,
-        user: true,
-        car: { include: { owner: true } },
-        legs: { include: { extensions: true } },
-      },
-    });
-
-    if (!updatedBooking) {
-      // This shouldn't happen since we just updated the booking, but handle gracefully
-      this.logger.error(
-        {
-          bookingId,
-          paymentId: payment.id,
-          txRef,
-        },
-        "Booking not found after successful update",
       );
       return false;
     }

--- a/src/modules/booking/booking-creation.service.spec.ts
+++ b/src/modules/booking/booking-creation.service.spec.ts
@@ -710,6 +710,7 @@ describe("BookingCreationService", () => {
             ]),
           flight: { upsert: vi.fn().mockResolvedValue({ id: "flight-123" }) },
           booking: {
+            findFirst: vi.fn().mockResolvedValue(null),
             create: vi.fn().mockResolvedValue({
               id: "booking-123",
               bookingReference: "BK-123456-ABC",
@@ -753,7 +754,7 @@ describe("BookingCreationService", () => {
       );
     });
 
-    it("should mark referralDiscountUsed=true within the transaction to prevent race conditions", async () => {
+    it("should reserve referral discount without marking it used before payment", async () => {
       // Mock user in database with referral info
       vi.mocked(databaseService.user.findUnique).mockResolvedValue(
         createUser({
@@ -801,6 +802,7 @@ describe("BookingCreationService", () => {
             ]),
           flight: { upsert: vi.fn().mockResolvedValue({ id: "flight-123" }) },
           booking: {
+            findFirst: vi.fn().mockResolvedValue(null),
             create: vi.fn().mockResolvedValue({
               id: "booking-123",
               bookingReference: "BK-123456-ABC",
@@ -834,12 +836,7 @@ describe("BookingCreationService", () => {
 
       await service.createBooking({ input: booking, sessionUser });
 
-      // Verify that user.referralDiscountUsed was set to true WITHIN the transaction
-      // This prevents the race condition where concurrent bookings could all receive the discount
-      expect(mockUserUpdate).toHaveBeenCalledWith({
-        where: { id: "user-123" },
-        data: { referralDiscountUsed: true },
-      });
+      expect(mockUserUpdate).not.toHaveBeenCalled();
     });
 
     it("should throw ReferralDiscountNoLongerAvailableException when discount was already used (race condition)", async () => {

--- a/src/modules/booking/booking-creation.service.ts
+++ b/src/modules/booking/booking-creation.service.ts
@@ -368,10 +368,10 @@ export class BookingCreationService {
 
     try {
       createdBooking = await this.databaseService.$transaction(async (tx) => {
-        // CRITICAL: Verify and claim referral discount FIRST with pessimistic locking
-        // This prevents race conditions where concurrent requests could all receive the one-time discount
+        // CRITICAL: Verify and reserve referral discount FIRST with pessimistic locking.
+        // This prevents concurrent active bookings from receiving the one-time discount.
         const verifiedReferralEligibility = sessionUser
-          ? await this.eligibilityService.verifyAndClaimReferralDiscountInTransaction(
+          ? await this.eligibilityService.verifyAndReserveReferralDiscountInTransaction(
               tx,
               sessionUser.id,
               preliminaryReferralEligibility,
@@ -438,7 +438,7 @@ export class BookingCreationService {
           legs,
         });
 
-        // Create referral reward record (the discount was already claimed above)
+        // Create pending referral reward record for the reserved discount.
         await this.eligibilityService.createReferralRewardIfEligible(
           tx,
           bookingRecord.id,

--- a/src/modules/booking/booking-eligibility.service.spec.ts
+++ b/src/modules/booking/booking-eligibility.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, type TestingModule } from "@nestjs/testing";
+import { BookingReferralStatus, BookingStatus } from "@prisma/client";
 import Decimal from "decimal.js";
 import { describe, expect, it, vi } from "vitest";
 import { mockPinoLoggerToken } from "@/testing/nest-pino-logger.mock";
@@ -98,13 +99,14 @@ describe("BookingEligibilityService", () => {
     const service = module.get<BookingEligibilityService>(BookingEligibilityService);
 
     await expect(
-      service.verifyAndClaimReferralDiscountInTransaction(
+      service.verifyAndReserveReferralDiscountInTransaction(
         {
           $queryRaw: vi
             .fn()
             .mockResolvedValue([
               { id: "user-1", referredByUserId: "referrer-1", referralDiscountUsed: true },
             ]),
+          booking: { findFirst: vi.fn() },
           user: { update: vi.fn() },
         } as never,
         "user-1",
@@ -156,6 +158,51 @@ describe("BookingEligibilityService", () => {
       referrerUserId: null,
       discountAmount: new Decimal(0),
     });
+  });
+
+  it("reserves eligibility without marking the discount used before payment", async () => {
+    const mockUserUpdate = vi.fn();
+    const service = (
+      await Test.createTestingModule({
+        providers: [
+          BookingEligibilityService,
+          {
+            provide: DatabaseService,
+            useValue: {
+              user: { findUnique: vi.fn() },
+              referralProgramConfig: { findMany: vi.fn() },
+            },
+          },
+        ],
+      })
+        .useMocker(mockPinoLoggerToken)
+        .compile()
+    ).get<BookingEligibilityService>(BookingEligibilityService);
+
+    const result = await service.verifyAndReserveReferralDiscountInTransaction(
+      {
+        $queryRaw: vi
+          .fn()
+          .mockResolvedValue([
+            { id: "user-1", referredByUserId: "referrer-1", referralDiscountUsed: false },
+          ]),
+        booking: { findFirst: vi.fn().mockResolvedValue(null) },
+        user: { update: mockUserUpdate },
+      } as never,
+      "user-1",
+      {
+        eligible: true,
+        referrerUserId: "referrer-1",
+        discountAmount: new Decimal(5000),
+      },
+    );
+
+    expect(result).toEqual({
+      eligible: true,
+      referrerUserId: "referrer-1",
+      discountAmount: new Decimal(5000),
+    });
+    expect(mockUserUpdate).not.toHaveBeenCalled();
   });
 
   it("returns pricing eligibility when referred user meets amount and booking type rules", async () => {
@@ -240,6 +287,22 @@ describe("BookingEligibilityService", () => {
       eligible: false,
       referrerUserId: null,
       discountAmount: new Decimal(0),
+    });
+    expect(databaseService.booking.findFirst).toHaveBeenCalledWith({
+      where: {
+        userId: "user-1",
+        referralStatus: {
+          in: [
+            BookingReferralStatus.RESERVED,
+            BookingReferralStatus.APPLIED,
+            BookingReferralStatus.REWARDED,
+          ],
+        },
+        status: {
+          in: [BookingStatus.PENDING, BookingStatus.CONFIRMED, BookingStatus.ACTIVE],
+        },
+      },
+      select: { id: true },
     });
   });
 

--- a/src/modules/booking/booking-eligibility.service.ts
+++ b/src/modules/booking/booking-eligibility.service.ts
@@ -56,7 +56,13 @@ export class BookingEligibilityService {
     const existingReserved = await this.databaseService.booking.findFirst({
       where: {
         userId: sessionUser.id,
-        referralStatus: { in: [BookingReferralStatus.APPLIED, BookingReferralStatus.REWARDED] },
+        referralStatus: {
+          in: [
+            BookingReferralStatus.RESERVED,
+            BookingReferralStatus.APPLIED,
+            BookingReferralStatus.REWARDED,
+          ],
+        },
         status: {
           in: [BookingStatus.PENDING, BookingStatus.CONFIRMED, BookingStatus.ACTIVE],
         },
@@ -92,7 +98,7 @@ export class BookingEligibilityService {
     };
   }
 
-  async verifyAndClaimReferralDiscountInTransaction(
+  async verifyAndReserveReferralDiscountInTransaction(
     tx: Prisma.TransactionClient,
     userId: string,
     preliminaryEligibility: ReferralEligibility,
@@ -128,12 +134,35 @@ export class BookingEligibilityService {
       return this.getIneligibleReferralEligibility();
     }
 
-    await tx.user.update({
-      where: { id: userId },
-      data: { referralDiscountUsed: true },
+    const existingReserved = await tx.booking.findFirst({
+      where: {
+        userId,
+        referralStatus: {
+          in: [
+            BookingReferralStatus.RESERVED,
+            BookingReferralStatus.APPLIED,
+            BookingReferralStatus.REWARDED,
+          ],
+        },
+        status: {
+          in: [BookingStatus.PENDING, BookingStatus.CONFIRMED, BookingStatus.ACTIVE],
+        },
+      },
+      select: { id: true },
     });
 
-    this.logger.info({ userId }, "Referral discount claimed and marked as used");
+    if (existingReserved) {
+      this.logger.warn(
+        {
+          userId,
+          bookingId: existingReserved.id,
+        },
+        "Referral discount already reserved by an active booking",
+      );
+      throw new ReferralDiscountNoLongerAvailableException();
+    }
+
+    this.logger.info({ userId }, "Referral discount verified for booking reservation");
     return preliminaryEligibility;
   }
 

--- a/src/modules/booking/booking-persistence.service.ts
+++ b/src/modules/booking/booking-persistence.service.ts
@@ -189,7 +189,7 @@ export class BookingPersistenceService {
         : null,
       referralDiscountAmount: referralEligibility.discountAmount,
       referralStatus: referralEligibility.eligible
-        ? BookingReferralStatus.APPLIED
+        ? BookingReferralStatus.RESERVED
         : BookingReferralStatus.NONE,
       referralCreditsUsed: financials.creditsUsed,
       referralCreditsReserved: financials.creditsUsed,

--- a/src/modules/referral/referral-api.service.spec.ts
+++ b/src/modules/referral/referral-api.service.spec.ts
@@ -83,7 +83,7 @@ describe("ReferralApiService", () => {
     });
     mockDatabaseService.booking.findFirst.mockResolvedValue({
       id: "booking-1",
-      referralStatus: BookingReferralStatus.APPLIED,
+      referralStatus: BookingReferralStatus.RESERVED,
     });
 
     const result = await service.checkReferralEligibility("user-1", 30000, "DAY");

--- a/src/modules/referral/referral-api.service.ts
+++ b/src/modules/referral/referral-api.service.ts
@@ -66,7 +66,13 @@ export class ReferralApiService {
     const existingReserved = await this.databaseService.booking.findFirst({
       where: {
         userId,
-        referralStatus: { in: [BookingReferralStatus.APPLIED, BookingReferralStatus.REWARDED] },
+        referralStatus: {
+          in: [
+            BookingReferralStatus.RESERVED,
+            BookingReferralStatus.APPLIED,
+            BookingReferralStatus.REWARDED,
+          ],
+        },
         status: {
           in: [BookingStatus.PENDING, BookingStatus.CONFIRMED, BookingStatus.ACTIVE],
         },

--- a/src/modules/referral/referral-processing.service.ts
+++ b/src/modules/referral/referral-processing.service.ts
@@ -157,10 +157,8 @@ export class ReferralProcessingService {
           }
         }
 
-        // Mark discount used if not already.
-        // Note: This is a fallback for bookings created before the race condition fix.
-        // New bookings set referralDiscountUsed=true during booking creation (in the same transaction)
-        // to prevent concurrent bookings from all receiving the one-time discount.
+        // Mark discount used if not already. This is a fallback for bookings
+        // confirmed before the payment confirmation path marked the discount used.
         if (referee && !referee.referralDiscountUsed) {
           await tx.user.update({
             where: { id: booking.userId },


### PR DESCRIPTION
## Summary
- Add a RESERVED booking referral state so checkout creation reserves, but does not consume, a referral discount.
- Move `referralDiscountUsed` and `RESERVED -> APPLIED` transition to successful payment confirmation.
- Keep active reserved/applied/rewarded bookings blocking duplicate referral discounts, with focused unit coverage.

## Test plan
- `pnpm vitest run src/modules/booking/booking-eligibility.service.spec.ts src/modules/booking/booking-creation.service.spec.ts src/modules/booking/booking-confirmation.service.spec.ts src/modules/referral/referral-api.service.spec.ts`
- `pnpm exec tsc --noEmit --pretty false`
- Commit hook: `pnpm test` (160 files, 1435 tests)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes booking/referral state transitions and writes within payment confirmation transactions, plus a Postgres enum migration; incorrect handling could block discounts or mis-mark usage in production.
> 
> **Overview**
> Adds a new `BookingReferralStatus.RESERVED` state (Prisma + migration) to represent a referral discount held during checkout but not yet consumed.
> 
> Updates booking creation to **reserve** the discount by setting `booking.referralStatus=RESERVED` and renaming the in-transaction check from `verifyAndClaim...` to `verifyAndReserve...`, removing the earlier `user.referralDiscountUsed=true` write while still blocking concurrent active bookings from reserving/using the discount.
> 
> Moves consumption to payment confirmation: `BookingConfirmationService.confirmFromPayment` now wraps confirmation in a DB transaction and, when a booking is `RESERVED`, sets `user.referralDiscountUsed=true` and transitions `RESERVED -> APPLIED`; referral eligibility checks in `ReferralApiService` and associated unit tests are updated to treat `RESERVED` as blocking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb7624ccde2228a54926c5f386d5837db72c26b3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->