### PR TITLE
fix(referral): release stale RESERVED discount on retry and failed charge

### DIFF
--- a/src/modules/booking/booking-creation.service.spec.ts
+++ b/src/modules/booking/booking-creation.service.spec.ts
@@ -711,6 +711,8 @@ describe("BookingCreationService", () => {
           flight: { upsert: vi.fn().mockResolvedValue({ id: "flight-123" }) },
           booking: {
             findFirst: vi.fn().mockResolvedValue(null),
+            findMany: vi.fn().mockResolvedValue([]),
+            findUnique: vi.fn(),
             create: vi.fn().mockResolvedValue({
               id: "booking-123",
               bookingReference: "BK-123456-ABC",
@@ -725,7 +727,7 @@ describe("BookingCreationService", () => {
               { key: "REFERRAL_RELEASE_CONDITION", value: "COMPLETED" },
             ]),
           },
-          referralReward: { create: vi.fn() },
+          referralReward: { create: vi.fn(), deleteMany: vi.fn() },
           userReferralStats: { upsert: vi.fn() },
           user: { update: vi.fn() },
         };
@@ -803,6 +805,8 @@ describe("BookingCreationService", () => {
           flight: { upsert: vi.fn().mockResolvedValue({ id: "flight-123" }) },
           booking: {
             findFirst: vi.fn().mockResolvedValue(null),
+            findMany: vi.fn().mockResolvedValue([]),
+            findUnique: vi.fn(),
             create: vi.fn().mockResolvedValue({
               id: "booking-123",
               bookingReference: "BK-123456-ABC",
@@ -817,7 +821,7 @@ describe("BookingCreationService", () => {
               { key: "REFERRAL_RELEASE_CONDITION", value: "COMPLETED" },
             ]),
           },
-          referralReward: { create: vi.fn() },
+          referralReward: { create: vi.fn(), deleteMany: vi.fn() },
           userReferralStats: { upsert: vi.fn() },
           user: { update: mockUserUpdate },
         };

--- a/src/modules/booking/booking-creation.service.spec.ts
+++ b/src/modules/booking/booking-creation.service.spec.ts
@@ -727,8 +727,12 @@ describe("BookingCreationService", () => {
               { key: "REFERRAL_RELEASE_CONDITION", value: "COMPLETED" },
             ]),
           },
-          referralReward: { create: vi.fn(), deleteMany: vi.fn() },
-          userReferralStats: { upsert: vi.fn() },
+          referralReward: {
+            create: vi.fn(),
+            findMany: vi.fn().mockResolvedValue([]),
+            updateMany: vi.fn(),
+          },
+          userReferralStats: { upsert: vi.fn(), findUnique: vi.fn(), update: vi.fn() },
           user: { update: vi.fn() },
         };
 
@@ -821,8 +825,12 @@ describe("BookingCreationService", () => {
               { key: "REFERRAL_RELEASE_CONDITION", value: "COMPLETED" },
             ]),
           },
-          referralReward: { create: vi.fn(), deleteMany: vi.fn() },
-          userReferralStats: { upsert: vi.fn() },
+          referralReward: {
+            create: vi.fn(),
+            findMany: vi.fn().mockResolvedValue([]),
+            updateMany: vi.fn(),
+          },
+          userReferralStats: { upsert: vi.fn(), findUnique: vi.fn(), update: vi.fn() },
           user: { update: mockUserUpdate },
         };
 

--- a/src/modules/booking/booking-eligibility.service.spec.ts
+++ b/src/modules/booking/booking-eligibility.service.spec.ts
@@ -1,5 +1,10 @@
 import { Test, type TestingModule } from "@nestjs/testing";
-import { BookingReferralStatus, BookingStatus } from "@prisma/client";
+import {
+  BookingReferralStatus,
+  BookingStatus,
+  PaymentStatus,
+  ReferralRewardStatus,
+} from "@prisma/client";
 import Decimal from "decimal.js";
 import { describe, expect, it, vi } from "vitest";
 import { mockPinoLoggerToken } from "@/testing/nest-pino-logger.mock";
@@ -186,7 +191,13 @@ describe("BookingEligibilityService", () => {
           .mockResolvedValue([
             { id: "user-1", referredByUserId: "referrer-1", referralDiscountUsed: false },
           ]),
-        booking: { findFirst: vi.fn().mockResolvedValue(null) },
+        booking: {
+          findFirst: vi.fn().mockResolvedValue(null),
+          findMany: vi.fn().mockResolvedValue([]),
+          findUnique: vi.fn(),
+          update: vi.fn(),
+        },
+        referralReward: { deleteMany: vi.fn() },
         user: { update: mockUserUpdate },
       } as never,
       "user-1",
@@ -291,16 +302,20 @@ describe("BookingEligibilityService", () => {
     expect(databaseService.booking.findFirst).toHaveBeenCalledWith({
       where: {
         userId: "user-1",
-        referralStatus: {
-          in: [
-            BookingReferralStatus.RESERVED,
-            BookingReferralStatus.APPLIED,
-            BookingReferralStatus.REWARDED,
-          ],
-        },
         status: {
           in: [BookingStatus.PENDING, BookingStatus.CONFIRMED, BookingStatus.ACTIVE],
         },
+        OR: [
+          {
+            referralStatus: {
+              in: [BookingReferralStatus.APPLIED, BookingReferralStatus.REWARDED],
+            },
+          },
+          {
+            referralStatus: BookingReferralStatus.RESERVED,
+            paymentStatus: { not: PaymentStatus.UNPAID },
+          },
+        ],
       },
       select: { id: true },
     });
@@ -355,5 +370,340 @@ describe("BookingEligibilityService", () => {
         totalRewardsPending: { increment: new Decimal(2500) },
       },
     });
+  });
+
+  it("ignores stale RESERVED+PENDING+UNPAID bookings when checking pricing eligibility", async () => {
+    const databaseService = {
+      user: {
+        findUnique: vi
+          .fn()
+          .mockResolvedValue(
+            createUser({ referredByUserId: "referrer-1", referralDiscountUsed: false }),
+          ),
+      },
+      booking: { findFirst: vi.fn().mockResolvedValue(null) },
+      referralProgramConfig: {
+        findMany: vi.fn().mockResolvedValue([
+          { key: "REFERRAL_ENABLED", value: true },
+          { key: "REFERRAL_DISCOUNT_AMOUNT", value: "5000" },
+        ]),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BookingEligibilityService,
+        { provide: DatabaseService, useValue: databaseService },
+      ],
+    })
+      .useMocker(mockPinoLoggerToken)
+      .compile();
+
+    const service = module.get<BookingEligibilityService>(BookingEligibilityService);
+    const result = await service.checkReferralEligibilityForPricing(
+      { id: "user-1" } as never,
+      new Decimal(52500),
+      "DAY",
+    );
+
+    expect(result).toEqual({
+      eligible: true,
+      referrerUserId: "referrer-1",
+      discountAmount: new Decimal(5000),
+    });
+    // The OR branch covering RESERVED requires paymentStatus != UNPAID, so an abandoned
+    // checkout (RESERVED + PENDING + UNPAID) doesn't match and the user stays eligible.
+    expect(databaseService.booking.findFirst).toHaveBeenCalledWith({
+      where: {
+        userId: "user-1",
+        status: {
+          in: [BookingStatus.PENDING, BookingStatus.CONFIRMED, BookingStatus.ACTIVE],
+        },
+        OR: [
+          {
+            referralStatus: {
+              in: [BookingReferralStatus.APPLIED, BookingReferralStatus.REWARDED],
+            },
+          },
+          {
+            referralStatus: BookingReferralStatus.RESERVED,
+            paymentStatus: { not: PaymentStatus.UNPAID },
+          },
+        ],
+      },
+      select: { id: true },
+    });
+  });
+
+  describe("releaseReferralReservation", () => {
+    const buildService = async () => {
+      const module = await Test.createTestingModule({
+        providers: [
+          BookingEligibilityService,
+          {
+            provide: DatabaseService,
+            useValue: {
+              user: { findUnique: vi.fn() },
+              referralProgramConfig: { findMany: vi.fn() },
+            },
+          },
+        ],
+      })
+        .useMocker(mockPinoLoggerToken)
+        .compile();
+      return module.get<BookingEligibilityService>(BookingEligibilityService);
+    };
+
+    it("clears the reservation and deletes pending reward when releasable", async () => {
+      const service = await buildService();
+      const bookingUpdate = vi.fn().mockResolvedValue({});
+      const rewardDeleteMany = vi.fn().mockResolvedValue({ count: 1 });
+      const bookingFindUnique = vi.fn().mockResolvedValue({
+        id: "booking-1",
+        userId: "user-1",
+        referralStatus: BookingReferralStatus.RESERVED,
+        status: BookingStatus.PENDING,
+        paymentStatus: PaymentStatus.UNPAID,
+      });
+
+      const result = await service.releaseReferralReservation(
+        {
+          booking: { findUnique: bookingFindUnique, update: bookingUpdate },
+          referralReward: { deleteMany: rewardDeleteMany },
+        } as never,
+        "booking-1",
+      );
+
+      expect(result).toEqual({ released: true });
+      expect(bookingUpdate).toHaveBeenCalledWith({
+        where: { id: "booking-1" },
+        data: {
+          referralStatus: BookingReferralStatus.REVERSED,
+          referralDiscountAmount: new Decimal(0),
+          referralReferrerUserId: null,
+        },
+      });
+      expect(rewardDeleteMany).toHaveBeenCalledWith({
+        where: {
+          bookingId: "booking-1",
+          status: ReferralRewardStatus.PENDING,
+        },
+      });
+    });
+
+    it("is a no-op when the booking is missing", async () => {
+      const service = await buildService();
+      const bookingUpdate = vi.fn();
+      const rewardDeleteMany = vi.fn();
+
+      const result = await service.releaseReferralReservation(
+        {
+          booking: { findUnique: vi.fn().mockResolvedValue(null), update: bookingUpdate },
+          referralReward: { deleteMany: rewardDeleteMany },
+        } as never,
+        "missing-booking",
+      );
+
+      expect(result).toEqual({ released: false });
+      expect(bookingUpdate).not.toHaveBeenCalled();
+      expect(rewardDeleteMany).not.toHaveBeenCalled();
+    });
+
+    it("does not release a discount that has already been APPLIED", async () => {
+      const service = await buildService();
+      const bookingUpdate = vi.fn();
+      const rewardDeleteMany = vi.fn();
+
+      const result = await service.releaseReferralReservation(
+        {
+          booking: {
+            findUnique: vi.fn().mockResolvedValue({
+              id: "booking-1",
+              userId: "user-1",
+              referralStatus: BookingReferralStatus.APPLIED,
+              status: BookingStatus.CONFIRMED,
+              paymentStatus: PaymentStatus.PAID,
+            }),
+            update: bookingUpdate,
+          },
+          referralReward: { deleteMany: rewardDeleteMany },
+        } as never,
+        "booking-1",
+      );
+
+      expect(result).toEqual({ released: false });
+      expect(bookingUpdate).not.toHaveBeenCalled();
+      expect(rewardDeleteMany).not.toHaveBeenCalled();
+    });
+
+    it("does not release a reservation that is already mid-payment", async () => {
+      const service = await buildService();
+      const bookingUpdate = vi.fn();
+      const rewardDeleteMany = vi.fn();
+
+      const result = await service.releaseReferralReservation(
+        {
+          booking: {
+            findUnique: vi.fn().mockResolvedValue({
+              id: "booking-1",
+              userId: "user-1",
+              referralStatus: BookingReferralStatus.RESERVED,
+              status: BookingStatus.PENDING,
+              paymentStatus: PaymentStatus.PAID,
+            }),
+            update: bookingUpdate,
+          },
+          referralReward: { deleteMany: rewardDeleteMany },
+        } as never,
+        "booking-1",
+      );
+
+      expect(result).toEqual({ released: false });
+      expect(bookingUpdate).not.toHaveBeenCalled();
+      expect(rewardDeleteMany).not.toHaveBeenCalled();
+    });
+  });
+
+  it("releases stale reservations before reserving a new discount", async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BookingEligibilityService,
+        {
+          provide: DatabaseService,
+          useValue: {
+            user: { findUnique: vi.fn() },
+            referralProgramConfig: { findMany: vi.fn() },
+          },
+        },
+      ],
+    })
+      .useMocker(mockPinoLoggerToken)
+      .compile();
+
+    const service = module.get<BookingEligibilityService>(BookingEligibilityService);
+
+    const bookingFindMany = vi
+      .fn()
+      .mockResolvedValueOnce([{ id: "stale-booking-1" }, { id: "stale-booking-2" }]);
+    const bookingFindUnique = vi
+      .fn()
+      .mockResolvedValueOnce({
+        id: "stale-booking-1",
+        userId: "user-1",
+        referralStatus: BookingReferralStatus.RESERVED,
+        status: BookingStatus.PENDING,
+        paymentStatus: PaymentStatus.UNPAID,
+      })
+      .mockResolvedValueOnce({
+        id: "stale-booking-2",
+        userId: "user-1",
+        referralStatus: BookingReferralStatus.RESERVED,
+        status: BookingStatus.PENDING,
+        paymentStatus: PaymentStatus.UNPAID,
+      });
+    const bookingUpdate = vi.fn().mockResolvedValue({});
+    const rewardDeleteMany = vi.fn().mockResolvedValue({ count: 0 });
+    const bookingFindFirst = vi.fn().mockResolvedValue(null);
+
+    const result = await service.verifyAndReserveReferralDiscountInTransaction(
+      {
+        $queryRaw: vi
+          .fn()
+          .mockResolvedValue([
+            { id: "user-1", referredByUserId: "referrer-1", referralDiscountUsed: false },
+          ]),
+        booking: {
+          findMany: bookingFindMany,
+          findUnique: bookingFindUnique,
+          findFirst: bookingFindFirst,
+          update: bookingUpdate,
+        },
+        referralReward: { deleteMany: rewardDeleteMany },
+        user: { update: vi.fn() },
+      } as never,
+      "user-1",
+      {
+        eligible: true,
+        referrerUserId: "referrer-1",
+        discountAmount: new Decimal(5000),
+      },
+    );
+
+    expect(result).toEqual({
+      eligible: true,
+      referrerUserId: "referrer-1",
+      discountAmount: new Decimal(5000),
+    });
+    expect(bookingFindMany).toHaveBeenCalledWith({
+      where: {
+        userId: "user-1",
+        referralStatus: BookingReferralStatus.RESERVED,
+        status: BookingStatus.PENDING,
+        paymentStatus: PaymentStatus.UNPAID,
+      },
+      select: { id: true },
+    });
+    expect(bookingUpdate).toHaveBeenCalledTimes(2);
+    expect(bookingUpdate).toHaveBeenNthCalledWith(1, {
+      where: { id: "stale-booking-1" },
+      data: {
+        referralStatus: BookingReferralStatus.REVERSED,
+        referralDiscountAmount: new Decimal(0),
+        referralReferrerUserId: null,
+      },
+    });
+    expect(bookingUpdate).toHaveBeenNthCalledWith(2, {
+      where: { id: "stale-booking-2" },
+      data: {
+        referralStatus: BookingReferralStatus.REVERSED,
+        referralDiscountAmount: new Decimal(0),
+        referralReferrerUserId: null,
+      },
+    });
+  });
+
+  it("still throws when an in-flight (PAID) reservation blocks reuse after stale release", async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BookingEligibilityService,
+        {
+          provide: DatabaseService,
+          useValue: {
+            user: { findUnique: vi.fn() },
+            referralProgramConfig: { findMany: vi.fn() },
+          },
+        },
+      ],
+    })
+      .useMocker(mockPinoLoggerToken)
+      .compile();
+
+    const service = module.get<BookingEligibilityService>(BookingEligibilityService);
+
+    await expect(
+      service.verifyAndReserveReferralDiscountInTransaction(
+        {
+          $queryRaw: vi
+            .fn()
+            .mockResolvedValue([
+              { id: "user-1", referredByUserId: "referrer-1", referralDiscountUsed: false },
+            ]),
+          booking: {
+            findMany: vi.fn().mockResolvedValue([]),
+            findUnique: vi.fn(),
+            findFirst: vi.fn().mockResolvedValue({ id: "in-flight-booking" }),
+            update: vi.fn(),
+          },
+          referralReward: { deleteMany: vi.fn() },
+          user: { update: vi.fn() },
+        } as never,
+        "user-1",
+        {
+          eligible: true,
+          referrerUserId: "referrer-1",
+          discountAmount: new Decimal(5000),
+        },
+      ),
+    ).rejects.toThrow(ReferralDiscountNoLongerAvailableException);
   });
 });

--- a/src/modules/booking/booking-eligibility.service.spec.ts
+++ b/src/modules/booking/booking-eligibility.service.spec.ts
@@ -196,7 +196,8 @@ describe("BookingEligibilityService", () => {
           findMany: vi.fn().mockResolvedValue([]),
           updateMany: vi.fn(),
         },
-        referralReward: { deleteMany: vi.fn() },
+        referralReward: { findMany: vi.fn(), updateMany: vi.fn() },
+        userReferralStats: { findUnique: vi.fn(), update: vi.fn() },
         user: { update: mockUserUpdate },
       } as never,
       "user-1",
@@ -453,16 +454,53 @@ describe("BookingEligibilityService", () => {
       return module.get<BookingEligibilityService>(BookingEligibilityService);
     };
 
-    it("clears the reservation and deletes pending reward when the conditional update affects a row", async () => {
+    const buildTx = (
+      overrides: {
+        bookingUpdateMany?: ReturnType<typeof vi.fn>;
+        rewardFindMany?: ReturnType<typeof vi.fn>;
+        rewardUpdateMany?: ReturnType<typeof vi.fn>;
+        statsFindUnique?: ReturnType<typeof vi.fn>;
+        statsUpdate?: ReturnType<typeof vi.fn>;
+      } = {},
+    ) => ({
+      booking: {
+        updateMany: overrides.bookingUpdateMany ?? vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      referralReward: {
+        findMany: overrides.rewardFindMany ?? vi.fn().mockResolvedValue([]),
+        updateMany: overrides.rewardUpdateMany ?? vi.fn().mockResolvedValue({ count: 0 }),
+      },
+      userReferralStats: {
+        findUnique: overrides.statsFindUnique ?? vi.fn(),
+        update: overrides.statsUpdate ?? vi.fn(),
+      },
+    });
+
+    it("flips the booking, soft-deletes the pending reward to REVERSED, and decrements referrer stats", async () => {
       const service = await buildService();
       const bookingUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
-      const rewardDeleteMany = vi.fn().mockResolvedValue({ count: 1 });
+      const rewardFindMany = vi.fn().mockResolvedValue([
+        {
+          id: "reward-1",
+          referrerUserId: "referrer-1",
+          amount: new Decimal(2500),
+        },
+      ]);
+      const rewardUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
+      const statsFindUnique = vi.fn().mockResolvedValue({
+        totalReferrals: 3,
+        totalRewardsPending: new Decimal(7500),
+      });
+      const statsUpdate = vi.fn().mockResolvedValue({});
 
       const result = await service.releaseReferralReservation(
-        {
-          booking: { updateMany: bookingUpdateMany },
-          referralReward: { deleteMany: rewardDeleteMany },
-        } as never,
+        buildTx({
+          bookingUpdateMany,
+          rewardFindMany,
+          rewardUpdateMany,
+          statsFindUnique,
+          statsUpdate,
+        }) as never,
         "booking-1",
       );
 
@@ -480,10 +518,30 @@ describe("BookingEligibilityService", () => {
           referralReferrerUserId: null,
         },
       });
-      expect(rewardDeleteMany).toHaveBeenCalledWith({
+      expect(rewardFindMany).toHaveBeenCalledWith({
+        where: { bookingId: "booking-1", status: ReferralRewardStatus.PENDING },
+        select: { id: true, referrerUserId: true, amount: true },
+      });
+      expect(rewardUpdateMany).toHaveBeenCalledWith({
         where: {
-          bookingId: "booking-1",
+          id: { in: ["reward-1"] },
           status: ReferralRewardStatus.PENDING,
+        },
+        data: {
+          status: ReferralRewardStatus.REVERSED,
+          processedAt: expect.any(Date),
+          reason: "RESERVATION_RELEASED",
+        },
+      });
+      expect(statsFindUnique).toHaveBeenCalledWith({
+        where: { userId: "referrer-1" },
+        select: { totalReferrals: true, totalRewardsPending: true },
+      });
+      expect(statsUpdate).toHaveBeenCalledWith({
+        where: { userId: "referrer-1" },
+        data: {
+          totalReferrals: 2,
+          totalRewardsPending: new Decimal(5000),
         },
       });
     });
@@ -493,21 +551,148 @@ describe("BookingEligibilityService", () => {
     // the state predicates live in the WHERE clause. We can't distinguish those
     // scenarios at the unit level without a real DB; the E2E test in
     // booking-flow.e2e-spec.ts asserts on the actual states.
-    it("is a no-op when the conditional update affects zero rows", async () => {
+    it("is a no-op when the conditional booking update affects zero rows", async () => {
       const service = await buildService();
       const bookingUpdateMany = vi.fn().mockResolvedValue({ count: 0 });
-      const rewardDeleteMany = vi.fn();
+      const rewardFindMany = vi.fn();
+      const rewardUpdateMany = vi.fn();
+      const statsUpdate = vi.fn();
 
       const result = await service.releaseReferralReservation(
-        {
-          booking: { updateMany: bookingUpdateMany },
-          referralReward: { deleteMany: rewardDeleteMany },
-        } as never,
+        buildTx({
+          bookingUpdateMany,
+          rewardFindMany,
+          rewardUpdateMany,
+          statsUpdate,
+        }) as never,
         "booking-1",
       );
 
       expect(result).toEqual({ released: false });
-      expect(rewardDeleteMany).not.toHaveBeenCalled();
+      expect(rewardFindMany).not.toHaveBeenCalled();
+      expect(rewardUpdateMany).not.toHaveBeenCalled();
+      expect(statsUpdate).not.toHaveBeenCalled();
+    });
+
+    it("skips reward updates and stats decrement when no PENDING rewards exist for the booking", async () => {
+      const service = await buildService();
+      const rewardFindMany = vi.fn().mockResolvedValue([]);
+      const rewardUpdateMany = vi.fn();
+      const statsFindUnique = vi.fn();
+      const statsUpdate = vi.fn();
+
+      const result = await service.releaseReferralReservation(
+        buildTx({ rewardFindMany, rewardUpdateMany, statsFindUnique, statsUpdate }) as never,
+        "booking-1",
+      );
+
+      expect(result).toEqual({ released: true });
+      expect(rewardUpdateMany).not.toHaveBeenCalled();
+      expect(statsFindUnique).not.toHaveBeenCalled();
+      expect(statsUpdate).not.toHaveBeenCalled();
+    });
+
+    it("floors stats counters at zero when current values are lower than the decrement (drift defense)", async () => {
+      const service = await buildService();
+      const rewardFindMany = vi.fn().mockResolvedValue([
+        {
+          id: "reward-1",
+          referrerUserId: "referrer-1",
+          amount: new Decimal(5000),
+        },
+      ]);
+      const statsFindUnique = vi.fn().mockResolvedValue({
+        totalReferrals: 0,
+        totalRewardsPending: new Decimal(1000),
+      });
+      const statsUpdate = vi.fn().mockResolvedValue({});
+
+      await service.releaseReferralReservation(
+        buildTx({ rewardFindMany, statsFindUnique, statsUpdate }) as never,
+        "booking-1",
+      );
+
+      expect(statsUpdate).toHaveBeenCalledWith({
+        where: { userId: "referrer-1" },
+        data: {
+          totalReferrals: 0,
+          totalRewardsPending: new Decimal(0),
+        },
+      });
+    });
+
+    it("skips the stats update and warns when no UserReferralStats row exists", async () => {
+      const service = await buildService();
+      const rewardFindMany = vi.fn().mockResolvedValue([
+        {
+          id: "reward-1",
+          referrerUserId: "referrer-missing",
+          amount: new Decimal(2500),
+        },
+      ]);
+      const statsFindUnique = vi.fn().mockResolvedValue(null);
+      const statsUpdate = vi.fn();
+
+      const result = await service.releaseReferralReservation(
+        buildTx({ rewardFindMany, statsFindUnique, statsUpdate }) as never,
+        "booking-1",
+      );
+
+      expect(result).toEqual({ released: true });
+      expect(statsFindUnique).toHaveBeenCalledWith({
+        where: { userId: "referrer-missing" },
+        select: { totalReferrals: true, totalRewardsPending: true },
+      });
+      expect(statsUpdate).not.toHaveBeenCalled();
+    });
+
+    it("aggregates multiple PENDING rewards per referrer into a single stats update", async () => {
+      const service = await buildService();
+      const rewardFindMany = vi.fn().mockResolvedValue([
+        {
+          id: "reward-1",
+          referrerUserId: "referrer-1",
+          amount: new Decimal(2500),
+        },
+        {
+          id: "reward-2",
+          referrerUserId: "referrer-1",
+          amount: new Decimal(1500),
+        },
+        {
+          id: "reward-3",
+          referrerUserId: "referrer-2",
+          amount: new Decimal(3000),
+        },
+      ]);
+      const statsFindUnique = vi.fn().mockImplementation(({ where }) => {
+        if (where.userId === "referrer-1") {
+          return Promise.resolve({ totalReferrals: 5, totalRewardsPending: new Decimal(10000) });
+        }
+        return Promise.resolve({ totalReferrals: 2, totalRewardsPending: new Decimal(5000) });
+      });
+      const statsUpdate = vi.fn().mockResolvedValue({});
+
+      await service.releaseReferralReservation(
+        buildTx({ rewardFindMany, statsFindUnique, statsUpdate }) as never,
+        "booking-1",
+      );
+
+      expect(statsUpdate).toHaveBeenCalledTimes(2);
+      expect(statsUpdate).toHaveBeenCalledWith({
+        where: { userId: "referrer-1" },
+        data: {
+          totalReferrals: 3,
+          totalRewardsPending: new Decimal(6000),
+        },
+      });
+      expect(statsUpdate).toHaveBeenCalledWith({
+        where: { userId: "referrer-2" },
+        data: {
+          totalReferrals: 1,
+          totalRewardsPending: new Decimal(2000),
+        },
+      });
     });
   });
 
@@ -533,7 +718,8 @@ describe("BookingEligibilityService", () => {
       .fn()
       .mockResolvedValueOnce([{ id: "stale-booking-1" }, { id: "stale-booking-2" }]);
     const bookingUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
-    const rewardDeleteMany = vi.fn().mockResolvedValue({ count: 0 });
+    const rewardFindMany = vi.fn().mockResolvedValue([]);
+    const rewardUpdateMany = vi.fn();
     const bookingFindFirst = vi.fn().mockResolvedValue(null);
 
     const result = await service.verifyAndReserveReferralDiscountInTransaction(
@@ -548,7 +734,8 @@ describe("BookingEligibilityService", () => {
           findFirst: bookingFindFirst,
           updateMany: bookingUpdateMany,
         },
-        referralReward: { deleteMany: rewardDeleteMany },
+        referralReward: { findMany: rewardFindMany, updateMany: rewardUpdateMany },
+        userReferralStats: { findUnique: vi.fn(), update: vi.fn() },
         user: { update: vi.fn() },
       } as never,
       "user-1",
@@ -630,7 +817,8 @@ describe("BookingEligibilityService", () => {
             findFirst: vi.fn().mockResolvedValue({ id: "in-flight-booking" }),
             updateMany: vi.fn(),
           },
-          referralReward: { deleteMany: vi.fn() },
+          referralReward: { findMany: vi.fn(), updateMany: vi.fn() },
+          userReferralStats: { findUnique: vi.fn(), update: vi.fn() },
           user: { update: vi.fn() },
         } as never,
         "user-1",

--- a/src/modules/booking/booking-eligibility.service.spec.ts
+++ b/src/modules/booking/booking-eligibility.service.spec.ts
@@ -194,8 +194,7 @@ describe("BookingEligibilityService", () => {
         booking: {
           findFirst: vi.fn().mockResolvedValue(null),
           findMany: vi.fn().mockResolvedValue([]),
-          findUnique: vi.fn(),
-          update: vi.fn(),
+          updateMany: vi.fn(),
         },
         referralReward: { deleteMany: vi.fn() },
         user: { update: mockUserUpdate },
@@ -454,29 +453,27 @@ describe("BookingEligibilityService", () => {
       return module.get<BookingEligibilityService>(BookingEligibilityService);
     };
 
-    it("clears the reservation and deletes pending reward when releasable", async () => {
+    it("clears the reservation and deletes pending reward when the conditional update affects a row", async () => {
       const service = await buildService();
-      const bookingUpdate = vi.fn().mockResolvedValue({});
+      const bookingUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
       const rewardDeleteMany = vi.fn().mockResolvedValue({ count: 1 });
-      const bookingFindUnique = vi.fn().mockResolvedValue({
-        id: "booking-1",
-        userId: "user-1",
-        referralStatus: BookingReferralStatus.RESERVED,
-        status: BookingStatus.PENDING,
-        paymentStatus: PaymentStatus.UNPAID,
-      });
 
       const result = await service.releaseReferralReservation(
         {
-          booking: { findUnique: bookingFindUnique, update: bookingUpdate },
+          booking: { updateMany: bookingUpdateMany },
           referralReward: { deleteMany: rewardDeleteMany },
         } as never,
         "booking-1",
       );
 
       expect(result).toEqual({ released: true });
-      expect(bookingUpdate).toHaveBeenCalledWith({
-        where: { id: "booking-1" },
+      expect(bookingUpdateMany).toHaveBeenCalledWith({
+        where: {
+          id: "booking-1",
+          referralStatus: BookingReferralStatus.RESERVED,
+          status: BookingStatus.PENDING,
+          paymentStatus: PaymentStatus.UNPAID,
+        },
         data: {
           referralStatus: BookingReferralStatus.REVERSED,
           referralDiscountAmount: new Decimal(0),
@@ -491,75 +488,25 @@ describe("BookingEligibilityService", () => {
       });
     });
 
-    it("is a no-op when the booking is missing", async () => {
+    // The atomic updateMany returns count: 0 in all "not releasable" scenarios —
+    // missing booking, already APPLIED/REWARDED, or RESERVED+mid-payment — because
+    // the state predicates live in the WHERE clause. We can't distinguish those
+    // scenarios at the unit level without a real DB; the E2E test in
+    // booking-flow.e2e-spec.ts asserts on the actual states.
+    it("is a no-op when the conditional update affects zero rows", async () => {
       const service = await buildService();
-      const bookingUpdate = vi.fn();
+      const bookingUpdateMany = vi.fn().mockResolvedValue({ count: 0 });
       const rewardDeleteMany = vi.fn();
 
       const result = await service.releaseReferralReservation(
         {
-          booking: { findUnique: vi.fn().mockResolvedValue(null), update: bookingUpdate },
-          referralReward: { deleteMany: rewardDeleteMany },
-        } as never,
-        "missing-booking",
-      );
-
-      expect(result).toEqual({ released: false });
-      expect(bookingUpdate).not.toHaveBeenCalled();
-      expect(rewardDeleteMany).not.toHaveBeenCalled();
-    });
-
-    it("does not release a discount that has already been APPLIED", async () => {
-      const service = await buildService();
-      const bookingUpdate = vi.fn();
-      const rewardDeleteMany = vi.fn();
-
-      const result = await service.releaseReferralReservation(
-        {
-          booking: {
-            findUnique: vi.fn().mockResolvedValue({
-              id: "booking-1",
-              userId: "user-1",
-              referralStatus: BookingReferralStatus.APPLIED,
-              status: BookingStatus.CONFIRMED,
-              paymentStatus: PaymentStatus.PAID,
-            }),
-            update: bookingUpdate,
-          },
+          booking: { updateMany: bookingUpdateMany },
           referralReward: { deleteMany: rewardDeleteMany },
         } as never,
         "booking-1",
       );
 
       expect(result).toEqual({ released: false });
-      expect(bookingUpdate).not.toHaveBeenCalled();
-      expect(rewardDeleteMany).not.toHaveBeenCalled();
-    });
-
-    it("does not release a reservation that is already mid-payment", async () => {
-      const service = await buildService();
-      const bookingUpdate = vi.fn();
-      const rewardDeleteMany = vi.fn();
-
-      const result = await service.releaseReferralReservation(
-        {
-          booking: {
-            findUnique: vi.fn().mockResolvedValue({
-              id: "booking-1",
-              userId: "user-1",
-              referralStatus: BookingReferralStatus.RESERVED,
-              status: BookingStatus.PENDING,
-              paymentStatus: PaymentStatus.PAID,
-            }),
-            update: bookingUpdate,
-          },
-          referralReward: { deleteMany: rewardDeleteMany },
-        } as never,
-        "booking-1",
-      );
-
-      expect(result).toEqual({ released: false });
-      expect(bookingUpdate).not.toHaveBeenCalled();
       expect(rewardDeleteMany).not.toHaveBeenCalled();
     });
   });
@@ -585,23 +532,7 @@ describe("BookingEligibilityService", () => {
     const bookingFindMany = vi
       .fn()
       .mockResolvedValueOnce([{ id: "stale-booking-1" }, { id: "stale-booking-2" }]);
-    const bookingFindUnique = vi
-      .fn()
-      .mockResolvedValueOnce({
-        id: "stale-booking-1",
-        userId: "user-1",
-        referralStatus: BookingReferralStatus.RESERVED,
-        status: BookingStatus.PENDING,
-        paymentStatus: PaymentStatus.UNPAID,
-      })
-      .mockResolvedValueOnce({
-        id: "stale-booking-2",
-        userId: "user-1",
-        referralStatus: BookingReferralStatus.RESERVED,
-        status: BookingStatus.PENDING,
-        paymentStatus: PaymentStatus.UNPAID,
-      });
-    const bookingUpdate = vi.fn().mockResolvedValue({});
+    const bookingUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
     const rewardDeleteMany = vi.fn().mockResolvedValue({ count: 0 });
     const bookingFindFirst = vi.fn().mockResolvedValue(null);
 
@@ -614,9 +545,8 @@ describe("BookingEligibilityService", () => {
           ]),
         booking: {
           findMany: bookingFindMany,
-          findUnique: bookingFindUnique,
           findFirst: bookingFindFirst,
-          update: bookingUpdate,
+          updateMany: bookingUpdateMany,
         },
         referralReward: { deleteMany: rewardDeleteMany },
         user: { update: vi.fn() },
@@ -643,22 +573,29 @@ describe("BookingEligibilityService", () => {
       },
       select: { id: true },
     });
-    expect(bookingUpdate).toHaveBeenCalledTimes(2);
-    expect(bookingUpdate).toHaveBeenNthCalledWith(1, {
-      where: { id: "stale-booking-1" },
-      data: {
-        referralStatus: BookingReferralStatus.REVERSED,
-        referralDiscountAmount: new Decimal(0),
-        referralReferrerUserId: null,
+    expect(bookingUpdateMany).toHaveBeenCalledTimes(2);
+    const expectedUpdateData = {
+      referralStatus: BookingReferralStatus.REVERSED,
+      referralDiscountAmount: new Decimal(0),
+      referralReferrerUserId: null,
+    };
+    expect(bookingUpdateMany).toHaveBeenNthCalledWith(1, {
+      where: {
+        id: "stale-booking-1",
+        referralStatus: BookingReferralStatus.RESERVED,
+        status: BookingStatus.PENDING,
+        paymentStatus: PaymentStatus.UNPAID,
       },
+      data: expectedUpdateData,
     });
-    expect(bookingUpdate).toHaveBeenNthCalledWith(2, {
-      where: { id: "stale-booking-2" },
-      data: {
-        referralStatus: BookingReferralStatus.REVERSED,
-        referralDiscountAmount: new Decimal(0),
-        referralReferrerUserId: null,
+    expect(bookingUpdateMany).toHaveBeenNthCalledWith(2, {
+      where: {
+        id: "stale-booking-2",
+        referralStatus: BookingReferralStatus.RESERVED,
+        status: BookingStatus.PENDING,
+        paymentStatus: PaymentStatus.UNPAID,
       },
+      data: expectedUpdateData,
     });
   });
 
@@ -690,9 +627,8 @@ describe("BookingEligibilityService", () => {
             ]),
           booking: {
             findMany: vi.fn().mockResolvedValue([]),
-            findUnique: vi.fn(),
             findFirst: vi.fn().mockResolvedValue({ id: "in-flight-booking" }),
-            update: vi.fn(),
+            updateMany: vi.fn(),
           },
           referralReward: { deleteMany: vi.fn() },
           user: { update: vi.fn() },

--- a/src/modules/booking/booking-eligibility.service.ts
+++ b/src/modules/booking/booking-eligibility.service.ts
@@ -14,6 +14,14 @@ import { DatabaseService } from "../database/database.service";
 import { ReferralDiscountNoLongerAvailableException } from "./booking.error";
 import type { ReferralEligibility } from "./booking.interface";
 
+/**
+ * Stored on `ReferralReward.reason` when a PENDING reward is tombstoned by
+ * `releaseReferralReservation`. Distinct from `referral-processing.service.ts`
+ * reversal reasons so audit logs can tell apart "user abandoned checkout" from
+ * "release condition failed downstream".
+ */
+const RELEASED_RESERVATION_REASON = "RESERVATION_RELEASED";
+
 @Injectable()
 export class BookingEligibilityService {
   constructor(
@@ -160,7 +168,13 @@ export class BookingEligibilityService {
    * Effects when releasing:
    * - Clears `referralReferrerUserId`, zeroes `referralDiscountAmount`
    * - Sets `referralStatus = REVERSED`
-   * - Deletes any PENDING `ReferralReward` rows tied to the booking
+   * - Soft-deletes any PENDING `ReferralReward` rows tied to the booking
+   *   (status → REVERSED, sets `processedAt` and `reason`) so the audit trail
+   *   of the reservation attempt is preserved
+   * - Decrements the referrer's `UserReferralStats` counters
+   *   (`totalReferrals`, `totalRewardsPending`) that `createReferralRewardIfEligible`
+   *   incremented when the reservation was first made, with a floor at zero to
+   *   defend against any historical drift
    *
    * Call this from a transaction so the reservation release is atomic with any
    * dependent work (e.g. reserving a new discount on a fresh booking).
@@ -192,16 +206,104 @@ export class BookingEligibilityService {
       return { released: false };
     }
 
-    await tx.referralReward.deleteMany({
-      where: {
-        bookingId,
-        status: ReferralRewardStatus.PENDING,
-      },
+    // Capture referrer + amount before flipping the rows: `updateMany` returns a
+    // count only, but we need this data to decrement the matching stats counters.
+    const pendingRewards = await tx.referralReward.findMany({
+      where: { bookingId, status: ReferralRewardStatus.PENDING },
+      select: { id: true, referrerUserId: true, amount: true },
     });
 
-    this.logger.info({ bookingId }, "Released referral reservation");
+    if (pendingRewards.length > 0) {
+      // Soft-delete: tombstone the row with status REVERSED + processedAt + reason
+      // so we keep an auditable record of every reservation attempt. The re-check
+      // on `status: PENDING` is a guard against a concurrent writer transitioning
+      // the same row in between our findMany and updateMany.
+      await tx.referralReward.updateMany({
+        where: {
+          id: { in: pendingRewards.map((r) => r.id) },
+          status: ReferralRewardStatus.PENDING,
+        },
+        data: {
+          status: ReferralRewardStatus.REVERSED,
+          processedAt: new Date(),
+          reason: RELEASED_RESERVATION_REASON,
+        },
+      });
+
+      await this.decrementReferralStatsForReversedRewards(tx, pendingRewards);
+    }
+
+    this.logger.info(
+      { bookingId, reversedRewards: pendingRewards.length },
+      "Released referral reservation",
+    );
 
     return { released: true };
+  }
+
+  /**
+   * Decrement `UserReferralStats` for each referrer affected by reward reversal.
+   *
+   * Read-modify-write inside the caller's transaction (safe because the tx sees
+   * a consistent snapshot) with floor-at-zero — mirrors the pattern used in
+   * `referral-processing.service.ts` when releasing a pending reward, and
+   * defends against pre-existing drift where the counters might already be
+   * lower than the decrement would suggest.
+   *
+   * Aggregates per referrer so a future where one booking has multiple PENDING
+   * rewards for the same referrer collapses into a single update (today the
+   * create path only ever produces one PENDING reward per booking).
+   */
+  private async decrementReferralStatsForReversedRewards(
+    tx: Prisma.TransactionClient,
+    rewards: Array<{ referrerUserId: string; amount: Decimal | Prisma.Decimal }>,
+  ): Promise<void> {
+    const perReferrer = new Map<string, { count: number; amount: Decimal }>();
+    for (const reward of rewards) {
+      const current = perReferrer.get(reward.referrerUserId) ?? {
+        count: 0,
+        amount: new Decimal(0),
+      };
+      perReferrer.set(reward.referrerUserId, {
+        count: current.count + 1,
+        amount: current.amount.plus(new Decimal(reward.amount.toString())),
+      });
+    }
+
+    for (const [referrerUserId, { count, amount }] of perReferrer) {
+      const stats = await tx.userReferralStats.findUnique({
+        where: { userId: referrerUserId },
+        select: { totalReferrals: true, totalRewardsPending: true },
+      });
+
+      if (!stats) {
+        // No row to decrement against. This should not happen in practice
+        // because `createReferralRewardIfEligible` upserts the row when it
+        // creates the PENDING reward, but if we hit it we'd rather log than
+        // create a meaningless zero row.
+        this.logger.warn(
+          {
+            referrerUserId,
+            decrementCount: count,
+            decrementAmount: amount.toString(),
+          },
+          "No userReferralStats row to decrement; skipping",
+        );
+        continue;
+      }
+
+      const newReferrals = Math.max(0, stats.totalReferrals - count);
+      const newPendingRaw = new Decimal(stats.totalRewardsPending.toString()).minus(amount);
+      const newPending = newPendingRaw.lessThan(0) ? new Decimal(0) : newPendingRaw;
+
+      await tx.userReferralStats.update({
+        where: { userId: referrerUserId },
+        data: {
+          totalReferrals: newReferrals,
+          totalRewardsPending: newPending,
+        },
+      });
+    }
   }
 
   private buildExistingDiscountClaimFilter(userId: string): Prisma.BookingWhereInput {

--- a/src/modules/booking/booking-eligibility.service.ts
+++ b/src/modules/booking/booking-eligibility.service.ts
@@ -169,31 +169,18 @@ export class BookingEligibilityService {
     tx: Prisma.TransactionClient,
     bookingId: string,
   ): Promise<{ released: boolean }> {
-    const booking = await tx.booking.findUnique({
-      where: { id: bookingId },
-      select: {
-        id: true,
-        userId: true,
-        referralStatus: true,
-        status: true,
-        paymentStatus: true,
+    // Conditional update is atomic at the DB row level: the state predicates live
+    // in the WHERE clause, so a concurrent transition (e.g. a late charge.completed
+    // (successful) re-delivery flipping the booking to APPLIED+PAID) cannot be
+    // clobbered by a stale read-then-write race. count === 0 means another writer
+    // already moved the booking out of the releasable state.
+    const { count } = await tx.booking.updateMany({
+      where: {
+        id: bookingId,
+        referralStatus: BookingReferralStatus.RESERVED,
+        status: BookingStatus.PENDING,
+        paymentStatus: PaymentStatus.UNPAID,
       },
-    });
-
-    if (!booking) {
-      return { released: false };
-    }
-
-    if (
-      booking.referralStatus !== BookingReferralStatus.RESERVED ||
-      booking.status !== BookingStatus.PENDING ||
-      booking.paymentStatus !== PaymentStatus.UNPAID
-    ) {
-      return { released: false };
-    }
-
-    await tx.booking.update({
-      where: { id: booking.id },
       data: {
         referralStatus: BookingReferralStatus.REVERSED,
         referralDiscountAmount: new Decimal(0),
@@ -201,17 +188,18 @@ export class BookingEligibilityService {
       },
     });
 
+    if (count === 0) {
+      return { released: false };
+    }
+
     await tx.referralReward.deleteMany({
       where: {
-        bookingId: booking.id,
+        bookingId,
         status: ReferralRewardStatus.PENDING,
       },
     });
 
-    this.logger.info(
-      { bookingId: booking.id, userId: booking.userId },
-      "Released referral reservation",
-    );
+    this.logger.info({ bookingId }, "Released referral reservation");
 
     return { released: true };
   }

--- a/src/modules/booking/booking-eligibility.service.ts
+++ b/src/modules/booking/booking-eligibility.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@nestjs/common";
 import {
   BookingReferralStatus,
   BookingStatus,
+  PaymentStatus,
   Prisma,
   ReferralReleaseCondition,
   ReferralRewardStatus,
@@ -54,19 +55,7 @@ export class BookingEligibilityService {
     }
 
     const existingReserved = await this.databaseService.booking.findFirst({
-      where: {
-        userId: sessionUser.id,
-        referralStatus: {
-          in: [
-            BookingReferralStatus.RESERVED,
-            BookingReferralStatus.APPLIED,
-            BookingReferralStatus.REWARDED,
-          ],
-        },
-        status: {
-          in: [BookingStatus.PENDING, BookingStatus.CONFIRMED, BookingStatus.ACTIVE],
-        },
-      },
+      where: this.buildExistingDiscountClaimFilter(sessionUser.id),
       select: { id: true },
     });
 
@@ -134,20 +123,14 @@ export class BookingEligibilityService {
       return this.getIneligibleReferralEligibility();
     }
 
+    // A new booking attempt is the user's signal that any prior unpaid reservation is
+    // abandoned. Release those reservations first so the eligibility check below sees
+    // a fresh state. Any reservation still mid-payment (paymentStatus != UNPAID) or
+    // already settled (APPLIED/REWARDED) is preserved and will block this attempt.
+    await this.releaseStaleReferralReservationsForUser(tx, userId);
+
     const existingReserved = await tx.booking.findFirst({
-      where: {
-        userId,
-        referralStatus: {
-          in: [
-            BookingReferralStatus.RESERVED,
-            BookingReferralStatus.APPLIED,
-            BookingReferralStatus.REWARDED,
-          ],
-        },
-        status: {
-          in: [BookingStatus.PENDING, BookingStatus.CONFIRMED, BookingStatus.ACTIVE],
-        },
-      },
+      where: this.buildExistingDiscountClaimFilter(userId),
       select: { id: true },
     });
 
@@ -164,6 +147,115 @@ export class BookingEligibilityService {
 
     this.logger.info({ userId }, "Referral discount verified for booking reservation");
     return preliminaryEligibility;
+  }
+
+  /**
+   * Release a referral discount reservation tied to a booking.
+   *
+   * Idempotent: only releases when the booking is still in
+   * `RESERVED + PENDING + UNPAID` state. APPLIED/REWARDED bookings and any
+   * booking with a non-UNPAID payment status are intentionally left alone — the
+   * discount has either been settled or is mid-payment and must not be reverted.
+   *
+   * Effects when releasing:
+   * - Clears `referralReferrerUserId`, zeroes `referralDiscountAmount`
+   * - Sets `referralStatus = REVERSED`
+   * - Deletes any PENDING `ReferralReward` rows tied to the booking
+   *
+   * Call this from a transaction so the reservation release is atomic with any
+   * dependent work (e.g. reserving a new discount on a fresh booking).
+   */
+  async releaseReferralReservation(
+    tx: Prisma.TransactionClient,
+    bookingId: string,
+  ): Promise<{ released: boolean }> {
+    const booking = await tx.booking.findUnique({
+      where: { id: bookingId },
+      select: {
+        id: true,
+        userId: true,
+        referralStatus: true,
+        status: true,
+        paymentStatus: true,
+      },
+    });
+
+    if (!booking) {
+      return { released: false };
+    }
+
+    if (
+      booking.referralStatus !== BookingReferralStatus.RESERVED ||
+      booking.status !== BookingStatus.PENDING ||
+      booking.paymentStatus !== PaymentStatus.UNPAID
+    ) {
+      return { released: false };
+    }
+
+    await tx.booking.update({
+      where: { id: booking.id },
+      data: {
+        referralStatus: BookingReferralStatus.REVERSED,
+        referralDiscountAmount: new Decimal(0),
+        referralReferrerUserId: null,
+      },
+    });
+
+    await tx.referralReward.deleteMany({
+      where: {
+        bookingId: booking.id,
+        status: ReferralRewardStatus.PENDING,
+      },
+    });
+
+    this.logger.info(
+      { bookingId: booking.id, userId: booking.userId },
+      "Released referral reservation",
+    );
+
+    return { released: true };
+  }
+
+  private buildExistingDiscountClaimFilter(userId: string): Prisma.BookingWhereInput {
+    return {
+      userId,
+      status: {
+        in: [BookingStatus.PENDING, BookingStatus.CONFIRMED, BookingStatus.ACTIVE],
+      },
+      OR: [
+        // Settled uses of the discount — cannot be released.
+        {
+          referralStatus: {
+            in: [BookingReferralStatus.APPLIED, BookingReferralStatus.REWARDED],
+          },
+        },
+        // Reserved on a booking that is mid-payment or already paid. RESERVED + UNPAID
+        // is intentionally excluded here because a new booking attempt releases it.
+        {
+          referralStatus: BookingReferralStatus.RESERVED,
+          paymentStatus: { not: PaymentStatus.UNPAID },
+        },
+      ],
+    };
+  }
+
+  private async releaseStaleReferralReservationsForUser(
+    tx: Prisma.TransactionClient,
+    userId: string,
+  ): Promise<void> {
+    const stale = await tx.booking.findMany({
+      where: {
+        userId,
+        referralStatus: BookingReferralStatus.RESERVED,
+        status: BookingStatus.PENDING,
+        paymentStatus: PaymentStatus.UNPAID,
+      },
+      select: { id: true },
+    });
+
+    for (const { id } of stale) {
+      await this.releaseReferralReservation(tx, id);
+    }
   }
 
   async createReferralRewardIfEligible(

--- a/src/modules/payment/charge-completed.handler.spec.ts
+++ b/src/modules/payment/charge-completed.handler.spec.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mockPinoLoggerToken } from "@/testing/nest-pino-logger.mock";
 import { createBooking, createExtension, createPaymentRecord } from "../../shared/helper.fixtures";
 import { BookingConfirmationService } from "../booking/booking-confirmation.service";
+import { BookingEligibilityService } from "../booking/booking-eligibility.service";
 import { ExtensionConfirmationService } from "../booking/extension-confirmation.service";
 import { DatabaseService } from "../database/database.service";
 import type { FlutterwaveChargeData } from "../flutterwave/flutterwave.interface";
@@ -17,12 +18,16 @@ describe("ChargeCompletedHandler", () => {
   let flutterwaveService: FlutterwaveService;
   let bookingConfirmationService: BookingConfirmationService;
   let extensionConfirmationService: ExtensionConfirmationService;
+  let bookingEligibilityService: BookingEligibilityService;
 
   const mockBookingConfirmationService = {
     confirmFromPayment: vi.fn(),
   };
   const mockExtensionConfirmationService = {
     confirmFromPayment: vi.fn(),
+  };
+  const mockBookingEligibilityService = {
+    releaseReferralReservation: vi.fn(),
   };
   const mockChargeData: FlutterwaveChargeData = {
     id: 12345,
@@ -67,6 +72,7 @@ describe("ChargeCompletedHandler", () => {
             extension: {
               findFirst: vi.fn(),
             },
+            $transaction: vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb({} as never)),
           },
         },
         {
@@ -77,6 +83,7 @@ describe("ChargeCompletedHandler", () => {
         },
         { provide: BookingConfirmationService, useValue: mockBookingConfirmationService },
         { provide: ExtensionConfirmationService, useValue: mockExtensionConfirmationService },
+        { provide: BookingEligibilityService, useValue: mockBookingEligibilityService },
       ],
     })
       .useMocker(mockPinoLoggerToken)
@@ -89,6 +96,7 @@ describe("ChargeCompletedHandler", () => {
     extensionConfirmationService = module.get<ExtensionConfirmationService>(
       ExtensionConfirmationService,
     );
+    bookingEligibilityService = module.get<BookingEligibilityService>(BookingEligibilityService);
     vi.clearAllMocks();
   });
 
@@ -323,5 +331,108 @@ describe("ChargeCompletedHandler", () => {
 
     expect(flutterwaveService.verifyTransaction).not.toHaveBeenCalled();
     expect(databaseService.payment.upsert).not.toHaveBeenCalled();
+  });
+
+  it("releases referral reservation and skips confirmation when verified charge is not successful", async () => {
+    const failedPayment = {
+      ...createPaymentRecord({
+        id: "payment-failed-123",
+        txRef: "tx-ref-123",
+        status: PaymentAttemptStatus.FAILED,
+        bookingId: "booking-456",
+        amountExpected: new Decimal(10000),
+        amountCharged: new Decimal(10000),
+        currency: "NGN",
+      }),
+      booking: { id: "booking-456", status: BookingStatus.PENDING },
+    };
+
+    vi.mocked(flutterwaveService.verifyTransaction).mockResolvedValueOnce({
+      status: "success",
+      message: "ok",
+      data: { ...mockChargeData, status: "failed" },
+    });
+    vi.mocked(databaseService.booking.findFirst).mockResolvedValueOnce(
+      createBooking({ id: "booking-456", totalAmount: new Decimal(10000) }),
+    );
+    vi.mocked(databaseService.extension.findFirst).mockResolvedValueOnce(null);
+    vi.mocked(databaseService.payment.upsert).mockResolvedValueOnce(failedPayment);
+    vi.mocked(bookingEligibilityService.releaseReferralReservation).mockResolvedValueOnce({
+      released: true,
+    });
+
+    await handler.handle({ ...mockChargeData, status: "failed" });
+
+    expect(databaseService.payment.upsert).toHaveBeenCalled();
+    expect(bookingEligibilityService.releaseReferralReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      "booking-456",
+    );
+    expect(bookingConfirmationService.confirmFromPayment).not.toHaveBeenCalled();
+    expect(extensionConfirmationService.confirmFromPayment).not.toHaveBeenCalled();
+  });
+
+  it("does not call release on successful charges", async () => {
+    const createdPayment = {
+      ...createPaymentRecord({
+        id: "payment-123",
+        txRef: "tx-ref-123",
+        status: PaymentAttemptStatus.SUCCESSFUL,
+        bookingId: "booking-456",
+        amountExpected: new Decimal(10000),
+        amountCharged: new Decimal(10000),
+        currency: "NGN",
+      }),
+      booking: { id: "booking-456", status: BookingStatus.PENDING },
+    };
+
+    vi.mocked(flutterwaveService.verifyTransaction).mockResolvedValueOnce({
+      status: "success",
+      message: "ok",
+      data: { ...mockChargeData },
+    });
+    vi.mocked(databaseService.booking.findFirst).mockResolvedValueOnce(
+      createBooking({ id: "booking-456", totalAmount: new Decimal(10000) }),
+    );
+    vi.mocked(databaseService.extension.findFirst).mockResolvedValueOnce(null);
+    vi.mocked(databaseService.payment.upsert).mockResolvedValueOnce(createdPayment);
+    vi.mocked(bookingConfirmationService.confirmFromPayment).mockResolvedValueOnce(true);
+
+    await handler.handle(mockChargeData);
+
+    expect(bookingEligibilityService.releaseReferralReservation).not.toHaveBeenCalled();
+    expect(bookingConfirmationService.confirmFromPayment).toHaveBeenCalledWith(createdPayment);
+  });
+
+  it("swallows release errors so webhook acks regardless of release outcome", async () => {
+    const failedPayment = {
+      ...createPaymentRecord({
+        id: "payment-failed-123",
+        txRef: "tx-ref-123",
+        status: PaymentAttemptStatus.FAILED,
+        bookingId: "booking-456",
+        amountExpected: new Decimal(10000),
+        amountCharged: new Decimal(10000),
+        currency: "NGN",
+      }),
+      booking: { id: "booking-456", status: BookingStatus.PENDING },
+    };
+
+    vi.mocked(flutterwaveService.verifyTransaction).mockResolvedValueOnce({
+      status: "success",
+      message: "ok",
+      data: { ...mockChargeData, status: "failed" },
+    });
+    vi.mocked(databaseService.booking.findFirst).mockResolvedValueOnce(
+      createBooking({ id: "booking-456", totalAmount: new Decimal(10000) }),
+    );
+    vi.mocked(databaseService.extension.findFirst).mockResolvedValueOnce(null);
+    vi.mocked(databaseService.payment.upsert).mockResolvedValueOnce(failedPayment);
+    vi.mocked(bookingEligibilityService.releaseReferralReservation).mockRejectedValueOnce(
+      new Error("db hiccup"),
+    );
+
+    await expect(handler.handle({ ...mockChargeData, status: "failed" })).resolves.toBeUndefined();
+    expect(bookingEligibilityService.releaseReferralReservation).toHaveBeenCalled();
   });
 });

--- a/src/modules/payment/charge-completed.handler.ts
+++ b/src/modules/payment/charge-completed.handler.ts
@@ -4,6 +4,7 @@ import { PaymentAttemptStatus } from "@prisma/client";
 import Decimal from "decimal.js";
 import { PinoLogger } from "nestjs-pino";
 import { BookingConfirmationService } from "../booking/booking-confirmation.service";
+import { BookingEligibilityService } from "../booking/booking-eligibility.service";
 import { ExtensionConfirmationService } from "../booking/extension-confirmation.service";
 import { DatabaseService } from "../database/database.service";
 import type { FlutterwaveChargeData } from "../flutterwave/flutterwave.interface";
@@ -18,6 +19,7 @@ export class ChargeCompletedHandler {
     private readonly flutterwaveService: FlutterwaveService,
     private readonly bookingConfirmationService: BookingConfirmationService,
     private readonly extensionConfirmationService: ExtensionConfirmationService,
+    private readonly bookingEligibilityService: BookingEligibilityService,
     private readonly logger: PinoLogger,
   ) {
     this.logger.setContext(ChargeCompletedHandler.name);
@@ -119,6 +121,9 @@ export class ChargeCompletedHandler {
     );
 
     if (payment.status !== PaymentAttemptStatus.SUCCESSFUL) {
+      if (payment.bookingId) {
+        await this.releaseReferralReservation(payment.bookingId, txRef);
+      }
       return;
     }
 
@@ -296,6 +301,27 @@ export class ChargeCompletedHandler {
 
   private toNumber(value: Decimal | number): number {
     return value instanceof Decimal ? value.toNumber() : value;
+  }
+
+  private async releaseReferralReservation(bookingId: string, txRef: string): Promise<void> {
+    try {
+      const result = await this.databaseService.$transaction((tx) =>
+        this.bookingEligibilityService.releaseReferralReservation(tx, bookingId),
+      );
+      this.logger.info(
+        { bookingId, txRef, released: result.released },
+        "Processed referral reservation release after non-successful charge",
+      );
+    } catch (error) {
+      this.logger.error(
+        {
+          bookingId,
+          txRef,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "Failed to release referral reservation after non-successful charge",
+      );
+    }
   }
 
   private async findOrCreatePayment(

--- a/test/booking-flow.e2e-spec.ts
+++ b/test/booking-flow.e2e-spec.ts
@@ -435,4 +435,178 @@ describe("Booking Flow E2E", () => {
       await runExtensionFlow(cookie, car.id);
     });
   });
+
+  it("re-applies the referral discount on a fresh booking after a failed payment release", async () => {
+    const car = await factory.createCar(fleetOwnerId);
+
+    const { user: referrer } = await factory.authenticateAndGetUser(
+      uniqueEmail("ref-release-referrer"),
+      "user",
+      "mobile",
+    );
+
+    const { cookie, user: referee } = await factory.authenticateAndGetUser(
+      uniqueEmail("ref-release-referee"),
+      "user",
+      "mobile",
+      { referralCode: referrer.referralCode },
+    );
+    expect(referee.referredByUserId).toBe(referrer.id);
+
+    await factory.enableReferralProgram();
+
+    // Pin start to 9am local for a single-leg 12-hour DAY booking.
+    const startDate = new Date(Date.now() + ONE_DAY_MS * 2);
+    startDate.setHours(9, 0, 0, 0);
+    const endDate = new Date(startDate.getTime() + TWELVE_HOURS_MS);
+
+    const bookingPayload = {
+      carId: car.id,
+      startDate,
+      endDate,
+      pickupAddress: "123 Main St, Lagos",
+      bookingType: "DAY" as const,
+      pickupTime: "9:00 AM",
+      sameLocation: true as const,
+      includeSecurityDetail: false,
+      requiresFullTank: false,
+      useCredits: 0,
+    };
+
+    // Attempt 1: create booking with discount, then simulate a failed Flutterwave charge.
+    const firstAttempt = await request(app.getHttpServer())
+      .post("/api/bookings")
+      .set("Cookie", cookie)
+      .send(bookingPayload);
+    expect(firstAttempt.status).toBe(HttpStatus.CREATED);
+
+    const firstBookingId = firstAttempt.body.bookingId as string;
+    const firstBooking = await factory.getBookingById(firstBookingId);
+    if (!firstBooking) throw new Error("First booking not found");
+    expect(firstBooking.referralStatus).toBe("RESERVED");
+    expect(firstBooking.referralDiscountAmount.toNumber()).toBeGreaterThan(0);
+    const firstTxRef = firstBooking.paymentIntent;
+    if (!firstTxRef) throw new Error("First booking has no paymentIntent");
+
+    const failedChargeData: FlutterwaveChargeData = {
+      id: Date.now() + Math.floor(Math.random() * 100000),
+      tx_ref: firstTxRef,
+      status: "failed",
+      charged_amount: firstBooking.totalAmount.toNumber(),
+      flw_ref: `FLW-FAILED-${Date.now()}`,
+      device_fingerprint: "device-failed-test",
+      amount: firstBooking.totalAmount.toNumber(),
+      currency: "NGN",
+      app_fee: 0,
+      merchant_fee: 0,
+      processor_response: "Card declined",
+      auth_model: "PIN",
+      ip: "127.0.0.1",
+      narration: "Booking payment",
+      payment_type: "card",
+      created_at: new Date().toISOString(),
+      account_id: 123,
+      customer: {
+        id: 456,
+        name: "Test Customer",
+        phone_number: null,
+        email: "test@example.com",
+        created_at: new Date().toISOString(),
+      },
+    };
+
+    vi.mocked(flutterwaveService.verifyTransaction).mockResolvedValueOnce({
+      status: "success",
+      message: "Transaction verified",
+      data: failedChargeData,
+    });
+
+    const failedWebhook = await request(app.getHttpServer())
+      .post("/api/payments/webhook/flutterwave")
+      .set("verif-hash", webhookSecret)
+      .send({ event: "charge.completed", data: failedChargeData });
+    expect(failedWebhook.status).toBe(HttpStatus.CREATED);
+
+    // First booking's reservation should be released; user is eligible again.
+    const releasedBooking = await factory.getBookingById(firstBookingId);
+    if (!releasedBooking) throw new Error("Released booking not found");
+    expect(releasedBooking.referralStatus).toBe("REVERSED");
+    expect(releasedBooking.referralDiscountAmount.toNumber()).toBe(0);
+    expect(releasedBooking.referralReferrerUserId).toBeNull();
+    expect(releasedBooking.status).toBe("PENDING");
+    expect(releasedBooking.paymentStatus).toBe("UNPAID");
+
+    // Attempt 2: same payload — pricing preview must reflect the discount again and a
+    // fresh booking must reserve the discount with the original referrer.
+    const previewResponse = await request(app.getHttpServer())
+      .post("/api/bookings/pricing-preview")
+      .set("Cookie", cookie)
+      .send({
+        carId: car.id,
+        bookingType: "DAY",
+        startDate: startDate.toISOString(),
+        endDate: endDate.toISOString(),
+        pickupTime: "9:00 AM",
+        includeSecurityDetail: false,
+        requiresFullTank: false,
+      });
+    expect(previewResponse.status).toBe(HttpStatus.OK);
+    expect(previewResponse.body.referralDiscountAmount).toBeGreaterThan(0);
+
+    const retryResponse = await request(app.getHttpServer())
+      .post("/api/bookings")
+      .set("Cookie", cookie)
+      .send({
+        ...bookingPayload,
+        clientTotalAmount: String(previewResponse.body.totalAmount),
+      });
+    expect(retryResponse.status).toBe(HttpStatus.CREATED);
+
+    const retryBookingId = retryResponse.body.bookingId as string;
+    expect(retryBookingId).not.toBe(firstBookingId);
+
+    const retryBooking = await factory.getBookingById(retryBookingId);
+    if (!retryBooking) throw new Error("Retry booking not found");
+    expect(retryBooking.referralStatus).toBe("RESERVED");
+    expect(retryBooking.referralReferrerUserId).toBe(referrer.id);
+    expect(retryBooking.referralDiscountAmount.toNumber()).toBe(
+      previewResponse.body.referralDiscountAmount,
+    );
+    expect(retryBooking.totalAmount.toNumber()).toBe(previewResponse.body.totalAmount);
+
+    // Confirm via successful webhook to make sure release didn't break the confirmation path.
+    const retryTxRef = retryBooking.paymentIntent;
+    if (!retryTxRef) throw new Error("Retry booking has no paymentIntent");
+    const retryAmount = retryBooking.totalAmount.toNumber();
+
+    const successData: FlutterwaveChargeData = {
+      ...failedChargeData,
+      id: Date.now() + Math.floor(Math.random() * 100000),
+      tx_ref: retryTxRef,
+      status: "successful",
+      amount: retryAmount,
+      charged_amount: retryAmount,
+      flw_ref: `FLW-RETRY-${Date.now()}`,
+      processor_response: "Approved",
+    };
+
+    vi.mocked(flutterwaveService.verifyTransaction).mockResolvedValueOnce({
+      status: "success",
+      message: "Transaction verified",
+      data: successData,
+    });
+
+    const successWebhook = await request(app.getHttpServer())
+      .post("/api/payments/webhook/flutterwave")
+      .set("verif-hash", webhookSecret)
+      .send({ event: "charge.completed", data: successData });
+    expect(successWebhook.status).toBe(HttpStatus.CREATED);
+
+    const confirmedRetryBooking = await factory.getBookingById(retryBookingId);
+    if (!confirmedRetryBooking) throw new Error("Confirmed retry booking not found");
+    expect(confirmedRetryBooking.status).toBe("CONFIRMED");
+    expect(confirmedRetryBooking.paymentStatus).toBe("PAID");
+    expect(confirmedRetryBooking.referralStatus).toBe("APPLIED");
+    expect(confirmedRetryBooking.referralReferrerUserId).toBe(referrer.id);
+  });
 });

--- a/test/booking-flow.e2e-spec.ts
+++ b/test/booking-flow.e2e-spec.ts
@@ -453,7 +453,11 @@ describe("Booking Flow E2E", () => {
     );
     expect(referee.referredByUserId).toBe(referrer.id);
 
-    await factory.enableReferralProgram();
+    // Configure REFERRAL_REWARD_AMOUNT so createReferralRewardIfEligible actually
+    // creates the PENDING reward + bumps userReferralStats. This is what exercises
+    // the soft-delete + stats decrement path in releaseReferralReservation.
+    const REWARD_AMOUNT = 2500;
+    await factory.enableReferralProgram({ rewardAmount: REWARD_AMOUNT });
 
     // Pin start to 9am local for a single-leg 12-hour DAY booking.
     const startDate = new Date(Date.now() + ONE_DAY_MS * 2);
@@ -487,6 +491,18 @@ describe("Booking Flow E2E", () => {
     expect(firstBooking.referralDiscountAmount.toNumber()).toBeGreaterThan(0);
     const firstTxRef = firstBooking.paymentIntent;
     if (!firstTxRef) throw new Error("First booking has no paymentIntent");
+
+    // Reservation should have created a PENDING reward and bumped referrer stats.
+    const rewardsAfterReserve = await factory.getReferralRewardsByBookingId(firstBookingId);
+    expect(rewardsAfterReserve).toHaveLength(1);
+    expect(rewardsAfterReserve[0].status).toBe("PENDING");
+    expect(rewardsAfterReserve[0].amount.toNumber()).toBe(REWARD_AMOUNT);
+    expect(rewardsAfterReserve[0].referrerUserId).toBe(referrer.id);
+
+    const statsAfterReserve = await factory.getUserReferralStats(referrer.id);
+    if (!statsAfterReserve) throw new Error("Referrer stats row missing after first reservation");
+    expect(statsAfterReserve.totalReferrals).toBe(1);
+    expect(statsAfterReserve.totalRewardsPending.toNumber()).toBe(REWARD_AMOUNT);
 
     const failedChargeData: FlutterwaveChargeData = {
       id: Date.now() + Math.floor(Math.random() * 100000),
@@ -536,6 +552,21 @@ describe("Booking Flow E2E", () => {
     expect(releasedBooking.status).toBe("PENDING");
     expect(releasedBooking.paymentStatus).toBe("UNPAID");
 
+    // The PENDING reward should be soft-deleted (audit trail preserved) and the
+    // referrer's pending counters should have been decremented back to zero —
+    // this is the regression we're protecting against. Before the fix, totalReferrals
+    // and totalRewardsPending stayed inflated and the retry below would double-count.
+    const rewardsAfterRelease = await factory.getReferralRewardsByBookingId(firstBookingId);
+    expect(rewardsAfterRelease).toHaveLength(1);
+    expect(rewardsAfterRelease[0].status).toBe("REVERSED");
+    expect(rewardsAfterRelease[0].processedAt).toBeInstanceOf(Date);
+    expect(rewardsAfterRelease[0].reason).toBe("RESERVATION_RELEASED");
+
+    const statsAfterRelease = await factory.getUserReferralStats(referrer.id);
+    if (!statsAfterRelease) throw new Error("Referrer stats row missing after release");
+    expect(statsAfterRelease.totalReferrals).toBe(0);
+    expect(statsAfterRelease.totalRewardsPending.toNumber()).toBe(0);
+
     // Attempt 2: same payload — pricing preview must reflect the discount again and a
     // fresh booking must reserve the discount with the original referrer.
     const previewResponse = await request(app.getHttpServer())
@@ -574,6 +605,24 @@ describe("Booking Flow E2E", () => {
     );
     expect(retryBooking.totalAmount.toNumber()).toBe(previewResponse.body.totalAmount);
 
+    // The retry's reward is PENDING; the original is still REVERSED (audit trail intact).
+    const rewardsAfterRetryReserve = await factory.getReferralRewardsByBookingId(retryBookingId);
+    expect(rewardsAfterRetryReserve).toHaveLength(1);
+    expect(rewardsAfterRetryReserve[0].status).toBe("PENDING");
+    expect(rewardsAfterRetryReserve[0].amount.toNumber()).toBe(REWARD_AMOUNT);
+
+    const originalRewardsAfterRetry = await factory.getReferralRewardsByBookingId(firstBookingId);
+    expect(originalRewardsAfterRetry).toHaveLength(1);
+    expect(originalRewardsAfterRetry[0].status).toBe("REVERSED");
+
+    // Stats should reflect exactly ONE active reservation, not 2 — this is the
+    // core regression assertion. Pre-fix this would be totalReferrals=2 and
+    // totalRewardsPending=2*REWARD_AMOUNT because the release path didn't decrement.
+    const statsAfterRetry = await factory.getUserReferralStats(referrer.id);
+    if (!statsAfterRetry) throw new Error("Referrer stats row missing after retry");
+    expect(statsAfterRetry.totalReferrals).toBe(1);
+    expect(statsAfterRetry.totalRewardsPending.toNumber()).toBe(REWARD_AMOUNT);
+
     // Confirm via successful webhook to make sure release didn't break the confirmation path.
     const retryTxRef = retryBooking.paymentIntent;
     if (!retryTxRef) throw new Error("Retry booking has no paymentIntent");
@@ -608,5 +657,18 @@ describe("Booking Flow E2E", () => {
     expect(confirmedRetryBooking.paymentStatus).toBe("PAID");
     expect(confirmedRetryBooking.referralStatus).toBe("APPLIED");
     expect(confirmedRetryBooking.referralReferrerUserId).toBe(referrer.id);
+
+    // With releaseCondition=COMPLETED the reward stays PENDING after confirmation
+    // (release happens on booking completion downstream). Stats should still be the
+    // single active referral — proving the release/retry loop didn't leak counters.
+    const rewardsAfterConfirm = await factory.getReferralRewardsByBookingId(retryBookingId);
+    expect(rewardsAfterConfirm).toHaveLength(1);
+    expect(rewardsAfterConfirm[0].status).toBe("PENDING");
+
+    const statsAfterConfirm = await factory.getUserReferralStats(referrer.id);
+    if (!statsAfterConfirm) throw new Error("Referrer stats row missing after confirm");
+    expect(statsAfterConfirm.totalReferrals).toBe(1);
+    expect(statsAfterConfirm.totalRewardsPending.toNumber()).toBe(REWARD_AMOUNT);
+    expect(statsAfterConfirm.totalRewardsGranted.toNumber()).toBe(0);
   });
 });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -602,6 +602,27 @@ export class TestDataFactory {
   }
 
   /**
+   * Get all referral reward rows for a booking, ordered by creation time.
+   * Includes soft-deleted (REVERSED) rows so tests can assert on the audit
+   * trail of reservation attempts.
+   */
+  async getReferralRewardsByBookingId(bookingId: string) {
+    return this.prisma.referralReward.findMany({
+      where: { bookingId },
+      orderBy: { createdAt: "asc" },
+    });
+  }
+
+  /**
+   * Get the UserReferralStats row for a referrer, or null if none exists.
+   */
+  async getUserReferralStats(userId: string) {
+    return this.prisma.userReferralStats.findUnique({
+      where: { userId },
+    });
+  }
+
+  /**
    * Get a car by ID.
    */
   async getCarById(carId: string) {
@@ -708,8 +729,8 @@ export class TestDataFactory {
    * Idempotent via upsert — safe to call multiple times.
    * Sets: enabled, 10000 discount, 20000 min booking, DAY/NIGHT/FULL_DAY eligible, 30 day expiry.
    */
-  async enableReferralProgram(): Promise<void> {
-    await Promise.all([
+  async enableReferralProgram(options: { rewardAmount?: number } = {}): Promise<void> {
+    const writes: Promise<unknown>[] = [
       this.prisma.referralProgramConfig.upsert({
         where: { key: "REFERRAL_ENABLED" },
         create: { key: "REFERRAL_ENABLED", value: true },
@@ -735,7 +756,24 @@ export class TestDataFactory {
         create: { key: "REFERRAL_EXPIRY_DAYS", value: 30 },
         update: { value: 30 },
       }),
-    ]);
+    ];
+
+    if (options.rewardAmount !== undefined) {
+      writes.push(
+        this.prisma.referralProgramConfig.upsert({
+          where: { key: "REFERRAL_REWARD_AMOUNT" },
+          create: { key: "REFERRAL_REWARD_AMOUNT", value: options.rewardAmount },
+          update: { value: options.rewardAmount },
+        }),
+        this.prisma.referralProgramConfig.upsert({
+          where: { key: "REFERRAL_RELEASE_CONDITION" },
+          create: { key: "REFERRAL_RELEASE_CONDITION", value: "COMPLETED" },
+          update: { value: "COMPLETED" },
+        }),
+      );
+    }
+
+    await Promise.all(writes);
   }
 }
 


### PR DESCRIPTION
When a referee abandoned checkout (RESERVED + PENDING + UNPAID), the discount stayed locked, and the next booking attempt showed no discount. Now:

- Pricing preview ignores RESERVED + PENDING + UNPAID bookings, so the discount appears available on retry.
- Booking creation releases the user's stale RESERVED reservations in the same transaction before re-reserving, so a fresh booking gets the discount with the original referrer reattached.
- `charge.completed` handler releases the reservation when a verified charge is unsuccessful, so the discount is freed immediately, even if the user never returns.

Idempotent: only releases when booking is still RESERVED + PENDING + UNPAID. APPLIED/REWARDED or mid-payment reservations are preserved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches referral discount reservation/release logic and payment webhook handling, which can affect booking pricing and referral accounting; mitigated by idempotent conditional updates plus extensive new unit/E2E coverage.
> 
> **Overview**
> Fixes referral discounts getting stuck after an abandoned checkout by **treating `RESERVED + PENDING + UNPAID` bookings as releasable instead of blocking eligibility**.
> 
> Adds `BookingEligibilityService.releaseReferralReservation()` to atomically flip stale reservations to `REVERSED`, tombstone any `PENDING` `ReferralReward` rows with reason `RESERVATION_RELEASED`, and decrement `UserReferralStats` (flooring at zero). Booking reservation now releases any stale unpaid reservations for the user before checking for an active claim.
> 
> Updates the `charge.completed` webhook flow to release the reservation (inside a transaction, errors swallowed after logging) when a verified payment is not successful, and expands unit + E2E tests and test helpers to validate the release/retry behavior and referral stats correctness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f09ea5c1bd8f03225338f7c5079f7414ac9c2477. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->