### PR TITLE
feat(schema): add isPrimary flag to VehicleImage

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -471,11 +471,13 @@ model VehicleImage {
   approvedById String?
   notes        String?
   status       DocumentStatus @default(PENDING)
+  isPrimary    Boolean        @default(false)
   approvedBy   User?          @relation("ApprovedVehicleImages", fields: [approvedById], references: [id])
   car          Car            @relation(fields: [carId], references: [id], onDelete: Cascade)
 
   @@index([carId])
   @@index([status])
+  @@index([carId, isPrimary])
 }
 
 model Review {


### PR DESCRIPTION
Keeps the worker's Prisma client in sync with the shared DB column used for car cover-image selection. Worker only generates (no migrate), so no migration file is needed here.