### PR TITLE
fix(referral): derive summary stats from source rows and align reward amount config

### DIFF
--- a/src/modules/booking/booking-eligibility.service.spec.ts
+++ b/src/modules/booking/booking-eligibility.service.spec.ts
@@ -372,6 +372,67 @@ describe("BookingEligibilityService", () => {
     });
   });
 
+  it("uses REFERRAL_DISCOUNT_AMOUNT for reward amount when REFERRAL_REWARD_AMOUNT is missing", async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BookingEligibilityService,
+        {
+          provide: DatabaseService,
+          useValue: {
+            user: { findUnique: vi.fn() },
+            referralProgramConfig: { findMany: vi.fn() },
+          },
+        },
+      ],
+    })
+      .useMocker(mockPinoLoggerToken)
+      .compile();
+
+    const service = module.get<BookingEligibilityService>(BookingEligibilityService);
+    const rewardCreate = vi.fn().mockResolvedValue({});
+    const statsUpsert = vi.fn().mockResolvedValue({});
+
+    await service.createReferralRewardIfEligible(
+      {
+        referralProgramConfig: {
+          findMany: vi.fn().mockResolvedValue([
+            { key: "REFERRAL_DISCOUNT_AMOUNT", value: "10000" },
+            { key: "REFERRAL_RELEASE_CONDITION", value: "COMPLETED" },
+          ]),
+        },
+        referralReward: { create: rewardCreate },
+        userReferralStats: { upsert: statsUpsert },
+      } as never,
+      "booking-1",
+      { eligible: true, referrerUserId: "referrer-1", discountAmount: new Decimal(5000) },
+      "user-1",
+    );
+
+    expect(rewardCreate).toHaveBeenCalledWith({
+      data: {
+        referrer: { connect: { id: "referrer-1" } },
+        referee: { connect: { id: "user-1" } },
+        booking: { connect: { id: "booking-1" } },
+        amount: new Decimal(10000),
+        status: ReferralRewardStatus.PENDING,
+        releaseCondition: "COMPLETED",
+      },
+    });
+    expect(statsUpsert).toHaveBeenCalledWith({
+      where: { userId: "referrer-1" },
+      create: {
+        userId: "referrer-1",
+        totalReferrals: 1,
+        totalRewardsGranted: 0,
+        totalRewardsPending: new Decimal(10000),
+      },
+      update: {
+        totalReferrals: { increment: 1 },
+        totalRewardsPending: { increment: new Decimal(10000) },
+      },
+    });
+  });
+
   it("ignores stale RESERVED+PENDING+UNPAID bookings when checking pricing eligibility", async () => {
     const databaseService = {
       user: {

--- a/src/modules/booking/booking-eligibility.service.spec.ts
+++ b/src/modules/booking/booking-eligibility.service.spec.ts
@@ -433,6 +433,45 @@ describe("BookingEligibilityService", () => {
     });
   });
 
+  it("does not create referral reward when reward and discount config keys are missing", async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BookingEligibilityService,
+        {
+          provide: DatabaseService,
+          useValue: {
+            user: { findUnique: vi.fn() },
+            referralProgramConfig: { findMany: vi.fn() },
+          },
+        },
+      ],
+    })
+      .useMocker(mockPinoLoggerToken)
+      .compile();
+
+    const service = module.get<BookingEligibilityService>(BookingEligibilityService);
+    const rewardCreate = vi.fn().mockResolvedValue({});
+    const statsUpsert = vi.fn().mockResolvedValue({});
+
+    await service.createReferralRewardIfEligible(
+      {
+        referralProgramConfig: {
+          findMany: vi
+            .fn()
+            .mockResolvedValue([{ key: "REFERRAL_RELEASE_CONDITION", value: "COMPLETED" }]),
+        },
+        referralReward: { create: rewardCreate },
+        userReferralStats: { upsert: statsUpsert },
+      } as never,
+      "booking-1",
+      { eligible: true, referrerUserId: "referrer-1", discountAmount: new Decimal(7500) },
+      "user-1",
+    );
+
+    expect(rewardCreate).not.toHaveBeenCalled();
+    expect(statsUpsert).not.toHaveBeenCalled();
+  });
+
   it("ignores stale RESERVED+PENDING+UNPAID bookings when checking pricing eligibility", async () => {
     const databaseService = {
       user: {

--- a/src/modules/booking/booking-eligibility.service.ts
+++ b/src/modules/booking/booking-eligibility.service.ts
@@ -360,11 +360,14 @@ export class BookingEligibilityService {
 
     const rewardConfigMap = await this.getReferralConfigMap(tx.referralProgramConfig, [
       "REFERRAL_REWARD_AMOUNT",
+      "REFERRAL_DISCOUNT_AMOUNT",
       "REFERRAL_RELEASE_CONDITION",
     ]);
 
     const rewardAmount = this.parseDecimalConfig(
-      rewardConfigMap.REFERRAL_REWARD_AMOUNT,
+      rewardConfigMap.REFERRAL_REWARD_AMOUNT ??
+        rewardConfigMap.REFERRAL_DISCOUNT_AMOUNT ??
+        referralEligibility.discountAmount,
       "REFERRAL_REWARD_AMOUNT",
     );
     if (!rewardAmount.gt(0)) {

--- a/src/modules/booking/booking-eligibility.service.ts
+++ b/src/modules/booking/booking-eligibility.service.ts
@@ -365,9 +365,7 @@ export class BookingEligibilityService {
     ]);
 
     const rewardAmount = this.parseDecimalConfig(
-      rewardConfigMap.REFERRAL_REWARD_AMOUNT ??
-        rewardConfigMap.REFERRAL_DISCOUNT_AMOUNT ??
-        referralEligibility.discountAmount,
+      rewardConfigMap.REFERRAL_REWARD_AMOUNT ?? rewardConfigMap.REFERRAL_DISCOUNT_AMOUNT,
       "REFERRAL_REWARD_AMOUNT",
     );
     if (!rewardAmount.gt(0)) {

--- a/src/modules/referral/referral-api.service.spec.ts
+++ b/src/modules/referral/referral-api.service.spec.ts
@@ -15,6 +15,9 @@ describe("ReferralApiService", () => {
       findFirst: ReturnType<typeof vi.fn>;
       aggregate: ReturnType<typeof vi.fn>;
     };
+    referralReward: {
+      aggregate: ReturnType<typeof vi.fn>;
+    };
     userReferralStats: {
       findUnique: ReturnType<typeof vi.fn>;
     };
@@ -30,6 +33,9 @@ describe("ReferralApiService", () => {
       },
       booking: {
         findFirst: vi.fn(),
+        aggregate: vi.fn(),
+      },
+      referralReward: {
         aggregate: vi.fn(),
       },
       userReferralStats: {
@@ -130,9 +136,13 @@ describe("ReferralApiService", () => {
         },
       ],
     });
-    mockDatabaseService.userReferralStats.findUnique.mockResolvedValue({
-      totalRewardsGranted: { toNumber: () => 2500 },
-    });
+    mockDatabaseService.referralReward.aggregate
+      .mockResolvedValueOnce({
+        _sum: { amount: { toNumber: () => 2500 } },
+      })
+      .mockResolvedValueOnce({
+        _sum: { amount: { toNumber: () => 500 } },
+      });
     mockDatabaseService.booking.aggregate
       .mockResolvedValueOnce({
         _sum: { referralCreditsUsed: { toNumber: () => 500 } },
@@ -149,11 +159,67 @@ describe("ReferralApiService", () => {
     expect(result.shareLink).toBe("http://localhost:3000/auth?ref=ABCDEFGH");
     expect(result.programEnabled).toBe(true);
     expect(result.discountAmount).toBe(10000);
+    expect(result.stats.totalReferrals).toBe(1);
     expect(result.stats.totalRewardsGranted).toBe(2500);
+    expect(result.stats.totalRewardsPending).toBe(500);
     expect(result.stats.totalEarned).toBe(2500);
     expect(result.stats.totalUsed).toBe(500);
     expect(result.stats.availableCredits).toBe(1700);
     expect(result.rewards[0]?.amount).toBe(1500);
     expect(result.rewards[0]?.refereeName).toBe("Referee Name");
+  });
+
+  it("derives summary stats from source rows when denormalized stats drift", async () => {
+    mockDatabaseService.referralProgramConfig.findMany.mockResolvedValue([]);
+    mockDatabaseService.user.findUnique.mockResolvedValueOnce({
+      referralCode: "ABCDEFGH",
+      referredByUserId: null,
+      referralDiscountUsed: false,
+      referralSignupAt: null,
+      referrals: [
+        {
+          id: "referee-1",
+          name: null,
+          email: "referee@tripdly.com",
+          createdAt: new Date("2030-01-01T00:00:00.000Z"),
+        },
+      ],
+      referralRewardsEarned: [
+        {
+          id: "reward-1",
+          amount: { toNumber: () => 10000 },
+          status: "PENDING",
+          createdAt: new Date("2030-01-02T00:00:00.000Z"),
+          processedAt: null,
+          referee: {
+            name: null,
+            email: "referee@tripdly.com",
+          },
+        },
+      ],
+    });
+    mockDatabaseService.referralReward.aggregate
+      .mockResolvedValueOnce({
+        _sum: { amount: null },
+      })
+      .mockResolvedValueOnce({
+        _sum: { amount: { toNumber: () => 10000 } },
+      });
+    mockDatabaseService.booking.aggregate
+      .mockResolvedValueOnce({
+        _sum: { referralCreditsUsed: null },
+      })
+      .mockResolvedValueOnce({
+        _sum: { referralCreditsReserved: null },
+      });
+
+    const result = await service.getUserReferralSummary("referrer-1", "http://localhost:3000");
+
+    expect(result?.stats.totalReferrals).toBe(1);
+    expect(result?.stats.totalRewardsGranted).toBe(0);
+    expect(result?.stats.totalRewardsPending).toBe(10000);
+    expect(result?.stats.totalEarned).toBe(0);
+    expect(result?.stats.availableCredits).toBe(0);
+    expect(mockDatabaseService.userReferralStats.findUnique).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/referral/referral-api.service.spec.ts
+++ b/src/modules/referral/referral-api.service.spec.ts
@@ -108,12 +108,6 @@ describe("ReferralApiService", () => {
       referredByUserId: null,
       referralDiscountUsed: false,
       referralSignupAt: null,
-      referralStats: {
-        totalReferrals: 2,
-        totalRewardsGranted: { toNumber: () => 2500 },
-        totalRewardsPending: { toNumber: () => 500 },
-        lastReferralAt: null,
-      },
       referrals: [
         {
           id: "user-2",

--- a/src/modules/referral/referral-api.service.ts
+++ b/src/modules/referral/referral-api.service.ts
@@ -1,5 +1,11 @@
 import { Injectable } from "@nestjs/common";
-import { BookingReferralStatus, BookingStatus, PaymentStatus, type Prisma } from "@prisma/client";
+import {
+  BookingReferralStatus,
+  BookingStatus,
+  PaymentStatus,
+  type Prisma,
+  ReferralRewardStatus,
+} from "@prisma/client";
 import { DatabaseService } from "../database/database.service";
 import { ReferralInvalidCodeException, ReferralSelfReferralException } from "./referral.error";
 import type { ReferralConfig, ReferralUserSummaryResponse } from "./referral.interface";
@@ -124,7 +130,7 @@ export class ReferralApiService {
     userId: string,
     requestOrigin: string | null,
   ): Promise<ReferralUserSummaryResponse | null> {
-    const [referralInfo, bookingCredits, config] = await Promise.all([
+    const [referralInfo, rewardTotals, config] = await Promise.all([
       this.databaseService.user.findUnique({
         where: { id: userId },
         select: {
@@ -132,14 +138,6 @@ export class ReferralApiService {
           referredByUserId: true,
           referralDiscountUsed: true,
           referralSignupAt: true,
-          referralStats: {
-            select: {
-              totalReferrals: true,
-              totalRewardsGranted: true,
-              totalRewardsPending: true,
-              lastReferralAt: true,
-            },
-          },
           referrals: {
             select: {
               id: true,
@@ -167,7 +165,7 @@ export class ReferralApiService {
           },
         },
       }),
-      this.getUserBookingCredits(userId),
+      this.getReferralRewardTotals(userId),
       this.getReferralConfig(),
     ]);
 
@@ -175,17 +173,11 @@ export class ReferralApiService {
       return null;
     }
 
+    const bookingCredits = await this.getUserBookingCredits(userId, rewardTotals.totalReleased);
     const shareLink =
       referralInfo.referralCode && requestOrigin
         ? `${requestOrigin}/auth?ref=${referralInfo.referralCode}`
         : null;
-
-    const totalRewardsGranted = this.decimalToNumber(
-      referralInfo.referralStats?.totalRewardsGranted,
-    );
-    const totalRewardsPending = this.decimalToNumber(
-      referralInfo.referralStats?.totalRewardsPending,
-    );
 
     return {
       referralCode: referralInfo.referralCode,
@@ -196,10 +188,10 @@ export class ReferralApiService {
       referredBy: referralInfo.referredByUserId,
       signupDate: referralInfo.referralSignupAt,
       stats: {
-        totalReferrals: referralInfo.referralStats?.totalReferrals ?? 0,
-        totalRewardsGranted,
-        totalRewardsPending,
-        lastReferralAt: referralInfo.referralStats?.lastReferralAt ?? null,
+        totalReferrals: referralInfo.referrals.length,
+        totalRewardsGranted: rewardTotals.totalReleased,
+        totalRewardsPending: rewardTotals.totalPending,
+        lastReferralAt: this.getLastReferralAt(referralInfo.referrals),
         totalEarned: bookingCredits.totalEarned,
         totalUsed: bookingCredits.totalUsed,
         availableCredits: bookingCredits.availableCredits,
@@ -251,12 +243,32 @@ export class ReferralApiService {
     return config;
   }
 
-  private async getUserBookingCredits(userId: string) {
-    const [stats, usedCredits, reservedCredits] = await Promise.all([
-      this.databaseService.userReferralStats.findUnique({
-        where: { userId },
-        select: { totalRewardsGranted: true },
+  private async getReferralRewardTotals(userId: string) {
+    const [releasedRewards, pendingRewards] = await Promise.all([
+      this.databaseService.referralReward.aggregate({
+        where: {
+          referrerUserId: userId,
+          status: ReferralRewardStatus.RELEASED,
+        },
+        _sum: { amount: true },
       }),
+      this.databaseService.referralReward.aggregate({
+        where: {
+          referrerUserId: userId,
+          status: ReferralRewardStatus.PENDING,
+        },
+        _sum: { amount: true },
+      }),
+    ]);
+
+    return {
+      totalReleased: this.decimalToNumber(releasedRewards._sum.amount),
+      totalPending: this.decimalToNumber(pendingRewards._sum.amount),
+    };
+  }
+
+  private async getUserBookingCredits(userId: string, totalEarned: number) {
+    const [usedCredits, reservedCredits] = await Promise.all([
       this.databaseService.booking.aggregate({
         where: {
           paymentStatus: PaymentStatus.PAID,
@@ -276,7 +288,6 @@ export class ReferralApiService {
       }),
     ]);
 
-    const totalEarned = this.decimalToNumber(stats?.totalRewardsGranted);
     const totalUsed = this.decimalToNumber(usedCredits._sum.referralCreditsUsed);
     const totalReserved = this.decimalToNumber(reservedCredits._sum.referralCreditsReserved);
 
@@ -286,6 +297,16 @@ export class ReferralApiService {
       totalReserved,
       availableCredits: Math.max(0, totalEarned - totalUsed - totalReserved),
     };
+  }
+
+  private getLastReferralAt(referrals: Array<{ createdAt: Date }>): Date | null {
+    let latest: Date | null = null;
+    for (const referral of referrals) {
+      if (!latest || referral.createdAt > latest) {
+        latest = referral.createdAt;
+      }
+    }
+    return latest;
   }
 
   private decimalToNumber(value: Prisma.Decimal | number | null | undefined): number {


### PR DESCRIPTION
Compute referral dashboard totals from referrals and `ReferralReward` rows instead of stale `UserReferralStats` counters, and fall back reward creation to `REFERRAL_DISCOUNT_AMOUNT` when `REFERRAL_REWARD_AMOUNT` is unset.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how referral dashboard totals and available credits are computed, which can affect user-visible balances and payouts if the new aggregates or filters are wrong. Logic is straightforward but touches referral reward accounting paths.
> 
> **Overview**
> **Referral reward accounting is recalculated from source data instead of denormalized counters.** `getUserReferralSummary` now derives `totalReferrals`, `totalRewardsGranted`, `totalRewardsPending`, and `lastReferralAt` from `User.referrals` plus `ReferralReward` aggregates (by `RELEASED`/`PENDING`), and uses the released total as `totalEarned` when computing available credits.
> 
> **Reward creation is made more robust to missing config.** `BookingEligibilityService.createReferralRewardIfEligible` now falls back to `REFERRAL_DISCOUNT_AMOUNT` when `REFERRAL_REWARD_AMOUNT` is unset, and adds tests for the fallback and for the no-op when neither key is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db77df4898f0b28d952b6785253bceec57443b32. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->